### PR TITLE
Remove webhook url from `place_call`

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -165,12 +165,6 @@ call = identity.place_call(
 )
 print(call.status, call.rate_limit.calls_remaining)
 
-# Or receive call events via webhook instead
-call = identity.place_call(
-    to_number="+15167251294",
-    webhook_url="https://your-agent.example.com/call-events",
-)
-
 # List calls (paginated)
 calls = identity.list_calls(limit=10, offset=0)
 for call in calls:
@@ -299,12 +293,6 @@ inkbox.phone_numbers.update(
     incoming_call_action="webhook",
     incoming_call_webhook_url="https://example.com/calls",
 )
-```
-
-You can also supply a per-call webhook URL when placing a call:
-
-```python
-identity.place_call(to_number="+15005550006", webhook_url="https://example.com/call-events")
 ```
 
 ---

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -293,21 +293,18 @@ class AgentIdentity:
         *,
         to_number: str,
         client_websocket_url: str | None = None,
-        webhook_url: str | None = None,
     ) -> PhoneCallWithRateLimit:
         """Place an outbound call from this identity's phone number.
 
         Args:
             to_number: E.164 destination number.
             client_websocket_url: WebSocket URL (wss://) for audio bridging.
-            webhook_url: Custom webhook URL for call lifecycle events.
         """
         self._require_phone()
         return self._inkbox._calls.place(
             from_number=self._phone_number.number,  # type: ignore[union-attr]
             to_number=to_number,
             client_websocket_url=client_websocket_url,
-            webhook_url=webhook_url,
         )
 
     def list_calls(self, *, limit: int = 50, offset: int = 0) -> list[PhoneCall]:

--- a/sdk/python/inkbox/phone/resources/calls.py
+++ b/sdk/python/inkbox/phone/resources/calls.py
@@ -59,7 +59,6 @@ class CallsResource:
         from_number: str,
         to_number: str,
         client_websocket_url: str | None = None,
-        webhook_url: str | None = None,
     ) -> PhoneCallWithRateLimit:
         """Place an outbound call.
 
@@ -67,7 +66,6 @@ class CallsResource:
             from_number: E.164 number to call from. Must belong to your org and be active.
             to_number: E.164 number to call.
             client_websocket_url: WebSocket URL (wss://) for audio bridging.
-            webhook_url: Custom webhook URL for call lifecycle events.
 
         Returns:
             The created call record with current rate limit info.
@@ -78,7 +76,5 @@ class CallsResource:
         }
         if client_websocket_url is not None:
             body["client_websocket_url"] = client_websocket_url
-        if webhook_url is not None:
-            body["webhook_url"] = webhook_url
         data = self._http.post("/place-call", json=body)
         return PhoneCallWithRateLimit._from_dict(data)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_calls.py
+++ b/sdk/python/tests/test_calls.py
@@ -83,20 +83,6 @@ class TestCallsPlace:
         )
         assert call.status == "ringing"
 
-    def test_place_with_websocket_and_webhook(self, client, transport):
-        transport.post.return_value = PHONE_CALL_DICT
-
-        client._calls.place(
-            from_number="+18335794607",
-            to_number="+15167251294",
-            client_websocket_url="wss://agent.example.com/ws",
-            webhook_url="https://example.com/hook",
-        )
-
-        _, kwargs = transport.post.call_args
-        assert kwargs["json"]["client_websocket_url"] == "wss://agent.example.com/ws"
-        assert kwargs["json"]["webhook_url"] == "https://example.com/hook"
-
     def test_optional_fields_omitted_when_none(self, client, transport):
         transport.post.return_value = PHONE_CALL_DICT
 
@@ -107,4 +93,3 @@ class TestCallsPlace:
 
         _, kwargs = transport.post.call_args
         assert "client_websocket_url" not in kwargs["json"]
-        assert "webhook_url" not in kwargs["json"]

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -170,12 +170,6 @@ const call = await identity.placeCall({
 });
 console.log(call.status, call.rateLimit.callsRemaining);
 
-// Or receive call events via webhook instead
-const call2 = await identity.placeCall({
-  toNumber: "+15167251294",
-  webhookUrl: "https://your-agent.example.com/call-events",
-});
-
 // List calls (paginated)
 const calls = await identity.listCalls({ limit: 10, offset: 0 });
 for (const c of calls) {
@@ -307,12 +301,6 @@ await inkbox.phoneNumbers.update(number.id, {
   incomingCallAction: "webhook",
   incomingCallWebhookUrl: "https://example.com/calls",
 });
-```
-
-You can also supply a per-call webhook URL when placing a call:
-
-```ts
-await identity.placeCall({ toNumber: "+15005550006", webhookUrl: "https://example.com/call-events" });
 ```
 
 ---

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -241,19 +241,16 @@ export class AgentIdentity {
    *
    * @param options.toNumber - E.164 destination number.
    * @param options.clientWebsocketUrl - WebSocket URL (wss://) for audio bridging.
-   * @param options.webhookUrl - Custom webhook URL for call lifecycle events.
    */
   async placeCall(options: {
     toNumber: string;
     clientWebsocketUrl?: string;
-    webhookUrl?: string;
   }): Promise<PhoneCallWithRateLimit> {
     this._requirePhone();
     return this._inkbox._calls.place({
       fromNumber:          this._phoneNumber!.number,
       toNumber:            options.toNumber,
       clientWebsocketUrl:  options.clientWebsocketUrl,
-      webhookUrl:          options.webhookUrl,
     });
   }
 

--- a/sdk/typescript/src/phone/resources/calls.ts
+++ b/sdk/typescript/src/phone/resources/calls.ts
@@ -54,14 +54,12 @@ export class CallsResource {
    * @param options.fromNumber - E.164 number to call from. Must belong to your org and be active.
    * @param options.toNumber - E.164 number to call.
    * @param options.clientWebsocketUrl - WebSocket URL (wss://) for audio bridging.
-   * @param options.webhookUrl - Custom webhook URL for call lifecycle events.
    * @returns The created call record with current rate limit info.
    */
   async place(options: {
     fromNumber: string;
     toNumber: string;
     clientWebsocketUrl?: string;
-    webhookUrl?: string;
   }): Promise<PhoneCallWithRateLimit> {
     const body: Record<string, unknown> = {
       from_number: options.fromNumber,
@@ -69,9 +67,6 @@ export class CallsResource {
     };
     if (options.clientWebsocketUrl !== undefined) {
       body["client_websocket_url"] = options.clientWebsocketUrl;
-    }
-    if (options.webhookUrl !== undefined) {
-      body["webhook_url"] = options.webhookUrl;
     }
     const data = await this.http.post<RawPhoneCallWithRateLimit>("/place-call", body);
     return parsePhoneCallWithRateLimit(data);

--- a/sdk/typescript/tests/phone/calls.test.ts
+++ b/sdk/typescript/tests/phone/calls.test.ts
@@ -79,12 +79,10 @@ describe("CallsResource.place", () => {
       fromNumber: "+18335794607",
       toNumber: "+15167251294",
       clientWebsocketUrl: "wss://agent.example.com/ws",
-      webhookUrl: "https://example.com/hook",
     });
 
     const [, body] = vi.mocked(http.post).mock.calls[0] as [string, Record<string, unknown>];
     expect(body["client_websocket_url"]).toBe("wss://agent.example.com/ws");
-    expect(body["webhook_url"]).toBe("https://example.com/hook");
   });
 
   it("omits optional fields when not provided", async () => {
@@ -96,6 +94,5 @@ describe("CallsResource.place", () => {
 
     const [, body] = vi.mocked(http.post).mock.calls[0] as [string, Record<string, unknown>];
     expect(body["client_websocket_url"]).toBeUndefined();
-    expect(body["webhook_url"]).toBeUndefined();
   });
 });

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -134,12 +134,6 @@ call = identity.place_call(
 print(call.status)
 print(call.rate_limit.calls_remaining)   # rolling 24h budget
 
-# Or receive events via webhook
-call = identity.place_call(
-    to_number="+15167251294",
-    webhook_url="https://your-agent.example.com/call-events",
-)
-
 # List calls (offset pagination)
 calls = identity.list_calls(limit=10, offset=0)
 for c in calls:

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -138,12 +138,6 @@ const call = await identity.placeCall({
 console.log(call.status);
 console.log(call.rateLimit.callsRemaining);   // rolling 24h budget
 
-// Or receive events via webhook
-const call = await identity.placeCall({
-  toNumber: "+15167251294",
-  webhookUrl: "https://your-agent.example.com/call-events",
-});
-
 // List calls (offset pagination)
 const calls = await identity.listCalls({ limit: 10, offset: 0 });
 for (const c of calls) {


### PR DESCRIPTION
**Python SDK**
- [calls.py](inkbox/sdk/python/inkbox/phone/resources/calls.py) — removed `webhook_url` param from `place()`
- [agent_identity.py](inkbox/sdk/python/inkbox/agent_identity.py) — removed `webhook_url` param from `place_call()`
- [test_calls.py](inkbox/sdk/python/tests/test_calls.py) — removed the `webhook_url` test case; cleaned up the "omits optional fields" assertion
- [README.md](inkbox/sdk/python/README.md) — removed the "receive events via webhook" `place_call` example

**TypeScript SDK**
- [calls.ts](inkbox/sdk/typescript/src/phone/resources/calls.ts) — removed `webhookUrl` from `place()`
- [agent_identity.ts](inkbox/sdk/typescript/src/agent_identity.ts) — removed `webhookUrl` from `placeCall()`
- [calls.test.ts](inkbox/sdk/typescript/tests/phone/calls.test.ts) — removed the `webhookUrl` test case; cleaned up the "omits optional fields" assertion
- [README.md](inkbox/sdk/typescript/README.md) — removed the "receive events via webhook" `placeCall` example

**SKILL.md files**
- [inkbox-python/SKILL.md](inkbox/skills/inkbox-python/SKILL.md) — removed `webhook_url` example from `place_call`
- [inkbox-ts/SKILL.md](inkbox/skills/inkbox-ts/SKILL.md) — removed `webhookUrl` example from `placeCall`