### PR TITLE
SECURITY: redact TOTP secret from error messages

### DIFF
--- a/sdk/python/inkbox/vault/totp.py
+++ b/sdk/python/inkbox/vault/totp.py
@@ -136,7 +136,7 @@ def _b32decode(secret: str) -> bytes:
     try:
         return base64.b32decode(padded)
     except Exception:
-        raise ValueError(f"Invalid base32 secret: {secret!r}") from None
+        raise ValueError(f"Invalid base32 secret (length={len(secret)})") from None
 
 
 def _generate_hotp(

--- a/sdk/typescript/src/vault/totp.ts
+++ b/sdk/typescript/src/vault/totp.ts
@@ -91,13 +91,13 @@ export function validateTotpConfig(config: TOTPConfig): void {
 function b32decode(secret: string): Buffer {
   const upper = secret.toUpperCase().replace(/=+$/, "");
   if (upper.length === 0) {
-    throw new Error(`Invalid base32 secret: '${secret}'`);
+    throw new Error(`Invalid base32 secret (length=${secret.length})`);
   }
   const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
   const bits: number[] = [];
   for (const ch of upper) {
     const idx = alphabet.indexOf(ch);
-    if (idx === -1) throw new Error(`Invalid base32 secret: '${secret}'`);
+    if (idx === -1) throw new Error(`Invalid base32 secret (length=${secret.length})`);
     for (let i = 4; i >= 0; i--) {
       bits.push((idx >> i) & 1);
     }
@@ -109,7 +109,7 @@ function b32decode(secret: string): Buffer {
     bytes.push(byte);
   }
   if (bytes.length === 0) {
-    throw new Error(`Invalid base32 secret: '${secret}'`);
+    throw new Error(`Invalid base32 secret (length=${secret.length})`);
   }
   return Buffer.from(bytes);
 }


### PR DESCRIPTION
## Summary
- Redact TOTP shared secret from base32 validation error messages in both Python and TypeScript SDKs
- Error messages now include only the secret length (e.g., `Invalid base32 secret (length=32)`) instead of the raw secret value
- Prevents credential leakage to log aggregation services (Sentry, Datadog, CloudWatch, etc.) if base32 decoding fails

## Security context
Identified during security review of v0.2.0. TOTP shared secrets are high-value authentication factors — exposure in error messages could allow an attacker with log access to generate valid OTP codes.

## Test plan
- [x] TypeScript TOTP tests pass (30/30)
- [ ] Python TOTP tests pass (no venv configured locally, test matchers use `"Invalid base32"` which still matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)