### PR TITLE
Add AgentIdentity.get_message() to Python and TypeScript SDKs

### DIFF
--- a/examples/python/browser-use/src/agent.py
+++ b/examples/python/browser-use/src/agent.py
@@ -59,7 +59,7 @@ async def run_agent(
     )
 
     # set up controller with email tools
-    controller = build_controller(inkbox_client, identity)
+    controller = build_controller(identity)
 
     # set up browser session
     chrome_process: subprocess.Popen | None = None

--- a/examples/python/browser-use/src/tools.py
+++ b/examples/python/browser-use/src/tools.py
@@ -16,7 +16,6 @@ from pydantic import BaseModel, Field
 from browser_use import ActionResult, Controller
 
 if TYPE_CHECKING:
-    from inkbox import Inkbox
     from inkbox.agent_identity import AgentIdentity
 
 logger = logging.getLogger(__name__)
@@ -79,12 +78,11 @@ def _format_json(data: Any) -> str:
 
 # ── Controller builder ────────────────────────────────────────────────────
 
-def build_controller(inkbox_client: Inkbox, identity: AgentIdentity) -> Controller:
+def build_controller(identity: AgentIdentity) -> Controller:
     """
     Build a Browser Use Controller with Inkbox email tools registered.
 
     Args:
-        inkbox_client: Authenticated Inkbox client.
         identity: The agent identity (with mailbox) to use for email tools.
 
     Returns:
@@ -147,8 +145,7 @@ def build_controller(inkbox_client: Inkbox, identity: AgentIdentity) -> Controll
             return ActionResult(error="No mailbox linked to this agent identity.")
 
         msg = await asyncio.to_thread(
-            inkbox_client._messages.get,
-            identity.mailbox.email_address,
+            identity.get_message,
             params.message_id,
         )
         return ActionResult(extracted_content=_format_json(_sdk_to_dict(msg)))

--- a/examples/python/kernel/src/tools.py
+++ b/examples/python/kernel/src/tools.py
@@ -229,16 +229,14 @@ class ToolExecutor:
         return json.dumps(emails) if emails else "Inbox is empty"
 
     def _tool_read_email(self, message_id: str) -> str:
-        for msg in self.identity.iter_emails(page_size=50):
-            if str(msg.id) == message_id or msg.message_id == message_id:
-                return json.dumps({
-                    "id": str(msg.id),
-                    "from": msg.from_address,
-                    "to": msg.to_addresses,
-                    "subject": msg.subject,
-                    "snippet": msg.snippet,
-                    "direction": msg.direction,
-                    "is_read": msg.is_read,
-                })
-        return f"Email '{message_id}' not found"
+        msg = self.identity.get_message(message_id)
+        return json.dumps({
+            "id": str(msg.id),
+            "from": msg.from_address,
+            "to": msg.to_addresses,
+            "subject": msg.subject,
+            "body_text": msg.body_text,
+            "direction": msg.direction,
+            "is_read": msg.is_read,
+        })
 

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Iterator
 
 from inkbox.identities.types import _AgentIdentityData, IdentityMailbox, IdentityPhoneNumber
 from inkbox.mail.exceptions import InkboxError
-from inkbox.mail.types import Message, ThreadDetail
+from inkbox.mail.types import Message, MessageDetail, ThreadDetail
 from inkbox.phone.types import PhoneCall, PhoneCallWithRateLimit, PhoneTranscript
 
 if TYPE_CHECKING:
@@ -257,6 +257,19 @@ class AgentIdentity:
                 self._mailbox.email_address,  # type: ignore[union-attr]
                 mid,
             )
+
+    def get_message(self, message_id: str) -> MessageDetail:
+        """Get a single message with full body content.
+
+        Args:
+            message_id: UUID of the message to fetch. Obtain via ``msg.id``
+                on any :class:`~inkbox.mail.types.Message`.
+        """
+        self._require_mailbox()
+        return self._inkbox._messages.get(
+            self._mailbox.email_address,  # type: ignore[union-attr]
+            message_id,
+        )
 
     def get_thread(self, thread_id: str) -> ThreadDetail:
         """Get a thread with all its messages inlined (oldest-first).

--- a/sdk/python/tests/test_agent_identity.py
+++ b/sdk/python/tests/test_agent_identity.py
@@ -4,12 +4,12 @@ import pytest
 from unittest.mock import MagicMock
 
 from sample_data_identities import IDENTITY_DETAIL_DICT
-from sample_data_mail import THREAD_DETAIL_DICT
+from sample_data_mail import MESSAGE_DETAIL_DICT, THREAD_DETAIL_DICT
 
 from inkbox.agent_identity import AgentIdentity
 from inkbox.identities.types import _AgentIdentityData
 from inkbox.mail.exceptions import InkboxError
-from inkbox.mail.types import ThreadDetail
+from inkbox.mail.types import MessageDetail, ThreadDetail
 
 
 def _identity_with_mailbox():
@@ -25,6 +25,26 @@ def _identity_without_mailbox():
     data = _AgentIdentityData._from_dict(detail)
     inkbox = MagicMock()
     return AgentIdentity(data, inkbox), inkbox
+
+
+class TestAgentIdentityGetMessage:
+    def test_get_message_returns_message_detail(self):
+        identity, inkbox = _identity_with_mailbox()
+        message_id = MESSAGE_DETAIL_DICT["id"]
+        inkbox._messages.get.return_value = MessageDetail._from_dict(MESSAGE_DETAIL_DICT)
+
+        result = identity.get_message(message_id)
+
+        inkbox._messages.get.assert_called_once_with("sales-agent@inkbox.ai", message_id)
+        assert isinstance(result, MessageDetail)
+        assert str(result.id) == message_id
+        assert result.body_text == "Hi there, this is a test message body."
+
+    def test_get_message_requires_mailbox(self):
+        identity, _ = _identity_without_mailbox()
+
+        with pytest.raises(InkboxError, match="no mailbox assigned"):
+            identity.get_message("bbbb2222-0000-0000-0000-000000000001")
 
 
 class TestAgentIdentityGetThread:

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -10,7 +10,7 @@
  */
 
 import { InkboxAPIError } from "./_http.js";
-import type { Message, ThreadDetail } from "./mail/types.js";
+import type { Message, MessageDetail, ThreadDetail } from "./mail/types.js";
 import type { PhoneCall, PhoneCallWithRateLimit, PhoneTranscript } from "./phone/types.js";
 import type {
   AgentIdentitySummary,
@@ -208,6 +208,17 @@ export class AgentIdentity {
     for (const id of messageIds) {
       await this._inkbox._messages.markRead(this._mailbox!.emailAddress, id);
     }
+  }
+
+  /**
+   * Get a single message with full body content.
+   *
+   * @param messageId - UUID of the message to fetch. Obtain via `msg.id`
+   *   on any {@link Message}.
+   */
+  async getMessage(messageId: string): Promise<MessageDetail> {
+    this._requireMailbox();
+    return this._inkbox._messages.get(this._mailbox!.emailAddress, messageId);
   }
 
   /**

--- a/sdk/typescript/tests/identities/agent_identity.test.ts
+++ b/sdk/typescript/tests/identities/agent_identity.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi } from "vitest";
 import { AgentIdentity } from "../../src/agent_identity.js";
 import { parseAgentIdentityData } from "../../src/identities/types.js";
-import { parseThreadDetail } from "../../src/mail/types.js";
+import { parseMessageDetail, parseThreadDetail } from "../../src/mail/types.js";
 import type { Inkbox } from "../../src/inkbox.js";
 import { InkboxAPIError } from "../../src/_http.js";
-import { RAW_IDENTITY_DETAIL, RAW_THREAD_DETAIL } from "../sampleData.js";
+import { RAW_IDENTITY_DETAIL, RAW_MESSAGE_DETAIL, RAW_THREAD_DETAIL } from "../sampleData.js";
 
 const THREAD_ID = RAW_THREAD_DETAIL.id;
+const MESSAGE_ID = RAW_MESSAGE_DETAIL.id;
 
 function mockInkbox() {
   return {
+    _messages: { get: vi.fn() },
     _threads: { get: vi.fn() },
   } as unknown as Inkbox;
 }
@@ -25,6 +27,26 @@ function identityWithoutMailbox() {
   const inkbox = mockInkbox();
   return { identity: new AgentIdentity(data, inkbox), inkbox };
 }
+
+describe("AgentIdentity.getMessage", () => {
+  it("fetches message detail from identity mailbox", async () => {
+    const { identity, inkbox } = identityWithMailbox();
+    const messageDetail = parseMessageDetail(RAW_MESSAGE_DETAIL);
+    vi.mocked(inkbox._messages.get).mockResolvedValue(messageDetail);
+
+    const result = await identity.getMessage(MESSAGE_ID);
+
+    expect(inkbox._messages.get).toHaveBeenCalledWith("sales-agent@inkbox.ai", MESSAGE_ID);
+    expect(result.id).toBe(MESSAGE_ID);
+    expect(result.bodyText).toBe("Hi there, this is a test message body.");
+  });
+
+  it("throws when no mailbox is assigned", async () => {
+    const { identity } = identityWithoutMailbox();
+
+    await expect(identity.getMessage(MESSAGE_ID)).rejects.toThrow(InkboxAPIError);
+  });
+});
 
 describe("AgentIdentity.getThread", () => {
   it("fetches thread detail from identity mailbox", async () => {


### PR DESCRIPTION
## Summary

- Adds `get_message(message_id)` / `getMessage(messageId)` convenience method to `AgentIdentity` in both Python and TypeScript SDKs
- The server endpoint and `MessagesResource.get()` already existed, but consumers had to use private internals (`client._messages.get`) — this adds the missing public method following the same pattern as `get_thread`
- Updates browser-use example `tools.py` to use `identity.get_message()` instead of `inkbox_client._messages.get()`
- Updates kernel example `read_email` tool to use `identity.get_message()` instead of iterating all emails — now returns full body text with a single API call
- Unit tests added for both SDKs (happy path + no-mailbox guard)
- All 105 Python and 96 TypeScript tests pass


https://github.com/inkbox-ai/inkbox/issues/3