### PR TITLE
Agent self-signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ from inkbox import Inkbox
 result = Inkbox.signup(
     human_email="alex@example.com",
     display_name="My Agent",
+    note_to_human="Hey Alex, this is your agent signing up!",
 )
 api_key = result.api_key  # save this — shown only once
 
@@ -148,6 +149,7 @@ import { Inkbox } from "@inkbox/sdk";
 const result = await Inkbox.signup({
   humanEmail: "alex@example.com",
   displayName: "My Agent",
+  noteToHuman: "Hey Alex, this is your agent signing up!",
 });
 const apiKey = result.apiKey; // save this — shown only once
 
@@ -164,7 +166,8 @@ await identity.sendEmail({ to: ["alex@example.com"], subject: "Hello!", bodyText
 
 ```bash
 # 1. Sign up (no --api-key needed)
-inkbox signup create --human-email alex@example.com --display-name "My Agent"
+inkbox signup create --human-email alex@example.com --display-name "My Agent" \
+  --note-to-human "Hey Alex, this is your agent signing up!"
 
 # 2. Verify (after human shares the 6-digit code)
 inkbox signup verify --code 483921

--- a/README.md
+++ b/README.md
@@ -114,6 +114,67 @@ inkbox vault get <secret-id>
 
 ---
 
+## Agent Signup
+
+Agents can self-register without a pre-existing API key. The flow provisions a mailbox, identity, and API key in one call:
+
+### Python
+
+```python
+from inkbox import Inkbox
+
+# 1. Sign up (no API key needed)
+result = Inkbox.signup(
+    human_email="alex@example.com",
+    display_name="My Agent",
+)
+api_key = result.api_key  # save this — shown only once
+
+# 2. Verify (after human shares the 6-digit code)
+Inkbox.verify_signup(api_key, verification_code="483921")
+
+# 3. Use the API key
+with Inkbox(api_key=api_key) as inkbox:
+    identity = inkbox.get_identity(result.agent_handle)
+    identity.send_email(to=["alex@example.com"], subject="Hello!", body_text="I'm set up.")
+```
+
+### TypeScript
+
+```typescript
+import { Inkbox } from "@inkbox/sdk";
+
+// 1. Sign up (no API key needed)
+const result = await Inkbox.signup({
+  humanEmail: "alex@example.com",
+  displayName: "My Agent",
+});
+const apiKey = result.apiKey; // save this — shown only once
+
+// 2. Verify (after human shares the 6-digit code)
+await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
+
+// 3. Use the API key
+const inkbox = new Inkbox({ apiKey });
+const identity = await inkbox.getIdentity(result.agentHandle);
+await identity.sendEmail({ to: ["alex@example.com"], subject: "Hello!", bodyText: "I'm set up." });
+```
+
+### CLI
+
+```bash
+# 1. Sign up (no --api-key needed)
+inkbox signup create --human-email alex@example.com --display-name "My Agent"
+
+# 2. Verify (after human shares the 6-digit code)
+inkbox signup verify --code 483921
+
+# 3. Check status
+inkbox signup status
+```
+
+---
+
 ## What's in this repo
 
 | Directory | Description |

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ from inkbox import Inkbox
 
 # 1. Sign up (no API key needed)
 result = Inkbox.signup(
-    human_email="alex@example.com",
+    human_email="john@example.com",
     display_name="My Agent",
-    note_to_human="Hey Alex, this is your agent signing up!",
+    note_to_human="Hey John, this is your agent signing up!",
 )
 api_key = result.api_key  # save this — shown only once
 
@@ -137,7 +137,7 @@ Inkbox.verify_signup(api_key, verification_code="483921")
 # 3. Use the API key
 with Inkbox(api_key=api_key) as inkbox:
     identity = inkbox.get_identity(result.agent_handle)
-    identity.send_email(to=["alex@example.com"], subject="Hello!", body_text="I'm set up.")
+    identity.send_email(to=["john@example.com"], subject="Hello!", body_text="I'm set up.")
 ```
 
 ### TypeScript
@@ -147,9 +147,9 @@ import { Inkbox } from "@inkbox/sdk";
 
 // 1. Sign up (no API key needed)
 const result = await Inkbox.signup({
-  humanEmail: "alex@example.com",
+  humanEmail: "john@example.com",
   displayName: "My Agent",
-  noteToHuman: "Hey Alex, this is your agent signing up!",
+  noteToHuman: "Hey John, this is your agent signing up!",
 });
 const apiKey = result.apiKey; // save this — shown only once
 
@@ -159,15 +159,15 @@ await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
 // 3. Use the API key
 const inkbox = new Inkbox({ apiKey });
 const identity = await inkbox.getIdentity(result.agentHandle);
-await identity.sendEmail({ to: ["alex@example.com"], subject: "Hello!", bodyText: "I'm set up." });
+await identity.sendEmail({ to: ["john@example.com"], subject: "Hello!", bodyText: "I'm set up." });
 ```
 
 ### CLI
 
 ```bash
 # 1. Sign up (no --api-key needed)
-inkbox signup create --human-email alex@example.com --display-name "My Agent" \
-  --note-to-human "Hey Alex, this is your agent signing up!"
+inkbox signup create --human-email john@example.com --display-name "My Agent" \
+  --note-to-human "Hey John, this is your agent signing up!"
 
 # 2. Verify (after human shares the 6-digit code)
 inkbox signup verify --code 483921

--- a/cli/README.md
+++ b/cli/README.md
@@ -56,7 +56,7 @@ Agent self-signup flow. The `create` command does not require an API key.
 inkbox signup create                             # Register a new agent (no API key needed)
   --human-email <email>                          #   Email of the human to approve (required)
   --display-name <name>                          #   Agent display name (required)
-  --note-to-human <note>                         #   Optional message in verification email
+  --note-to-human <note>                         #   Message to human in verification email (required)
 
 inkbox signup verify                             # Submit verification code
   --code <code>                                  #   6-digit code from email (required)

--- a/cli/README.md
+++ b/cli/README.md
@@ -280,6 +280,15 @@ inkbox number update <id>                    # Update phone number config
 inkbox number release <number-id>             # Release a phone number
 ```
 
+### whoami
+
+Show the authenticated caller's identity.
+
+```bash
+inkbox whoami                                # Display caller identity (API key or JWT)
+inkbox whoami --json                         # Output as JSON
+```
+
 ### signing-key
 
 Webhook signing key management.

--- a/cli/README.md
+++ b/cli/README.md
@@ -62,6 +62,7 @@ inkbox signup verify                             # Submit verification code
   --code <code>                                  #   6-digit code from email (required)
 
 inkbox signup resend-verification                # Resend the verification email (5-min cooldown)
+                                                 # Returns current organization_id (may change after verify/approval)
 
 inkbox signup status                             # Check claim status and restrictions
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,6 +48,24 @@ inkbox --json identity list
 
 ## Commands
 
+### signup
+
+Agent self-signup flow. The `create` command does not require an API key.
+
+```bash
+inkbox signup create                             # Register a new agent (no API key needed)
+  --human-email <email>                          #   Email of the human to approve (required)
+  --display-name <name>                          #   Agent display name (required)
+  --note-to-human <note>                         #   Optional message in verification email
+
+inkbox signup verify                             # Submit verification code
+  --code <code>                                  #   6-digit code from email (required)
+
+inkbox signup resend-verification                # Resend the verification email (5-min cooldown)
+
+inkbox signup status                             # Check claim status and restrictions
+```
+
 ### identity
 
 Manage agent identities.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.2.5",
+    "@inkbox/sdk": "file:../sdk/typescript",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/signup.ts
+++ b/cli/src/commands/signup.ts
@@ -1,0 +1,122 @@
+import { Command } from "commander";
+import { getGlobalOpts, type GlobalOpts } from "../client.js";
+import { output } from "../output.js";
+import { withErrorHandler } from "../errors.js";
+import { Inkbox } from "@inkbox/sdk";
+
+function requireApiKey(opts: GlobalOpts): string {
+  const apiKey = opts.apiKey ?? process.env.INKBOX_API_KEY;
+  if (!apiKey) {
+    console.error(
+      "Error: API key required. Set INKBOX_API_KEY or pass --api-key.",
+    );
+    process.exit(1);
+  }
+  return apiKey;
+}
+
+export function registerSignupCommands(program: Command): void {
+  const signup = program
+    .command("signup")
+    .description("Agent self-signup flow");
+
+  signup
+    .command("create")
+    .description("Register a new agent (no API key required)")
+    .requiredOption("--human-email <email>", "Email of the human who should approve this agent")
+    .requiredOption("--display-name <name>", "Human-readable name for the agent")
+    .option("--note-to-human <note>", "Optional message included in the verification email")
+    .action(
+      withErrorHandler(async function (this: Command) {
+        const globalOpts = getGlobalOpts(this);
+        const cmdOpts = this.opts();
+        const result = await Inkbox.signup(
+          {
+            humanEmail: cmdOpts.humanEmail,
+            displayName: cmdOpts.displayName,
+            noteToHuman: cmdOpts.noteToHuman,
+          },
+          { baseUrl: globalOpts.baseUrl },
+        );
+        if (globalOpts.json) {
+          output(result, { json: true });
+        } else {
+          console.log();
+          console.log("Agent registered successfully!");
+          console.log();
+          console.log(`  Email:    ${result.emailAddress}`);
+          console.log(`  Handle:   ${result.agentHandle}`);
+          console.log(`  Org:      ${result.organizationId}`);
+          console.log(`  Status:   ${result.claimStatus}`);
+          console.log();
+          console.log(`  API Key:  ${result.apiKey}`);
+          console.log();
+          console.log("Save the API key — it is shown only once.");
+          console.log(`A verification email has been sent to ${result.humanEmail}.`);
+        }
+      }),
+    );
+
+  signup
+    .command("verify")
+    .description("Submit a 6-digit verification code")
+    .requiredOption("--code <code>", "The 6-digit verification code")
+    .action(
+      withErrorHandler(async function (this: Command) {
+        const globalOpts = getGlobalOpts(this);
+        const apiKey = requireApiKey(globalOpts);
+        const cmdOpts = this.opts();
+        const result = await Inkbox.verifySignup(
+          apiKey,
+          { verificationCode: cmdOpts.code },
+          { baseUrl: globalOpts.baseUrl },
+        );
+        output(result, { json: !!globalOpts.json });
+      }),
+    );
+
+  signup
+    .command("resend-verification")
+    .description("Resend the verification email (5-minute cooldown)")
+    .action(
+      withErrorHandler(async function (this: Command) {
+        const globalOpts = getGlobalOpts(this);
+        const apiKey = requireApiKey(globalOpts);
+        const result = await Inkbox.resendSignupVerification(
+          apiKey,
+          { baseUrl: globalOpts.baseUrl },
+        );
+        output(result, { json: !!globalOpts.json });
+      }),
+    );
+
+  signup
+    .command("status")
+    .description("Check signup claim status and restrictions")
+    .action(
+      withErrorHandler(async function (this: Command) {
+        const globalOpts = getGlobalOpts(this);
+        const apiKey = requireApiKey(globalOpts);
+        const result = await Inkbox.getSignupStatus(
+          apiKey,
+          { baseUrl: globalOpts.baseUrl },
+        );
+        if (globalOpts.json) {
+          output(result, { json: true });
+        } else {
+          output(
+            {
+              claimStatus: result.claimStatus,
+              humanState: result.humanState,
+              humanEmail: result.humanEmail,
+              maxSendsPerDay: result.restrictions.maxSendsPerDay,
+              allowedRecipients: result.restrictions.allowedRecipients.join(", ") || "-",
+              canReceive: result.restrictions.canReceive,
+              canCreateMailboxes: result.restrictions.canCreateMailboxes,
+            },
+            { json: false },
+          );
+        }
+      }),
+    );
+}

--- a/cli/src/commands/signup.ts
+++ b/cli/src/commands/signup.ts
@@ -25,7 +25,7 @@ export function registerSignupCommands(program: Command): void {
     .description("Register a new agent (no API key required)")
     .requiredOption("--human-email <email>", "Email of the human who should approve this agent")
     .requiredOption("--display-name <name>", "Human-readable name for the agent")
-    .option("--note-to-human <note>", "Optional message included in the verification email")
+    .requiredOption("--note-to-human <note>", "Message from the agent to the human, included in the verification email")
     .action(
       withErrorHandler(async function (this: Command) {
         const globalOpts = getGlobalOpts(this);

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { createClient, getGlobalOpts } from "../client.js";
+import { output } from "../output.js";
+import { withErrorHandler } from "../errors.js";
+
+export function registerWhoamiCommand(program: Command): void {
+  program
+    .command("whoami")
+    .description("Show the authenticated caller's identity")
+    .action(
+      withErrorHandler(async function (this: Command) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const info = await inkbox.whoami();
+        output(info, { json: !!opts.json });
+      }),
+    );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerSignupCommands } from "./commands/signup.js";
 import { registerIdentityCommands } from "./commands/identity.js";
 import { registerEmailCommands } from "./commands/email.js";
@@ -21,6 +22,7 @@ const program = new Command()
   .option("--base-url <url>", "Override API base URL")
   .option("--json", "Output as JSON", false);
 
+registerWhoamiCommand(program);
 registerSignupCommands(program);
 registerIdentityCommands(program);
 registerEmailCommands(program);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { registerSignupCommands } from "./commands/signup.js";
 import { registerIdentityCommands } from "./commands/identity.js";
 import { registerEmailCommands } from "./commands/email.js";
 import { registerPhoneCommands } from "./commands/phone.js";
@@ -20,6 +21,7 @@ const program = new Command()
   .option("--base-url <url>", "Override API base URL")
   .option("--json", "Output as JSON", false);
 
+registerSignupCommands(program);
 registerIdentityCommands(program);
 registerEmailCommands(program);
 registerPhoneCommands(program);

--- a/examples/use-inkbox-browser-use/README.md
+++ b/examples/use-inkbox-browser-use/README.md
@@ -21,7 +21,7 @@ cp .env.example .env
 ## Quickstart
 
 ```bash
-uv run inkbox-browser-use "Go to news.ycombinator.com, get the top 5 posts, and email a summary to alex@example.com"
+uv run inkbox-browser-use "Go to news.ycombinator.com, get the top 5 posts, and email a summary to john@example.com"
 ```
 
 Chrome will be auto-launched in debug mode if it isn't already running.
@@ -30,19 +30,19 @@ Chrome will be auto-launched in debug mode if it isn't already running.
 
 ```bash
 # local Chrome (default — auto-launches if not running)
-uv run inkbox-browser-use "Go to hacker news, get the top 10 posts, and email them to alex@example.com"
+uv run inkbox-browser-use "Go to hacker news, get the top 10 posts, and email them to john@example.com"
 
 # sign up for a service using the agent's email
 uv run inkbox-browser-use "Sign up for a free account on example.com using my email"
 
 # Browser Use Cloud (no local Chrome needed)
-uv run inkbox-browser-use --env cloud "Go to example.com/pricing, summarize the plans, and email it to alex@example.com"
+uv run inkbox-browser-use --env cloud "Go to example.com/pricing, summarize the plans, and email it to john@example.com"
 
 # keep the browser open after the task completes
 uv run inkbox-browser-use --keep-browser "Sign up for a free account on example.com using my email"
 
 # local Chrome with custom debug URL
-uv run inkbox-browser-use --chrome-debug-url http://127.0.0.1:9333 "Email alex@example.com with a summary of example.com"
+uv run inkbox-browser-use --chrome-debug-url http://127.0.0.1:9333 "Email john@example.com with a summary of example.com"
 ```
 
 ### CLI flags

--- a/examples/use-inkbox-kernel/README.md
+++ b/examples/use-inkbox-kernel/README.md
@@ -21,7 +21,7 @@ cp .env.example .env
 ## Quickstart
 
 ```bash
-uv run inkbox-kernel "Go to news.ycombinator.com, read the top 3 posts, and email me a summary at alex@example.com"
+uv run inkbox-kernel "Go to news.ycombinator.com, read the top 3 posts, and email me a summary at john@example.com"
 ```
 
 ## Usage

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -65,6 +65,48 @@ Use `with Inkbox(...) as inkbox:` (recommended) or call `inkbox.close()` manuall
 
 ---
 
+## Agent Signup
+
+Agents can self-register without a pre-existing API key. All signup methods are **class methods** — no `Inkbox` instance required.
+
+```python
+from inkbox import Inkbox
+
+# Sign up (public — no API key needed)
+result = Inkbox.signup(
+    human_email="alex@example.com",
+    display_name="Sales Agent",
+    note_to_human="Hey Alex, this is your sales bot signing up!",
+)
+api_key = result.api_key          # save — shown only once
+email = result.email_address      # e.g. "sales-agent-a1b2c3@inkboxmail.com"
+handle = result.agent_handle      # e.g. "sales-agent-a1b2c3"
+
+# Verify (after human shares the 6-digit code from the email)
+Inkbox.verify_signup(api_key, verification_code="483921")
+
+# Resend verification email (5-minute cooldown)
+Inkbox.resend_signup_verification(api_key)
+
+# Check status and restrictions
+status = Inkbox.get_signup_status(api_key)
+print(status.claim_status)                    # "agent_unclaimed" or "agent_claimed"
+print(status.restrictions.max_sends_per_day)  # 10 (unclaimed) or 500 (claimed)
+```
+
+| Method | Auth | Returns |
+|---|---|---|
+| `Inkbox.signup(human_email, display_name, *, note_to_human=None)` | None | `AgentSignupResponse` |
+| `Inkbox.verify_signup(api_key, verification_code)` | API key | `AgentSignupVerifyResponse` |
+| `Inkbox.resend_signup_verification(api_key)` | API key | `AgentSignupResendResponse` |
+| `Inkbox.get_signup_status(api_key)` | API key | `AgentSignupStatusResponse` |
+
+All methods accept optional `base_url` and `timeout` keyword arguments.
+
+> **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
+
+---
+
 ## Identities
 
 `inkbox.create_identity()` and `inkbox.get_identity()` return an `AgentIdentity` object that holds the identity's channels and exposes convenience methods scoped to those channels.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -592,6 +592,23 @@ inkbox.phone_numbers.update(
 
 ---
 
+## Whoami
+
+```python
+# Check the authenticated caller's identity
+info = inkbox.whoami()
+print(info.auth_type)        # "api_key" or "jwt"
+print(info.organization_id)
+
+# Narrow by auth type
+if isinstance(info, inkbox.WhoamiApiKeyResponse):
+    print(info.key_id, info.label)
+elif isinstance(info, inkbox.WhoamiJwtResponse):
+    print(info.email, info.org_role)
+```
+
+---
+
 ## Signing Keys
 
 ```python

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -74,9 +74,9 @@ from inkbox import Inkbox
 
 # Sign up (public — no API key needed)
 result = Inkbox.signup(
-    human_email="alex@example.com",
+    human_email="john@example.com",
     display_name="Sales Agent",
-    note_to_human="Hey Alex, this is your sales bot signing up!",  # required
+    note_to_human="Hey John, this is your sales bot signing up!",  # required
 )
 api_key = result.api_key          # save — shown only once
 email = result.email_address      # e.g. "sales-agent-a1b2c3@inkboxmail.com"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -76,7 +76,7 @@ from inkbox import Inkbox
 result = Inkbox.signup(
     human_email="alex@example.com",
     display_name="Sales Agent",
-    note_to_human="Hey Alex, this is your sales bot signing up!",
+    note_to_human="Hey Alex, this is your sales bot signing up!",  # required
 )
 api_key = result.api_key          # save — shown only once
 email = result.email_address      # e.g. "sales-agent-a1b2c3@inkboxmail.com"
@@ -96,7 +96,7 @@ print(status.restrictions.max_sends_per_day)  # 10 (unclaimed) or 500 (claimed)
 
 | Method | Auth | Returns |
 |---|---|---|
-| `Inkbox.signup(human_email, display_name, *, note_to_human=None)` | None | `AgentSignupResponse` |
+| `Inkbox.signup(human_email, display_name, note_to_human)` | None | `AgentSignupResponse` |
 | `Inkbox.verify_signup(api_key, verification_code)` | API key | `AgentSignupVerifyResponse` |
 | `Inkbox.resend_signup_verification(api_key)` | API key | `AgentSignupResendResponse` |
 | `Inkbox.get_signup_status(api_key)` | API key | `AgentSignupStatusResponse` |

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -101,7 +101,7 @@ print(status.restrictions.max_sends_per_day)  # 10 (unclaimed) or 500 (claimed)
 | `Inkbox.resend_signup_verification(api_key)` | API key | `AgentSignupResendResponse` |
 | `Inkbox.get_signup_status(api_key)` | API key | `AgentSignupStatusResponse` |
 
-All methods accept optional `base_url` and `timeout` keyword arguments.
+All three arguments to `signup()` (`human_email`, `display_name`, `note_to_human`) are required. All methods accept optional `base_url` and `timeout` keyword arguments.
 
 > **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -105,6 +105,8 @@ All three arguments to `signup()` (`human_email`, `display_name`, `note_to_human
 
 > **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
 
+> **Note:** The `organization_id` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. Always use the `organization_id` from the most recent response (`verify_signup` or `resend_signup_verification`) rather than caching the value from the initial `signup()` call.
+
 ---
 
 ## Identities

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -72,6 +72,15 @@ from inkbox.vault.crypto import (
     generate_vault_key_material,
 )
 
+# Agent signup types
+from inkbox.agent_signup.types import (
+    AgentSignupResponse,
+    AgentSignupVerifyResponse,
+    AgentSignupResendResponse,
+    AgentSignupStatusResponse,
+    SignupRestrictions,
+)
+
 # Signing key + webhook verification
 from inkbox.signing_keys import SigningKey, verify_webhook
 
@@ -132,6 +141,12 @@ __all__ = [
     "TOTPConfig",
     "generate_totp",
     "parse_totp_uri",
+    # Agent signup types
+    "AgentSignupResponse",
+    "AgentSignupVerifyResponse",
+    "AgentSignupResendResponse",
+    "AgentSignupStatusResponse",
+    "SignupRestrictions",
     # Signing key + webhook verification
     "SigningKey",
     "verify_webhook",

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -81,6 +81,13 @@ from inkbox.agent_signup.types import (
     SignupRestrictions,
 )
 
+# Whoami types
+from inkbox.whoami.types import (
+    WhoamiApiKeyResponse,
+    WhoamiJwtResponse,
+    WhoamiResponse,
+)
+
 # Signing key + webhook verification
 from inkbox.signing_keys import SigningKey, verify_webhook
 
@@ -147,6 +154,10 @@ __all__ = [
     "AgentSignupResendResponse",
     "AgentSignupStatusResponse",
     "SignupRestrictions",
+    # Whoami types
+    "WhoamiApiKeyResponse",
+    "WhoamiJwtResponse",
+    "WhoamiResponse",
     # Signing key + webhook verification
     "SigningKey",
     "verify_webhook",

--- a/sdk/python/inkbox/agent_signup/types.py
+++ b/sdk/python/inkbox/agent_signup/types.py
@@ -1,0 +1,101 @@
+"""
+inkbox/agent_signup/types.py
+
+Dataclasses for the agent self-signup flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class AgentSignupResponse:
+    """Response from ``POST /api/v1/agent-signup``."""
+
+    email_address: str
+    organization_id: str
+    api_key: str
+    agent_handle: str
+    claim_status: str
+    human_email: str
+    message: str
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> AgentSignupResponse:
+        return cls(
+            email_address=d["email_address"],
+            organization_id=d["organization_id"],
+            api_key=d["api_key"],
+            agent_handle=d["agent_handle"],
+            claim_status=d["claim_status"],
+            human_email=d["human_email"],
+            message=d["message"],
+        )
+
+
+@dataclass
+class AgentSignupVerifyResponse:
+    """Response from ``POST /api/v1/agent-signup/verify``."""
+
+    claim_status: str
+    organization_id: str
+    message: str
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> AgentSignupVerifyResponse:
+        return cls(
+            claim_status=d["claim_status"],
+            organization_id=d["organization_id"],
+            message=d["message"],
+        )
+
+
+@dataclass
+class AgentSignupResendResponse:
+    """Response from ``POST /api/v1/agent-signup/resend-verification``."""
+
+    message: str
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> AgentSignupResendResponse:
+        return cls(message=d["message"])
+
+
+@dataclass
+class SignupRestrictions:
+    """Behavioral restrictions applied to an agent based on claim status."""
+
+    max_sends_per_day: int
+    allowed_recipients: list[str]
+    can_receive: bool
+    can_create_mailboxes: bool
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> SignupRestrictions:
+        return cls(
+            max_sends_per_day=d["max_sends_per_day"],
+            allowed_recipients=d["allowed_recipients"],
+            can_receive=d["can_receive"],
+            can_create_mailboxes=d["can_create_mailboxes"],
+        )
+
+
+@dataclass
+class AgentSignupStatusResponse:
+    """Response from ``GET /api/v1/agent-signup/status``."""
+
+    claim_status: str
+    human_state: str
+    human_email: str
+    restrictions: SignupRestrictions
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> AgentSignupStatusResponse:
+        return cls(
+            claim_status=d["claim_status"],
+            human_state=d["human_state"],
+            human_email=d["human_email"],
+            restrictions=SignupRestrictions._from_dict(d["restrictions"]),
+        )

--- a/sdk/python/inkbox/agent_signup/types.py
+++ b/sdk/python/inkbox/agent_signup/types.py
@@ -56,11 +56,17 @@ class AgentSignupVerifyResponse:
 class AgentSignupResendResponse:
     """Response from ``POST /api/v1/agent-signup/resend-verification``."""
 
+    claim_status: str
+    organization_id: str
     message: str
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> AgentSignupResendResponse:
-        return cls(message=d["message"])
+        return cls(
+            claim_status=d["claim_status"],
+            organization_id=d["organization_id"],
+            message=d["message"],
+        )
 
 
 @dataclass

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -26,6 +26,7 @@ from inkbox.identities.types import (
     IdentityPhoneNumberCreateOptions,
 )
 from inkbox.signing_keys import SigningKey, SigningKeysResource
+from inkbox.whoami.types import WhoamiResponse, _parse_whoami
 from inkbox.agent_signup.types import (
     AgentSignupResponse,
     AgentSignupVerifyResponse,
@@ -247,6 +248,11 @@ class Inkbox:
     def list_identities(self) -> list[AgentIdentitySummary]:
         """List all agent identities for your organisation."""
         return self._ids_resource.list()
+
+    def whoami(self) -> WhoamiResponse:
+        """Return the authenticated caller's identity and auth type."""
+        data = self._root_api_http.get("/whoami")
+        return _parse_whoami(data)
 
     def create_signing_key(self) -> SigningKey:
         """

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -26,6 +26,12 @@ from inkbox.identities.types import (
     IdentityPhoneNumberCreateOptions,
 )
 from inkbox.signing_keys import SigningKey, SigningKeysResource
+from inkbox.agent_signup.types import (
+    AgentSignupResponse,
+    AgentSignupVerifyResponse,
+    AgentSignupResendResponse,
+    AgentSignupStatusResponse,
+)
 from uuid import UUID
 from typing import Literal
 
@@ -249,3 +255,156 @@ class Inkbox:
         The plaintext key is returned once — save it immediately.
         """
         return self._signing_keys.create_or_rotate()
+
+    ## Agent signup (class methods — no instance required)
+
+    @classmethod
+    def _validate_base_url(cls, base_url: str) -> None:
+        if not base_url.startswith("https://"):
+            from urllib.parse import urlparse
+            _parsed = urlparse(base_url)
+            if _parsed.hostname not in ("localhost", "127.0.0.1"):
+                raise ValueError(
+                    "Only HTTPS base URLs are permitted (HTTP is allowed for "
+                    "localhost and 127.0.0.1)."
+                )
+
+    @classmethod
+    def _signup_request(
+        cls,
+        method: str,
+        path: str,
+        *,
+        api_key: str | None = None,
+        json: dict | None = None,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> dict:
+        """One-shot HTTP request for agent-signup endpoints."""
+        import httpx
+        from inkbox.exceptions import InkboxAPIError
+
+        cls._validate_base_url(base_url)
+        url = f"{base_url.rstrip('/')}/api/v1/agent-signup{path}"
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if api_key:
+            headers["X-Service-Token"] = api_key
+
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.request(method, url, headers=headers, json=json)
+
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise InkboxAPIError(status_code=resp.status_code, detail=str(detail))
+        return resp.json()
+
+    @classmethod
+    def signup(
+        cls,
+        human_email: str,
+        display_name: str,
+        *,
+        note_to_human: str | None = None,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> AgentSignupResponse:
+        """
+        Register a new agent (public — no API key required).
+
+        Returns the provisioned email, org, and a one-time API key.
+
+        Args:
+            human_email: Email of the human who should approve this agent.
+            display_name: Human-readable name for the agent.
+            note_to_human: Optional message included in the verification email.
+            base_url: Override the API base URL.
+            timeout: Request timeout in seconds.
+        """
+        body: dict[str, str] = {
+            "human_email": human_email,
+            "display_name": display_name,
+        }
+        if note_to_human is not None:
+            body["note_to_human"] = note_to_human
+        data = cls._signup_request(
+            "POST", "", json=body, base_url=base_url, timeout=timeout,
+        )
+        return AgentSignupResponse._from_dict(data)
+
+    @classmethod
+    def verify_signup(
+        cls,
+        api_key: str,
+        verification_code: str,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> AgentSignupVerifyResponse:
+        """
+        Submit a 6-digit verification code to unlock full capabilities.
+
+        Args:
+            api_key: The API key returned from :meth:`signup`.
+            verification_code: The 6-digit code from the verification email.
+            base_url: Override the API base URL.
+            timeout: Request timeout in seconds.
+        """
+        data = cls._signup_request(
+            "POST", "/verify",
+            api_key=api_key,
+            json={"verification_code": verification_code},
+            base_url=base_url,
+            timeout=timeout,
+        )
+        return AgentSignupVerifyResponse._from_dict(data)
+
+    @classmethod
+    def resend_signup_verification(
+        cls,
+        api_key: str,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> AgentSignupResendResponse:
+        """
+        Resend the verification email (5-minute cooldown).
+
+        Args:
+            api_key: The API key returned from :meth:`signup`.
+            base_url: Override the API base URL.
+            timeout: Request timeout in seconds.
+        """
+        data = cls._signup_request(
+            "POST", "/resend-verification",
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        return AgentSignupResendResponse._from_dict(data)
+
+    @classmethod
+    def get_signup_status(
+        cls,
+        api_key: str,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> AgentSignupStatusResponse:
+        """
+        Check the current signup claim status and restrictions.
+
+        Args:
+            api_key: The API key returned from :meth:`signup`.
+            base_url: Override the API base URL.
+            timeout: Request timeout in seconds.
+        """
+        data = cls._signup_request(
+            "GET", "/status",
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        return AgentSignupStatusResponse._from_dict(data)

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -307,7 +307,7 @@ class Inkbox:
         human_email: str,
         display_name: str,
         *,
-        note_to_human: str | None = None,
+        note_to_human: str,
         base_url: str = _DEFAULT_BASE_URL,
         timeout: float = 30.0,
     ) -> AgentSignupResponse:
@@ -319,16 +319,16 @@ class Inkbox:
         Args:
             human_email: Email of the human who should approve this agent.
             display_name: Human-readable name for the agent.
-            note_to_human: Optional message included in the verification email.
+            note_to_human: Message from the agent to the human, included in
+                the verification email.
             base_url: Override the API base URL.
             timeout: Request timeout in seconds.
         """
         body: dict[str, str] = {
             "human_email": human_email,
             "display_name": display_name,
+            "note_to_human": note_to_human,
         }
-        if note_to_human is not None:
-            body["note_to_human"] = note_to_human
         data = cls._signup_request(
             "POST", "", json=body, base_url=base_url, timeout=timeout,
         )

--- a/sdk/python/inkbox/whoami/types.py
+++ b/sdk/python/inkbox/whoami/types.py
@@ -1,0 +1,80 @@
+"""
+inkbox/whoami/types.py
+
+Dataclasses for the ``GET /api/whoami`` endpoint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class WhoamiApiKeyResponse:
+    """Returned when the caller authenticates with an API key."""
+
+    auth_type: str
+    auth_subtype: str | None
+    organization_id: str | None
+    created_by: str | None
+    creator_type: str | None
+    key_id: str | None
+    label: str | None
+    description: str | None
+    created_at: float | None
+    last_used_at: float | None
+    expires_at: float | None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> WhoamiApiKeyResponse:
+        return cls(
+            auth_type=d["auth_type"],
+            auth_subtype=d.get("auth_subtype"),
+            organization_id=d.get("organization_id"),
+            created_by=d.get("created_by"),
+            creator_type=d.get("creator_type"),
+            key_id=d.get("key_id"),
+            label=d.get("label"),
+            description=d.get("description"),
+            created_at=d.get("created_at"),
+            last_used_at=d.get("last_used_at"),
+            expires_at=d.get("expires_at"),
+        )
+
+
+@dataclass
+class WhoamiJwtResponse:
+    """Returned when the caller authenticates with a JWT."""
+
+    auth_type: str
+    auth_subtype: str | None
+    user_id: str | None
+    email: str | None
+    name: str | None
+    organization_id: str | None
+    org_role: str | None
+    org_slug: str | None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> WhoamiJwtResponse:
+        return cls(
+            auth_type=d["auth_type"],
+            auth_subtype=d.get("auth_subtype"),
+            user_id=d.get("user_id"),
+            email=d.get("email"),
+            name=d.get("name"),
+            organization_id=d.get("organization_id"),
+            org_role=d.get("org_role"),
+            org_slug=d.get("org_slug"),
+        )
+
+
+WhoamiResponse = WhoamiApiKeyResponse | WhoamiJwtResponse
+
+
+def _parse_whoami(d: dict[str, Any]) -> WhoamiResponse:
+    """Dispatch to the correct dataclass based on ``auth_type``."""
+    if d.get("auth_type") == "api_key":
+        return WhoamiApiKeyResponse._from_dict(d)
+    return WhoamiJwtResponse._from_dict(d)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.2.5"
+version = "0.2.6"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_agent_signup.py
+++ b/sdk/python/tests/test_agent_signup.py
@@ -1,0 +1,241 @@
+"""
+sdk/python/tests/test_agent_signup.py
+
+Tests for the agent self-signup flow (Inkbox class methods).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inkbox import Inkbox
+from inkbox.agent_signup.types import (
+    AgentSignupResponse,
+    AgentSignupResendResponse,
+    AgentSignupStatusResponse,
+    AgentSignupVerifyResponse,
+    SignupRestrictions,
+)
+from inkbox.exceptions import InkboxAPIError
+
+
+# ---- raw API fixtures ----
+
+RAW_SIGNUP = {
+    "email_address": "agent@inkboxmail.com",
+    "organization_id": "org-123",
+    "api_key": "ApiKey_abc",
+    "agent_handle": "my-agent",
+    "claim_status": "unclaimed",
+    "human_email": "human@example.com",
+    "message": "Verification email sent",
+}
+
+RAW_VERIFY = {
+    "claim_status": "claimed",
+    "organization_id": "org-123",
+    "message": "Verified",
+}
+
+RAW_RESEND = {
+    "message": "Verification email resent",
+}
+
+RAW_STATUS = {
+    "claim_status": "unclaimed",
+    "human_state": "pending",
+    "human_email": "human@example.com",
+    "restrictions": {
+        "max_sends_per_day": 10,
+        "allowed_recipients": ["human@example.com"],
+        "can_receive": True,
+        "can_create_mailboxes": False,
+    },
+}
+
+
+def _mock_httpx_client(mock_client_cls: MagicMock, status_code: int, json_data: dict) -> MagicMock:
+    """Configure the mocked httpx.Client context manager to return a response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = json_data
+    mock_response.text = str(json_data)
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.request.return_value = mock_response
+    mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+    mock_client_instance.__exit__ = MagicMock(return_value=False)
+    mock_client_cls.return_value = mock_client_instance
+    return mock_client_instance
+
+
+class TestSignup:
+    @patch("httpx.Client")
+    def test_signup_sends_correct_request_and_parses_response(self, mock_client_cls: MagicMock):
+        client = _mock_httpx_client(mock_client_cls, 200, RAW_SIGNUP)
+
+        result = Inkbox.signup(
+            human_email="human@example.com",
+            display_name="My Agent",
+            note_to_human="Please approve me",
+        )
+
+        client.request.assert_called_once_with(
+            "POST",
+            "https://inkbox.ai/api/v1/agent-signup",
+            headers={"Accept": "application/json"},
+            json={
+                "human_email": "human@example.com",
+                "display_name": "My Agent",
+                "note_to_human": "Please approve me",
+            },
+        )
+
+        assert isinstance(result, AgentSignupResponse)
+        assert result.email_address == "agent@inkboxmail.com"
+        assert result.organization_id == "org-123"
+        assert result.api_key == "ApiKey_abc"
+        assert result.agent_handle == "my-agent"
+        assert result.claim_status == "unclaimed"
+        assert result.human_email == "human@example.com"
+        assert result.message == "Verification email sent"
+
+    @patch("httpx.Client")
+    def test_signup_custom_base_url(self, mock_client_cls: MagicMock):
+        client = _mock_httpx_client(mock_client_cls, 200, RAW_SIGNUP)
+
+        Inkbox.signup(
+            human_email="h@e.com",
+            display_name="A",
+            note_to_human="hi",
+            base_url="https://custom.example.com",
+        )
+
+        url = client.request.call_args[0][1]
+        assert url == "https://custom.example.com/api/v1/agent-signup"
+
+
+class TestVerifySignup:
+    @patch("httpx.Client")
+    def test_verify_sends_auth_header_and_code(self, mock_client_cls: MagicMock):
+        client = _mock_httpx_client(mock_client_cls, 200, RAW_VERIFY)
+
+        result = Inkbox.verify_signup(api_key="ApiKey_abc", verification_code="123456")
+
+        client.request.assert_called_once_with(
+            "POST",
+            "https://inkbox.ai/api/v1/agent-signup/verify",
+            headers={
+                "Accept": "application/json",
+                "X-Service-Token": "ApiKey_abc",
+            },
+            json={"verification_code": "123456"},
+        )
+
+        assert isinstance(result, AgentSignupVerifyResponse)
+        assert result.claim_status == "claimed"
+        assert result.organization_id == "org-123"
+        assert result.message == "Verified"
+
+
+class TestResendSignupVerification:
+    @patch("httpx.Client")
+    def test_resend_sends_auth_header_no_body(self, mock_client_cls: MagicMock):
+        client = _mock_httpx_client(mock_client_cls, 200, RAW_RESEND)
+
+        result = Inkbox.resend_signup_verification(api_key="ApiKey_abc")
+
+        client.request.assert_called_once_with(
+            "POST",
+            "https://inkbox.ai/api/v1/agent-signup/resend-verification",
+            headers={
+                "Accept": "application/json",
+                "X-Service-Token": "ApiKey_abc",
+            },
+            json=None,
+        )
+
+        assert isinstance(result, AgentSignupResendResponse)
+        assert result.message == "Verification email resent"
+
+
+class TestGetSignupStatus:
+    @patch("httpx.Client")
+    def test_status_sends_get_with_auth_and_parses_restrictions(self, mock_client_cls: MagicMock):
+        client = _mock_httpx_client(mock_client_cls, 200, RAW_STATUS)
+
+        result = Inkbox.get_signup_status(api_key="ApiKey_abc")
+
+        client.request.assert_called_once_with(
+            "GET",
+            "https://inkbox.ai/api/v1/agent-signup/status",
+            headers={
+                "Accept": "application/json",
+                "X-Service-Token": "ApiKey_abc",
+            },
+            json=None,
+        )
+
+        assert isinstance(result, AgentSignupStatusResponse)
+        assert result.claim_status == "unclaimed"
+        assert result.human_state == "pending"
+        assert result.human_email == "human@example.com"
+
+        assert isinstance(result.restrictions, SignupRestrictions)
+        assert result.restrictions.max_sends_per_day == 10
+        assert result.restrictions.allowed_recipients == ["human@example.com"]
+        assert result.restrictions.can_receive is True
+        assert result.restrictions.can_create_mailboxes is False
+
+
+class TestSignupErrors:
+    @patch("httpx.Client")
+    def test_raises_inkbox_api_error_on_4xx(self, mock_client_cls: MagicMock):
+        mock_response = MagicMock()
+        mock_response.status_code = 422
+        mock_response.json.return_value = {"detail": "Invalid verification code"}
+        mock_response.text = "Invalid verification code"
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.request.return_value = mock_response
+        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+        mock_client_instance.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client_instance
+
+        with pytest.raises(InkboxAPIError, match="422"):
+            Inkbox.verify_signup(api_key="ApiKey_abc", verification_code="000000")
+
+    def test_rejects_non_https_base_url(self):
+        with pytest.raises(ValueError, match="Only HTTPS base URLs are permitted"):
+            Inkbox.signup(
+                human_email="h@e.com",
+                display_name="A",
+                note_to_human="hi",
+                base_url="http://evil.com",
+            )
+
+    @patch("httpx.Client")
+    def test_allows_http_localhost(self, mock_client_cls: MagicMock):
+        _mock_httpx_client(mock_client_cls, 200, RAW_SIGNUP)
+
+        result = Inkbox.signup(
+            human_email="h@e.com",
+            display_name="A",
+            note_to_human="hi",
+            base_url="http://localhost:8000",
+        )
+        assert isinstance(result, AgentSignupResponse)
+
+    @patch("httpx.Client")
+    def test_allows_http_127(self, mock_client_cls: MagicMock):
+        _mock_httpx_client(mock_client_cls, 200, RAW_SIGNUP)
+
+        result = Inkbox.signup(
+            human_email="h@e.com",
+            display_name="A",
+            note_to_human="hi",
+            base_url="http://127.0.0.1:8000",
+        )
+        assert isinstance(result, AgentSignupResponse)

--- a/sdk/python/tests/test_agent_signup.py
+++ b/sdk/python/tests/test_agent_signup.py
@@ -40,6 +40,8 @@ RAW_VERIFY = {
 }
 
 RAW_RESEND = {
+    "claim_status": "pending_verification",
+    "organization_id": "org-123",
     "message": "Verification email resent",
 }
 
@@ -158,6 +160,8 @@ class TestResendSignupVerification:
         )
 
         assert isinstance(result, AgentSignupResendResponse)
+        assert result.claim_status == "pending_verification"
+        assert result.organization_id == "org-123"
         assert result.message == "Verification email resent"
 
 

--- a/sdk/python/tests/test_whoami.py
+++ b/sdk/python/tests/test_whoami.py
@@ -1,0 +1,71 @@
+"""
+sdk/python/tests/test_whoami.py
+
+Tests for the whoami types and client method.
+"""
+
+from unittest.mock import MagicMock
+
+from inkbox import Inkbox
+from inkbox.whoami.types import (
+    WhoamiApiKeyResponse,
+    WhoamiJwtResponse,
+    _parse_whoami,
+)
+
+RAW_API_KEY = {
+    "auth_type": "api_key",
+    "auth_subtype": "human",
+    "organization_id": "org_001",
+    "created_by": "user_abc",
+    "creator_type": "human",
+    "key_id": "key_xyz",
+    "label": "My Key",
+    "description": "Dev key",
+    "created_at": 1711929600.0,
+    "last_used_at": 1711933200.0,
+    "expires_at": None,
+}
+
+RAW_JWT = {
+    "auth_type": "jwt",
+    "auth_subtype": "clerk",
+    "user_id": "user_abc",
+    "email": "dev@example.com",
+    "name": "Dev User",
+    "organization_id": "org_001",
+    "org_role": "admin",
+    "org_slug": "my-org",
+}
+
+
+class TestParseWhoami:
+    def test_parses_api_key_response(self):
+        result = _parse_whoami(RAW_API_KEY)
+        assert isinstance(result, WhoamiApiKeyResponse)
+        assert result.auth_type == "api_key"
+        assert result.organization_id == "org_001"
+        assert result.key_id == "key_xyz"
+        assert result.label == "My Key"
+        assert result.expires_at is None
+
+    def test_parses_jwt_response(self):
+        result = _parse_whoami(RAW_JWT)
+        assert isinstance(result, WhoamiJwtResponse)
+        assert result.auth_type == "jwt"
+        assert result.email == "dev@example.com"
+        assert result.org_role == "admin"
+
+
+class TestClientWhoami:
+    def test_whoami_calls_root_api_http(self):
+        client = Inkbox(api_key="sk-test")
+        client._root_api_http = MagicMock()
+        client._root_api_http.get = MagicMock(return_value=RAW_API_KEY)
+
+        result = client.whoami()
+
+        client._root_api_http.get.assert_called_once_with("/whoami")
+        assert isinstance(result, WhoamiApiKeyResponse)
+        assert result.organization_id == "org_001"
+        client.close()

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -75,9 +75,9 @@ import { Inkbox } from "@inkbox/sdk";
 
 // Sign up (public — no API key needed)
 const result = await Inkbox.signup({
-  humanEmail: "alex@example.com",
+  humanEmail: "john@example.com",
   displayName: "Sales Agent",
-  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+  noteToHuman: "Hey John, this is your sales bot signing up!",
 });
 const apiKey = result.apiKey;          // save — shown only once
 const email = result.emailAddress;     // e.g. "sales-agent-a1b2c3@inkboxmail.com"

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -66,6 +66,48 @@ for (const login of creds.listLogins()) {
 
 ---
 
+## Agent Signup
+
+Agents can self-register without a pre-existing API key. All signup methods are **static** — no `Inkbox` instance required.
+
+```ts
+import { Inkbox } from "@inkbox/sdk";
+
+// Sign up (public — no API key needed)
+const result = await Inkbox.signup({
+  humanEmail: "alex@example.com",
+  displayName: "Sales Agent",
+  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+});
+const apiKey = result.apiKey;          // save — shown only once
+const email = result.emailAddress;     // e.g. "sales-agent-a1b2c3@inkboxmail.com"
+const handle = result.agentHandle;     // e.g. "sales-agent-a1b2c3"
+
+// Verify (after human shares the 6-digit code from the email)
+await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
+
+// Resend verification email (5-minute cooldown)
+await Inkbox.resendSignupVerification(apiKey);
+
+// Check status and restrictions
+const status = await Inkbox.getSignupStatus(apiKey);
+console.log(status.claimStatus);                    // "agent_unclaimed" or "agent_claimed"
+console.log(status.restrictions.maxSendsPerDay);    // 10 (unclaimed) or 500 (claimed)
+```
+
+| Method | Auth | Returns |
+|---|---|---|
+| `Inkbox.signup(request, options?)` | None | `AgentSignupResponse` |
+| `Inkbox.verifySignup(apiKey, request, options?)` | API key | `AgentSignupVerifyResponse` |
+| `Inkbox.resendSignupVerification(apiKey, options?)` | API key | `AgentSignupResendResponse` |
+| `Inkbox.getSignupStatus(apiKey, options?)` | API key | `AgentSignupStatusResponse` |
+
+All methods accept an optional `options` object with `baseUrl` and `timeoutMs`.
+
+> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
+
+---
+
 ## Identities
 
 `inkbox.createIdentity()` and `inkbox.getIdentity()` return an `AgentIdentity` object that holds the identity's channels and exposes convenience methods scoped to those channels.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -618,6 +618,24 @@ await inkbox.phoneNumbers.update(number.id, {
 
 ---
 
+## Whoami
+
+```ts
+// Check the authenticated caller's identity
+const info = await inkbox.whoami();
+console.log(info.authType);        // "api_key" or "jwt"
+console.log(info.organizationId);
+
+// Narrow by auth type (discriminated union)
+if (info.authType === "api_key") {
+  console.log(info.keyId, info.label);
+} else {
+  console.log(info.email, info.orgRole);
+}
+```
+
+---
+
 ## Signing Keys
 
 ```ts

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -106,6 +106,8 @@ console.log(status.restrictions.maxSendsPerDay);    // 10 (unclaimed) or 500 (cl
 
 > **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
 
+> **Note:** The `organizationId` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. Always use the `organizationId` from the most recent response (`verifySignup` or `resendSignupVerification`) rather than caching the value from the initial `signup()` call.
+
 ---
 
 ## Identities

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -102,7 +102,7 @@ console.log(status.restrictions.maxSendsPerDay);    // 10 (unclaimed) or 500 (cl
 | `Inkbox.resendSignupVerification(apiKey, options?)` | API key | `AgentSignupResendResponse` |
 | `Inkbox.getSignupStatus(apiKey, options?)` | API key | `AgentSignupStatusResponse` |
 
-All methods accept an optional `options` object with `baseUrl` and `timeoutMs`.
+`request` for `signup()` requires `humanEmail`, `displayName`, and `noteToHuman`. All methods accept an optional `options` object with `baseUrl` and `timeoutMs`.
 
 > **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_signup/types.ts
+++ b/sdk/typescript/src/agent_signup/types.ts
@@ -33,6 +33,8 @@ export interface AgentSignupVerifyResponse {
 }
 
 export interface AgentSignupResendResponse {
+  claimStatus: string;
+  organizationId: string;
   message: string;
 }
 
@@ -69,6 +71,8 @@ export interface RawAgentSignupVerifyResponse {
 }
 
 export interface RawAgentSignupResendResponse {
+  claim_status: string;
+  organization_id: string;
   message: string;
 }
 
@@ -109,7 +113,11 @@ export function parseAgentSignupVerifyResponse(r: RawAgentSignupVerifyResponse):
 }
 
 export function parseAgentSignupResendResponse(r: RawAgentSignupResendResponse): AgentSignupResendResponse {
-  return { message: r.message };
+  return {
+    claimStatus: r.claim_status,
+    organizationId: r.organization_id,
+    message: r.message,
+  };
 }
 
 function parseSignupRestrictions(r: RawSignupRestrictions): SignupRestrictions {

--- a/sdk/typescript/src/agent_signup/types.ts
+++ b/sdk/typescript/src/agent_signup/types.ts
@@ -9,7 +9,7 @@
 export interface AgentSignupRequest {
   humanEmail: string;
   displayName: string;
-  noteToHuman?: string;
+  noteToHuman: string;
 }
 
 export interface AgentSignupResponse {
@@ -139,7 +139,7 @@ export function agentSignupRequestToWire(
     human_email: req.humanEmail,
     display_name: req.displayName,
   };
-  if (req.noteToHuman !== undefined) body["note_to_human"] = req.noteToHuman;
+  body["note_to_human"] = req.noteToHuman;
   return body;
 }
 

--- a/sdk/typescript/src/agent_signup/types.ts
+++ b/sdk/typescript/src/agent_signup/types.ts
@@ -1,0 +1,150 @@
+/**
+ * inkbox/agent_signup/types.ts
+ *
+ * Types for the agent self-signup flow.
+ */
+
+// ---- public interfaces (camelCase) ----
+
+export interface AgentSignupRequest {
+  humanEmail: string;
+  displayName: string;
+  noteToHuman?: string;
+}
+
+export interface AgentSignupResponse {
+  emailAddress: string;
+  organizationId: string;
+  apiKey: string;
+  agentHandle: string;
+  claimStatus: string;
+  humanEmail: string;
+  message: string;
+}
+
+export interface AgentSignupVerifyRequest {
+  verificationCode: string;
+}
+
+export interface AgentSignupVerifyResponse {
+  claimStatus: string;
+  organizationId: string;
+  message: string;
+}
+
+export interface AgentSignupResendResponse {
+  message: string;
+}
+
+export interface SignupRestrictions {
+  maxSendsPerDay: number;
+  allowedRecipients: string[];
+  canReceive: boolean;
+  canCreateMailboxes: boolean;
+}
+
+export interface AgentSignupStatusResponse {
+  claimStatus: string;
+  humanState: string;
+  humanEmail: string;
+  restrictions: SignupRestrictions;
+}
+
+// ---- internal raw API shapes (snake_case from JSON) ----
+
+export interface RawAgentSignupResponse {
+  email_address: string;
+  organization_id: string;
+  api_key: string;
+  agent_handle: string;
+  claim_status: string;
+  human_email: string;
+  message: string;
+}
+
+export interface RawAgentSignupVerifyResponse {
+  claim_status: string;
+  organization_id: string;
+  message: string;
+}
+
+export interface RawAgentSignupResendResponse {
+  message: string;
+}
+
+export interface RawSignupRestrictions {
+  max_sends_per_day: number;
+  allowed_recipients: string[];
+  can_receive: boolean;
+  can_create_mailboxes: boolean;
+}
+
+export interface RawAgentSignupStatusResponse {
+  claim_status: string;
+  human_state: string;
+  human_email: string;
+  restrictions: RawSignupRestrictions;
+}
+
+// ---- parsers ----
+
+export function parseAgentSignupResponse(r: RawAgentSignupResponse): AgentSignupResponse {
+  return {
+    emailAddress: r.email_address,
+    organizationId: r.organization_id,
+    apiKey: r.api_key,
+    agentHandle: r.agent_handle,
+    claimStatus: r.claim_status,
+    humanEmail: r.human_email,
+    message: r.message,
+  };
+}
+
+export function parseAgentSignupVerifyResponse(r: RawAgentSignupVerifyResponse): AgentSignupVerifyResponse {
+  return {
+    claimStatus: r.claim_status,
+    organizationId: r.organization_id,
+    message: r.message,
+  };
+}
+
+export function parseAgentSignupResendResponse(r: RawAgentSignupResendResponse): AgentSignupResendResponse {
+  return { message: r.message };
+}
+
+function parseSignupRestrictions(r: RawSignupRestrictions): SignupRestrictions {
+  return {
+    maxSendsPerDay: r.max_sends_per_day,
+    allowedRecipients: r.allowed_recipients,
+    canReceive: r.can_receive,
+    canCreateMailboxes: r.can_create_mailboxes,
+  };
+}
+
+export function parseAgentSignupStatusResponse(r: RawAgentSignupStatusResponse): AgentSignupStatusResponse {
+  return {
+    claimStatus: r.claim_status,
+    humanState: r.human_state,
+    humanEmail: r.human_email,
+    restrictions: parseSignupRestrictions(r.restrictions),
+  };
+}
+
+// ---- to-wire ----
+
+export function agentSignupRequestToWire(
+  req: AgentSignupRequest,
+): Record<string, string> {
+  const body: Record<string, string> = {
+    human_email: req.humanEmail,
+    display_name: req.displayName,
+  };
+  if (req.noteToHuman !== undefined) body["note_to_human"] = req.noteToHuman;
+  return body;
+}
+
+export function agentSignupVerifyRequestToWire(
+  req: AgentSignupVerifyRequest,
+): Record<string, string> {
+  return { verification_code: req.verificationCode };
+}

--- a/sdk/typescript/src/agent_signup/types.ts
+++ b/sdk/typescript/src/agent_signup/types.ts
@@ -143,12 +143,11 @@ export function parseAgentSignupStatusResponse(r: RawAgentSignupStatusResponse):
 export function agentSignupRequestToWire(
   req: AgentSignupRequest,
 ): Record<string, string> {
-  const body: Record<string, string> = {
+  return {
     human_email: req.humanEmail,
     display_name: req.displayName,
+    note_to_human: req.noteToHuman,
   };
-  body["note_to_human"] = req.noteToHuman;
-  return body;
 }
 
 export function agentSignupVerifyRequestToWire(

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -12,6 +12,11 @@ export type {
   AgentSignupStatusResponse,
 } from "./agent_signup/types.js";
 export { InkboxError, InkboxAPIError, InkboxVaultKeyError } from "./_http.js";
+export type {
+  WhoamiApiKeyResponse,
+  WhoamiJwtResponse,
+  WhoamiResponse,
+} from "./whoami/types.js";
 export type { SigningKey } from "./signing_keys.js";
 export { verifyWebhook } from "./signing_keys.js";
 export { MessageDirection } from "./mail/types.js";

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,7 +1,16 @@
 export { Inkbox } from "./inkbox.js";
 export { AgentIdentity } from "./agent_identity.js";
 export { Credentials } from "./credentials.js";
-export type { InkboxOptions } from "./inkbox.js";
+export type { InkboxOptions, SignupOptions } from "./inkbox.js";
+export type {
+  AgentSignupRequest,
+  AgentSignupResponse,
+  AgentSignupVerifyRequest,
+  AgentSignupVerifyResponse,
+  AgentSignupResendResponse,
+  SignupRestrictions,
+  AgentSignupStatusResponse,
+} from "./agent_signup/types.js";
 export { InkboxError, InkboxAPIError, InkboxVaultKeyError } from "./_http.js";
 export type { SigningKey } from "./signing_keys.js";
 export { verifyWebhook } from "./signing_keys.js";

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -5,6 +5,8 @@
  */
 
 import { HttpTransport, InkboxAPIError } from "./_http.js";
+import type { RawWhoamiResponse, WhoamiResponse } from "./whoami/types.js";
+import { parseWhoamiResponse } from "./whoami/types.js";
 import { MailboxesResource } from "./mail/resources/mailboxes.js";
 import { MessagesResource } from "./mail/resources/messages.js";
 import { ThreadsResource } from "./mail/resources/threads.js";
@@ -110,6 +112,7 @@ export class Inkbox {
   readonly _transcripts: TranscriptsResource;
   readonly _idsResource: IdentitiesResource;
   readonly _vaultResource: VaultResource;
+  readonly _rootApiHttp: HttpTransport;
   /** @internal */
   _vaultUnlockPromise: Promise<unknown> | null = null;
 
@@ -147,6 +150,7 @@ export class Inkbox {
 
     this._idsResource = new IdentitiesResource(idsHttp);
 
+    this._rootApiHttp = rootApiHttp;
     this._vaultResource = new VaultResource(vaultHttp, rootApiHttp);
 
     if (options.vaultKey !== undefined) {
@@ -272,6 +276,16 @@ export class Inkbox {
    */
   async createSigningKey(): Promise<SigningKey> {
     return this._signingKeys.createOrRotate();
+  }
+
+  /**
+   * Return the authenticated caller's identity and auth type.
+   *
+   * @returns A {@link WhoamiResponse} — either an API-key or JWT variant.
+   */
+  async whoami(): Promise<WhoamiResponse> {
+    const raw = await this._rootApiHttp.get<RawWhoamiResponse>("/whoami");
+    return parseWhoamiResponse(raw);
   }
 
   // ------------------------------------------------------------------

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -4,7 +4,7 @@
  * Inkbox — org-level entry point for all Inkbox APIs.
  */
 
-import { HttpTransport } from "./_http.js";
+import { HttpTransport, InkboxAPIError } from "./_http.js";
 import { MailboxesResource } from "./mail/resources/mailboxes.js";
 import { MessagesResource } from "./mail/resources/messages.js";
 import { ThreadsResource } from "./mail/resources/threads.js";
@@ -18,8 +18,35 @@ import { IdentitiesResource } from "./identities/resources/identities.js";
 import { VaultResource } from "./vault/resources/vault.js";
 import { AgentIdentity } from "./agent_identity.js";
 import type { AgentIdentitySummary, CreateIdentityOptions } from "./identities/types.js";
+import type {
+  AgentSignupRequest,
+  AgentSignupResponse,
+  AgentSignupVerifyRequest,
+  AgentSignupVerifyResponse,
+  AgentSignupResendResponse,
+  AgentSignupStatusResponse,
+  RawAgentSignupResponse,
+  RawAgentSignupVerifyResponse,
+  RawAgentSignupResendResponse,
+  RawAgentSignupStatusResponse,
+} from "./agent_signup/types.js";
+import {
+  agentSignupRequestToWire,
+  agentSignupVerifyRequestToWire,
+  parseAgentSignupResponse,
+  parseAgentSignupVerifyResponse,
+  parseAgentSignupResendResponse,
+  parseAgentSignupStatusResponse,
+} from "./agent_signup/types.js";
 
 const DEFAULT_BASE_URL = "https://inkbox.ai";
+
+export interface SignupOptions {
+  /** Override the API base URL (useful for self-hosting or testing). */
+  baseUrl?: string;
+  /** Request timeout in milliseconds. Defaults to 30 000. */
+  timeoutMs?: number;
+}
 
 export interface InkboxOptions {
   /** Your Inkbox API key (sent as `X-Service-Token`). */
@@ -245,5 +272,116 @@ export class Inkbox {
    */
   async createSigningKey(): Promise<SigningKey> {
     return this._signingKeys.createOrRotate();
+  }
+
+  // ------------------------------------------------------------------
+  // Agent signup (static — no instance required)
+  // ------------------------------------------------------------------
+
+  /** @internal One-shot fetch for agent-signup endpoints. */
+  private static async _signupFetch<T>(
+    method: string,
+    path: string,
+    opts: { apiKey?: string; body?: unknown; baseUrl?: string; timeoutMs?: number },
+  ): Promise<T> {
+    const base = opts.baseUrl ?? DEFAULT_BASE_URL;
+    if (!base.startsWith("https://")) {
+      const parsed = new URL(base);
+      if (parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
+        throw new Error(
+          "Only HTTPS base URLs are permitted (HTTP is allowed for " +
+          "localhost and 127.0.0.1).",
+        );
+      }
+    }
+    const url = `${base.replace(/\/$/, "")}/api/v1/agent-signup${path}`;
+    const ms = opts.timeoutMs ?? 30_000;
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (opts.apiKey) headers["X-Service-Token"] = opts.apiKey;
+
+    let bodyStr: string | undefined;
+    if (opts.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      bodyStr = JSON.stringify(opts.body);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, { method, headers, body: bodyStr, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!resp.ok) {
+      let detail: string;
+      try {
+        const err = (await resp.json()) as { detail?: string };
+        detail = err.detail ?? resp.statusText;
+      } catch {
+        detail = resp.statusText;
+      }
+      throw new InkboxAPIError(resp.status, detail);
+    }
+
+    return resp.json() as Promise<T>;
+  }
+
+  /**
+   * Register a new agent (public — no API key required).
+   *
+   * Returns the provisioned email, org, and a one-time API key.
+   */
+  static async signup(
+    request: AgentSignupRequest,
+    options?: SignupOptions,
+  ): Promise<AgentSignupResponse> {
+    const raw = await Inkbox._signupFetch<RawAgentSignupResponse>(
+      "POST", "", { body: agentSignupRequestToWire(request), ...options },
+    );
+    return parseAgentSignupResponse(raw);
+  }
+
+  /**
+   * Submit a 6-digit verification code to unlock full capabilities.
+   */
+  static async verifySignup(
+    apiKey: string,
+    request: AgentSignupVerifyRequest,
+    options?: SignupOptions,
+  ): Promise<AgentSignupVerifyResponse> {
+    const raw = await Inkbox._signupFetch<RawAgentSignupVerifyResponse>(
+      "POST", "/verify", { apiKey, body: agentSignupVerifyRequestToWire(request), ...options },
+    );
+    return parseAgentSignupVerifyResponse(raw);
+  }
+
+  /**
+   * Resend the verification email (5-minute cooldown).
+   */
+  static async resendSignupVerification(
+    apiKey: string,
+    options?: SignupOptions,
+  ): Promise<AgentSignupResendResponse> {
+    const raw = await Inkbox._signupFetch<RawAgentSignupResendResponse>(
+      "POST", "/resend-verification", { apiKey, ...options },
+    );
+    return parseAgentSignupResendResponse(raw);
+  }
+
+  /**
+   * Check the current signup claim status and restrictions.
+   */
+  static async getSignupStatus(
+    apiKey: string,
+    options?: SignupOptions,
+  ): Promise<AgentSignupStatusResponse> {
+    const raw = await Inkbox._signupFetch<RawAgentSignupStatusResponse>(
+      "GET", "/status", { apiKey, ...options },
+    );
+    return parseAgentSignupStatusResponse(raw);
   }
 }

--- a/sdk/typescript/src/whoami/types.ts
+++ b/sdk/typescript/src/whoami/types.ts
@@ -1,0 +1,93 @@
+/**
+ * inkbox/whoami/types.ts
+ *
+ * Types for the ``GET /api/whoami`` endpoint.
+ */
+
+// ---- public interfaces (camelCase) ----
+
+export interface WhoamiApiKeyResponse {
+  authType: "api_key";
+  authSubtype: string | null;
+  organizationId: string | null;
+  createdBy: string | null;
+  creatorType: string | null;
+  keyId: string | null;
+  label: string | null;
+  description: string | null;
+  createdAt: number | null;
+  lastUsedAt: number | null;
+  expiresAt: number | null;
+}
+
+export interface WhoamiJwtResponse {
+  authType: "jwt";
+  authSubtype: string | null;
+  userId: string | null;
+  email: string | null;
+  name: string | null;
+  organizationId: string | null;
+  orgRole: string | null;
+  orgSlug: string | null;
+}
+
+export type WhoamiResponse = WhoamiApiKeyResponse | WhoamiJwtResponse;
+
+// ---- internal raw API shapes (snake_case from JSON) ----
+
+export interface RawWhoamiApiKeyResponse {
+  auth_type: "api_key";
+  auth_subtype: string | null;
+  organization_id: string | null;
+  created_by: string | null;
+  creator_type: string | null;
+  key_id: string | null;
+  label: string | null;
+  description: string | null;
+  created_at: number | null;
+  last_used_at: number | null;
+  expires_at: number | null;
+}
+
+export interface RawWhoamiJwtResponse {
+  auth_type: "jwt";
+  auth_subtype: string | null;
+  user_id: string | null;
+  email: string | null;
+  name: string | null;
+  organization_id: string | null;
+  org_role: string | null;
+  org_slug: string | null;
+}
+
+export type RawWhoamiResponse = RawWhoamiApiKeyResponse | RawWhoamiJwtResponse;
+
+// ---- parser ----
+
+export function parseWhoamiResponse(r: RawWhoamiResponse): WhoamiResponse {
+  if (r.auth_type === "api_key") {
+    return {
+      authType: r.auth_type,
+      authSubtype: r.auth_subtype,
+      organizationId: r.organization_id,
+      createdBy: r.created_by,
+      creatorType: r.creator_type,
+      keyId: r.key_id,
+      label: r.label,
+      description: r.description,
+      createdAt: r.created_at,
+      lastUsedAt: r.last_used_at,
+      expiresAt: r.expires_at,
+    };
+  }
+  return {
+    authType: r.auth_type,
+    authSubtype: r.auth_subtype,
+    userId: r.user_id,
+    email: r.email,
+    name: r.name,
+    organizationId: r.organization_id,
+    orgRole: r.org_role,
+    orgSlug: r.org_slug,
+  };
+}

--- a/sdk/typescript/tests/agent_signup.test.ts
+++ b/sdk/typescript/tests/agent_signup.test.ts
@@ -39,6 +39,8 @@ const RAW_VERIFY_RESPONSE = {
 };
 
 const RAW_RESEND_RESPONSE = {
+  claim_status: "pending_verification",
+  organization_id: "org_abc123",
   message: "Verification email resent",
 };
 
@@ -166,7 +168,11 @@ describe("Inkbox.resendSignupVerification", () => {
     expect(headers["X-Service-Token"]).toBe("ApiKey_abc");
     expect(init!.body).toBeUndefined();
 
-    expect(result).toEqual({ message: "Verification email resent" });
+    expect(result).toEqual({
+      claimStatus: "pending_verification",
+      organizationId: "org_abc123",
+      message: "Verification email resent",
+    });
   });
 });
 

--- a/sdk/typescript/tests/agent_signup.test.ts
+++ b/sdk/typescript/tests/agent_signup.test.ts
@@ -1,0 +1,225 @@
+// sdk/typescript/tests/agent_signup.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Inkbox } from "../src/inkbox.js";
+import { InkboxAPIError } from "../src/_http.js";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(status: number, body: unknown, ok = status < 400) {
+  vi.mocked(fetch).mockResolvedValue({
+    ok,
+    status,
+    statusText: "Error",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+// ---- raw API fixtures (snake_case) ----
+
+const RAW_SIGNUP_RESPONSE = {
+  email_address: "agent@inkboxmail.com",
+  organization_id: "org-123",
+  api_key: "ApiKey_abc",
+  agent_handle: "my-agent",
+  claim_status: "unclaimed",
+  human_email: "human@example.com",
+  message: "Verification email sent",
+};
+
+const RAW_VERIFY_RESPONSE = {
+  claim_status: "claimed",
+  organization_id: "org-123",
+  message: "Verified",
+};
+
+const RAW_RESEND_RESPONSE = {
+  message: "Verification email resent",
+};
+
+const RAW_STATUS_RESPONSE = {
+  claim_status: "unclaimed",
+  human_state: "pending",
+  human_email: "human@example.com",
+  restrictions: {
+    max_sends_per_day: 10,
+    allowed_recipients: ["human@example.com"],
+    can_receive: true,
+    can_create_mailboxes: false,
+  },
+};
+
+// ---- Tests ----
+
+describe("Inkbox.signup", () => {
+  it("sends POST to /api/v1/agent-signup with snake_case body and no auth header", async () => {
+    mockFetch(200, RAW_SIGNUP_RESPONSE);
+
+    const result = await Inkbox.signup({
+      humanEmail: "human@example.com",
+      displayName: "My Agent",
+      noteToHuman: "Please approve me",
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://inkbox.ai/api/v1/agent-signup");
+    expect(init!.method).toBe("POST");
+
+    const headers = init!.headers as Record<string, string>;
+    expect(headers["X-Service-Token"]).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init!.body as string);
+    expect(body).toEqual({
+      human_email: "human@example.com",
+      display_name: "My Agent",
+      note_to_human: "Please approve me",
+    });
+
+    // Parsed camelCase response
+    expect(result).toEqual({
+      emailAddress: "agent@inkboxmail.com",
+      organizationId: "org-123",
+      apiKey: "ApiKey_abc",
+      agentHandle: "my-agent",
+      claimStatus: "unclaimed",
+      humanEmail: "human@example.com",
+      message: "Verification email sent",
+    });
+  });
+
+  it("uses custom baseUrl", async () => {
+    mockFetch(200, RAW_SIGNUP_RESPONSE);
+
+    await Inkbox.signup(
+      { humanEmail: "h@e.com", displayName: "A", noteToHuman: "hi" },
+      { baseUrl: "https://custom.example.com" },
+    );
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toBe("https://custom.example.com/api/v1/agent-signup");
+  });
+
+  it("rejects non-HTTPS baseUrl", async () => {
+    await expect(
+      Inkbox.signup(
+        { humanEmail: "h@e.com", displayName: "A", noteToHuman: "hi" },
+        { baseUrl: "http://evil.com" },
+      ),
+    ).rejects.toThrow("Only HTTPS base URLs are permitted");
+  });
+
+  it("allows HTTP for localhost", async () => {
+    mockFetch(200, RAW_SIGNUP_RESPONSE);
+
+    await expect(
+      Inkbox.signup(
+        { humanEmail: "h@e.com", displayName: "A", noteToHuman: "hi" },
+        { baseUrl: "http://localhost:8000" },
+      ),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("Inkbox.verifySignup", () => {
+  it("sends POST to /verify with auth header and verification code", async () => {
+    mockFetch(200, RAW_VERIFY_RESPONSE);
+
+    const result = await Inkbox.verifySignup("ApiKey_abc", {
+      verificationCode: "123456",
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://inkbox.ai/api/v1/agent-signup/verify");
+    expect(init!.method).toBe("POST");
+
+    const headers = init!.headers as Record<string, string>;
+    expect(headers["X-Service-Token"]).toBe("ApiKey_abc");
+
+    const body = JSON.parse(init!.body as string);
+    expect(body).toEqual({ verification_code: "123456" });
+
+    expect(result).toEqual({
+      claimStatus: "claimed",
+      organizationId: "org-123",
+      message: "Verified",
+    });
+  });
+});
+
+describe("Inkbox.resendSignupVerification", () => {
+  it("sends POST to /resend-verification with auth header and no body", async () => {
+    mockFetch(200, RAW_RESEND_RESPONSE);
+
+    const result = await Inkbox.resendSignupVerification("ApiKey_abc");
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://inkbox.ai/api/v1/agent-signup/resend-verification");
+    expect(init!.method).toBe("POST");
+
+    const headers = init!.headers as Record<string, string>;
+    expect(headers["X-Service-Token"]).toBe("ApiKey_abc");
+    expect(init!.body).toBeUndefined();
+
+    expect(result).toEqual({ message: "Verification email resent" });
+  });
+});
+
+describe("Inkbox.getSignupStatus", () => {
+  it("sends GET to /status with auth header and returns parsed restrictions", async () => {
+    mockFetch(200, RAW_STATUS_RESPONSE);
+
+    const result = await Inkbox.getSignupStatus("ApiKey_abc");
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://inkbox.ai/api/v1/agent-signup/status");
+    expect(init!.method).toBe("GET");
+
+    const headers = init!.headers as Record<string, string>;
+    expect(headers["X-Service-Token"]).toBe("ApiKey_abc");
+
+    expect(result).toEqual({
+      claimStatus: "unclaimed",
+      humanState: "pending",
+      humanEmail: "human@example.com",
+      restrictions: {
+        maxSendsPerDay: 10,
+        allowedRecipients: ["human@example.com"],
+        canReceive: true,
+        canCreateMailboxes: false,
+      },
+    });
+  });
+});
+
+describe("Agent signup error handling", () => {
+  it("throws InkboxAPIError on non-ok response", async () => {
+    mockFetch(422, { detail: "Invalid verification code" }, false);
+
+    await expect(
+      Inkbox.verifySignup("ApiKey_abc", { verificationCode: "000000" }),
+    ).rejects.toThrow(InkboxAPIError);
+
+    await expect(
+      Inkbox.verifySignup("ApiKey_abc", { verificationCode: "000000" }),
+    ).rejects.toThrow("422");
+  });
+
+  it("falls back to statusText when JSON has no detail", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    await expect(
+      Inkbox.signup({ humanEmail: "h@e.com", displayName: "A", noteToHuman: "hi" }),
+    ).rejects.toThrow("Internal Server Error");
+  });
+});

--- a/sdk/typescript/tests/sampleData.ts
+++ b/sdk/typescript/tests/sampleData.ts
@@ -219,3 +219,30 @@ export const RAW_SIGNING_KEY = {
   signing_key: "sk-test-hmac-secret-abc123",
   created_at: "2026-03-09T00:00:00Z",
 };
+
+// ---- Whoami ----
+
+export const RAW_WHOAMI_API_KEY = {
+  auth_type: "api_key" as const,
+  auth_subtype: "human",
+  organization_id: "org-abc123",
+  created_by: "user_abc",
+  creator_type: "human",
+  key_id: "key_xyz",
+  label: "My Key",
+  description: "Dev key",
+  created_at: 1711929600,
+  last_used_at: 1711933200,
+  expires_at: null,
+};
+
+export const RAW_WHOAMI_JWT = {
+  auth_type: "jwt" as const,
+  auth_subtype: "clerk",
+  user_id: "user_abc",
+  email: "dev@example.com",
+  name: "Dev User",
+  organization_id: "org-abc123",
+  org_role: "admin",
+  org_slug: "my-org",
+};

--- a/sdk/typescript/tests/whoami.test.ts
+++ b/sdk/typescript/tests/whoami.test.ts
@@ -1,0 +1,55 @@
+// sdk/typescript/tests/whoami.test.ts
+import { describe, it, expect, vi } from "vitest";
+import type { HttpTransport } from "../src/_http.js";
+import { parseWhoamiResponse } from "../src/whoami/types.js";
+import { RAW_WHOAMI_API_KEY, RAW_WHOAMI_JWT } from "./sampleData.js";
+
+function mockHttp() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as HttpTransport;
+}
+
+describe("parseWhoamiResponse", () => {
+  it("parses API key response", () => {
+    const result = parseWhoamiResponse(RAW_WHOAMI_API_KEY);
+    expect(result.authType).toBe("api_key");
+    if (result.authType === "api_key") {
+      expect(result.organizationId).toBe("org-abc123");
+      expect(result.keyId).toBe("key_xyz");
+      expect(result.label).toBe("My Key");
+      expect(result.expiresAt).toBeNull();
+    }
+  });
+
+  it("parses JWT response", () => {
+    const result = parseWhoamiResponse(RAW_WHOAMI_JWT);
+    expect(result.authType).toBe("jwt");
+    if (result.authType === "jwt") {
+      expect(result.email).toBe("dev@example.com");
+      expect(result.orgRole).toBe("admin");
+      expect(result.orgSlug).toBe("my-org");
+    }
+  });
+});
+
+describe("Inkbox.whoami", () => {
+  it("calls GET /whoami on rootApiHttp", async () => {
+    const { Inkbox } = await import("../src/inkbox.js");
+    const client = new Inkbox({ apiKey: "sk-test" });
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue(RAW_WHOAMI_API_KEY);
+    (client as unknown as { _rootApiHttp: HttpTransport })._rootApiHttp = http;
+
+    const result = await client.whoami();
+
+    expect(http.get).toHaveBeenCalledWith("/whoami");
+    expect(result.authType).toBe("api_key");
+    if (result.authType === "api_key") {
+      expect(result.organizationId).toBe("org-abc123");
+    }
+  });
+});

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,9 +40,9 @@ Once the skills are installed, your coding agent will automatically know how to 
 
 | Skill | Language | Description |
 |-------|----------|-------------|
-| **inkbox-python** | Python ≥ 3.11 | Identities, email, phone, webhooks using the `inkbox` Python SDK |
-| **inkbox-ts** | TypeScript / Node ≥ 18 | Identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
-| **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — email and phone for your OpenClaw agent |
+| **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, webhooks using the `inkbox` Python SDK |
+| **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
+| **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email and phone for your OpenClaw agent |
 
 ## Documentation
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,6 +43,7 @@ Once the skills are installed, your coding agent will automatically know how to 
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, webhooks using the `inkbox` Python SDK |
 | **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
 | **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email and phone for your OpenClaw agent |
+| **agent-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
 
 ## Documentation
 

--- a/skills/agent-signup/SKILL.md
+++ b/skills/agent-signup/SKILL.md
@@ -163,7 +163,7 @@ curl -X POST https://inkbox.ai/api/v1/agent-signup/verify \
   -d '{ "verification_code": "483921" }'
 ```
 
-The verification code expires after 24 hours. Max 5 attempts before a resend is required.
+The verification code expires after 48 hours. Max 5 attempts before a resend is required.
 
 ### Resend Verification
 

--- a/skills/agent-signup/SKILL.md
+++ b/skills/agent-signup/SKILL.md
@@ -33,9 +33,9 @@ from inkbox import Inkbox
 
 # 1. Register
 result = Inkbox.signup(
-    human_email="alex@example.com",
+    human_email="john@example.com",
     display_name="Sales Agent",
-    note_to_human="Hey Alex, this is your sales bot signing up!",
+    note_to_human="Hey John, this is your sales bot signing up!",
 )
 
 # Save these — the api_key is shown only once
@@ -56,7 +56,7 @@ status = Inkbox.get_signup_status(api_key)
 # status.claim_status      → "agent_unclaimed" or "agent_claimed"
 # status.human_state        → "human_no_account", "human_account_unverified", etc.
 # status.restrictions.max_sends_per_day → 10 (unclaimed) or 500 (claimed)
-# status.restrictions.allowed_recipients → ["alex@example.com"] (unclaimed)
+# status.restrictions.allowed_recipients → ["john@example.com"] (unclaimed)
 ```
 
 Using the API key after signup:
@@ -65,7 +65,7 @@ Using the API key after signup:
 with Inkbox(api_key=api_key) as inkbox:
     identity = inkbox.get_identity(handle)
     identity.send_email(
-        to=["alex@example.com"],
+        to=["john@example.com"],
         subject="Hello from your agent!",
         body_text="I'm all set up.",
     )
@@ -80,9 +80,9 @@ import { Inkbox } from "@inkbox/sdk";
 
 // 1. Register
 const result = await Inkbox.signup({
-  humanEmail: "alex@example.com",
+  humanEmail: "john@example.com",
   displayName: "Sales Agent",
-  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+  noteToHuman: "Hey John, this is your sales bot signing up!",
 });
 
 // Save these — the apiKey is shown only once
@@ -103,7 +103,7 @@ const status = await Inkbox.getSignupStatus(apiKey);
 // status.claimStatus       → "agent_unclaimed" or "agent_claimed"
 // status.humanState         → "human_no_account", "human_account_unverified", etc.
 // status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
-// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
+// status.restrictions.allowedRecipients → ["john@example.com"] (unclaimed)
 ```
 
 Using the API key after signup:
@@ -112,7 +112,7 @@ Using the API key after signup:
 const inkbox = new Inkbox({ apiKey });
 const identity = await inkbox.getIdentity(handle);
 await identity.sendEmail({
-  to: ["alex@example.com"],
+  to: ["john@example.com"],
   subject: "Hello from your agent!",
   bodyText: "I'm all set up.",
 });
@@ -128,9 +128,9 @@ Base URL: `https://inkbox.ai/api`
 curl -X POST https://inkbox.ai/api/v1/agent-signup \
   -H "Content-Type: application/json" \
   -d '{
-    "human_email": "alex@example.com",
+    "human_email": "john@example.com",
     "display_name": "Sales Agent",
-    "note_to_human": "Hey Alex, this is your sales bot signing up!"
+    "note_to_human": "Hey John, this is your sales bot signing up!"
   }'
 ```
 
@@ -143,7 +143,7 @@ Response:
   "api_key": "ik_live_...",
   "agent_handle": "sales-agent-a1b2c3",
   "claim_status": "UNCLAIMED",
-  "human_email": "alex@example.com",
+  "human_email": "john@example.com",
   "message": "Agent created successfully."
 }
 ```
@@ -183,10 +183,10 @@ Response:
 {
   "claim_status": "UNCLAIMED",
   "human_state": "human_no_account",
-  "human_email": "alex@example.com",
+  "human_email": "john@example.com",
   "restrictions": {
     "max_sends_per_day": 10,
-    "allowed_recipients": ["alex@example.com"],
+    "allowed_recipients": ["john@example.com"],
     "can_receive": true,
     "can_create_mailboxes": false
   }

--- a/skills/agent-signup/SKILL.md
+++ b/skills/agent-signup/SKILL.md
@@ -1,0 +1,194 @@
+# Agent Signup
+
+## Overview
+
+Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+
+The flow has four steps:
+
+1. **Register** — create the agent (public, no auth)
+2. **Verify** — submit the 6-digit code the human received
+3. **Resend Verification** — re-send the code if needed
+4. **Check Status** — poll claim status and restrictions
+
+> **Important:** Always confirm with the user before initiating a signup, as it sends a real email to the specified human.
+
+## Restrictions
+
+| | Unclaimed | Claimed (after verification) |
+|---|---|---|
+| Max sends/day | 10 | 500 |
+| Allowed recipients | `human_email` only | No restriction |
+| Can receive email | Yes | Yes |
+| Can create mailboxes | No | No |
+
+## SDK Examples
+
+### Python
+
+All signup methods are **class methods** on `Inkbox` — no instance required.
+
+```python
+from inkbox import Inkbox
+
+# 1. Register
+result = Inkbox.signup(
+    human_email="alex@example.com",
+    display_name="Sales Agent",
+    note_to_human="Hey Alex, this is your sales bot signing up!",
+)
+
+# Save these — the api_key is shown only once
+api_key = result.api_key
+email = result.email_address       # e.g. "sales-agent-a1b2c3@inkboxmail.com"
+handle = result.agent_handle       # e.g. "sales-agent-a1b2c3"
+org_id = result.organization_id    # provisional org
+
+# 2. Verify (after the human shares the 6-digit code)
+verify = Inkbox.verify_signup(api_key, verification_code="483921")
+# verify.claim_status → "agent_claimed"
+
+# 3. Resend verification (5-minute cooldown)
+resend = Inkbox.resend_signup_verification(api_key)
+
+# 4. Check status
+status = Inkbox.get_signup_status(api_key)
+# status.claim_status      → "agent_unclaimed" or "agent_claimed"
+# status.human_state        → "human_no_account", "human_account_unverified", etc.
+# status.restrictions.max_sends_per_day → 10 (unclaimed) or 500 (claimed)
+# status.restrictions.allowed_recipients → ["alex@example.com"] (unclaimed)
+```
+
+Using the API key after signup:
+
+```python
+with Inkbox(api_key=api_key) as inkbox:
+    identity = inkbox.get_identity(handle)
+    identity.send_email(
+        to=["alex@example.com"],
+        subject="Hello from your agent!",
+        body_text="I'm all set up.",
+    )
+```
+
+### TypeScript
+
+All signup methods are **static methods** on `Inkbox` — no instance required.
+
+```ts
+import { Inkbox } from "@inkbox/sdk";
+
+// 1. Register
+const result = await Inkbox.signup({
+  humanEmail: "alex@example.com",
+  displayName: "Sales Agent",
+  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+});
+
+// Save these — the apiKey is shown only once
+const apiKey = result.apiKey;
+const email = result.emailAddress;       // e.g. "sales-agent-a1b2c3@inkboxmail.com"
+const handle = result.agentHandle;       // e.g. "sales-agent-a1b2c3"
+const orgId = result.organizationId;     // provisional org
+
+// 2. Verify (after the human shares the 6-digit code)
+const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
+// verify.claimStatus → "agent_claimed"
+
+// 3. Resend verification (5-minute cooldown)
+const resend = await Inkbox.resendSignupVerification(apiKey);
+
+// 4. Check status
+const status = await Inkbox.getSignupStatus(apiKey);
+// status.claimStatus       → "agent_unclaimed" or "agent_claimed"
+// status.humanState         → "human_no_account", "human_account_unverified", etc.
+// status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
+// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
+```
+
+Using the API key after signup:
+
+```ts
+const inkbox = new Inkbox({ apiKey });
+const identity = await inkbox.getIdentity(handle);
+await identity.sendEmail({
+  to: ["alex@example.com"],
+  subject: "Hello from your agent!",
+  bodyText: "I'm all set up.",
+});
+```
+
+## Direct API (curl)
+
+Base URL: `https://inkbox.ai/api`
+
+### Register (no auth required)
+
+```bash
+curl -X POST https://inkbox.ai/api/v1/agent-signup \
+  -H "Content-Type: application/json" \
+  -d '{
+    "human_email": "alex@example.com",
+    "display_name": "Sales Agent",
+    "note_to_human": "Hey Alex, this is your sales bot signing up!"
+  }'
+```
+
+Response:
+
+```json
+{
+  "email_address": "sales-agent-a1b2c3@inkboxmail.com",
+  "organization_id": "org_agent_...",
+  "api_key": "ik_live_...",
+  "agent_handle": "sales-agent-a1b2c3",
+  "claim_status": "UNCLAIMED",
+  "human_email": "alex@example.com",
+  "message": "Agent created successfully."
+}
+```
+
+Save the `api_key` — it is shown only once.
+
+### Verify
+
+```bash
+curl -X POST https://inkbox.ai/api/v1/agent-signup/verify \
+  -H "Content-Type: application/json" \
+  -H "X-Service-Token: ik_live_..." \
+  -d '{ "verification_code": "483921" }'
+```
+
+The verification code expires after 24 hours. Max 5 attempts before a resend is required.
+
+### Resend Verification
+
+```bash
+curl -X POST https://inkbox.ai/api/v1/agent-signup/resend-verification \
+  -H "X-Service-Token: ik_live_..."
+```
+
+5-minute cooldown between resends.
+
+### Check Status
+
+```bash
+curl https://inkbox.ai/api/v1/agent-signup/status \
+  -H "X-Service-Token: ik_live_..."
+```
+
+Response:
+
+```json
+{
+  "claim_status": "UNCLAIMED",
+  "human_state": "human_no_account",
+  "human_email": "alex@example.com",
+  "restrictions": {
+    "max_sends_per_day": 10,
+    "allowed_recipients": ["alex@example.com"],
+    "can_receive": true,
+    "can_create_mailboxes": false
+  }
+}
+```

--- a/skills/agent-signup/SKILL.md
+++ b/skills/agent-signup/SKILL.md
@@ -50,6 +50,7 @@ verify = Inkbox.verify_signup(api_key, verification_code="483921")
 
 # 3. Resend verification (5-minute cooldown)
 resend = Inkbox.resend_signup_verification(api_key)
+# resend.organization_id → current org (may differ from signup if migrated)
 
 # 4. Check status
 status = Inkbox.get_signup_status(api_key)
@@ -97,6 +98,7 @@ const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" })
 
 // 3. Resend verification (5-minute cooldown)
 const resend = await Inkbox.resendSignupVerification(apiKey);
+// resend.organizationId → current org (may differ from signup if migrated)
 
 // 4. Check status
 const status = await Inkbox.getSignupStatus(apiKey);
@@ -149,6 +151,8 @@ Response:
 ```
 
 Save the `api_key` — it is shown only once.
+
+> **Note:** The `organization_id` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. The `/verify` and `/resend-verification` endpoints both return the current `organization_id` — always prefer the most recent value over the one from the initial signup.
 
 ### Verify
 

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -66,6 +66,7 @@ Inkbox (org-level client)
 ├── .phoneNumbers           → PhoneNumbersResource
 ├── .texts                  → TextsResource
 ├── .vault                  → VaultResource
+├── .whoami()               → Promise<WhoamiResponse>
 └── .createSigningKey()     → Promise<SigningKey>
 
 AgentIdentity (identity-scoped helper)
@@ -482,6 +483,21 @@ await inkbox.phoneNumbers.update(num.id, {
 const hits = await inkbox.phoneNumbers.searchTranscripts(num.id, { q: "refund", party: "remote", limit: 50 });
 await inkbox.phoneNumbers.release(num.id);
 ```
+
+## Whoami
+
+```js
+// Check the authenticated caller's identity
+const info = await inkbox.whoami();
+console.log(info.authType);        // "api_key" or "jwt"
+console.log(info.organizationId);
+
+if (info.authType === "api_key") {
+  console.log(info.keyId, info.label);
+}
+```
+
+Returns `WhoamiApiKeyResponse` or `WhoamiJwtResponse` — discriminated on `authType`.
 
 ## Webhooks & Signature Verification
 

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -81,71 +81,13 @@ An identity must have a channel assigned before you can use mail/phone/text meth
 
 ## Agent Signup
 
-Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-All signup methods are **static methods** on `Inkbox` — no instance required.
+> **See:** `skills/agent-signup/SKILL.md`
+
+SDK methods: `Inkbox.signup({...})`, `Inkbox.verifySignup(apiKey, {...})`, `Inkbox.resendSignupVerification(apiKey)`, `Inkbox.getSignupStatus(apiKey)`.
 
 > **Important:** Always confirm with the user before initiating a signup, as it sends a real email to the specified human.
-
-### Signup (public, no API key)
-
-```js
-import { Inkbox } from "@inkbox/sdk";
-
-const result = await Inkbox.signup({
-  humanEmail: "alex@example.com",
-  displayName: "Sales Agent",
-  noteToHuman: "Hey Alex, this is your sales bot signing up!",
-});
-
-// Save these — the apiKey is shown only once
-const apiKey = result.apiKey;
-const email = result.emailAddress;       // e.g. "sales-agent-a1b2c3@inkboxmail.com"
-const handle = result.agentHandle;       // e.g. "sales-agent-a1b2c3"
-const orgId = result.organizationId;     // provisional org
-```
-
-### Verify (requires the API key from signup)
-
-After the human receives the verification email and shares the 6-digit code:
-
-```js
-const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
-// verify.claimStatus → "agent_claimed"
-```
-
-### Resend Verification
-
-```js
-const resend = await Inkbox.resendSignupVerification(apiKey);
-// 5-minute cooldown between resends
-```
-
-### Check Status
-
-```js
-const status = await Inkbox.getSignupStatus(apiKey);
-// status.claimStatus       → "agent_unclaimed" or "agent_claimed"
-// status.humanState         → "human_no_account", "human_account_unverified", etc.
-// status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
-// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
-```
-
-### Using the API key after signup
-
-Once you have the API key, use it like any other Inkbox API key:
-
-```js
-const inkbox = new Inkbox({ apiKey });
-const identity = await inkbox.getIdentity(handle);
-await identity.sendEmail({
-  to: ["alex@example.com"],
-  subject: "Hello from your agent!",
-  bodyText: "I'm all set up.",
-});
-```
-
-> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
 
 ## Identities
 

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -79,6 +79,74 @@ AgentIdentity (identity-scoped helper)
 
 An identity must have a channel assigned before you can use mail/phone/text methods. If not assigned, an `InkboxError` is thrown.
 
+## Agent Signup
+
+Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+
+All signup methods are **static methods** on `Inkbox` — no instance required.
+
+> **Important:** Always confirm with the user before initiating a signup, as it sends a real email to the specified human.
+
+### Signup (public, no API key)
+
+```js
+import { Inkbox } from "@inkbox/sdk";
+
+const result = await Inkbox.signup({
+  humanEmail: "alex@example.com",
+  displayName: "Sales Agent",
+  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+});
+
+// Save these — the apiKey is shown only once
+const apiKey = result.apiKey;
+const email = result.emailAddress;       // e.g. "sales-agent-a1b2c3@inkboxmail.com"
+const handle = result.agentHandle;       // e.g. "sales-agent-a1b2c3"
+const orgId = result.organizationId;     // provisional org
+```
+
+### Verify (requires the API key from signup)
+
+After the human receives the verification email and shares the 6-digit code:
+
+```js
+const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
+// verify.claimStatus → "agent_claimed"
+```
+
+### Resend Verification
+
+```js
+const resend = await Inkbox.resendSignupVerification(apiKey);
+// 5-minute cooldown between resends
+```
+
+### Check Status
+
+```js
+const status = await Inkbox.getSignupStatus(apiKey);
+// status.claimStatus       → "agent_unclaimed" or "agent_claimed"
+// status.humanState         → "human_no_account", "human_account_unverified", etc.
+// status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
+// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
+```
+
+### Using the API key after signup
+
+Once you have the API key, use it like any other Inkbox API key:
+
+```js
+const inkbox = new Inkbox({ apiKey });
+const identity = await inkbox.getIdentity(handle);
+await identity.sendEmail({
+  to: ["alex@example.com"],
+  subject: "Hello from your agent!",
+  bodyText: "I'm all set up.",
+});
+```
+
+> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
+
 ## Identities
 
 ```js

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -49,6 +49,72 @@ AgentIdentity (identity-scoped helper)
 
 An identity must have a channel assigned before you can use mail/phone methods. If not assigned, an `InkboxError` is raised with a clear message.
 
+## Agent Signup
+
+Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+
+All signup methods are **class methods** on `Inkbox` — no instance required.
+
+### Signup (public, no API key)
+
+```python
+from inkbox import Inkbox
+
+result = Inkbox.signup(
+    human_email="alex@example.com",
+    display_name="Sales Agent",
+    note_to_human="Hey Alex, this is your sales bot signing up!",
+)
+
+# Save these — the api_key is shown only once
+api_key = result.api_key
+email = result.email_address       # e.g. "sales-agent-a1b2c3@inkboxmail.com"
+handle = result.agent_handle       # e.g. "sales-agent-a1b2c3"
+org_id = result.organization_id    # provisional org
+```
+
+### Verify (requires the API key from signup)
+
+After the human receives the verification email and shares the 6-digit code:
+
+```python
+verify = Inkbox.verify_signup(api_key, verification_code="483921")
+# verify.claim_status → "agent_claimed"
+```
+
+### Resend Verification
+
+```python
+resend = Inkbox.resend_signup_verification(api_key)
+# 5-minute cooldown between resends
+```
+
+### Check Status
+
+```python
+status = Inkbox.get_signup_status(api_key)
+# status.claim_status      → "agent_unclaimed" or "agent_claimed"
+# status.human_state        → "human_no_account", "human_account_unverified", etc.
+# status.restrictions.max_sends_per_day → 10 (unclaimed) or 500 (claimed)
+# status.restrictions.allowed_recipients → ["alex@example.com"] (unclaimed)
+```
+
+### Using the API key after signup
+
+Once you have the API key, use it like any other Inkbox API key:
+
+```python
+with Inkbox(api_key=api_key) as inkbox:
+    identity = inkbox.get_identity(handle)
+    identity.send_email(
+        to=["alex@example.com"],
+        subject="Hello from your agent!",
+        body_text="I'm all set up.",
+    )
+```
+
+> **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
+
 ## Identities
 
 ```python

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -36,6 +36,7 @@ Inkbox (org-level client)
 ├── .phone_numbers           → PhoneNumbersResource
 ├── .texts                   → TextsResource
 ├── .vault                   → VaultResource
+├── .whoami()                → WhoamiResponse
 └── .create_signing_key()    → SigningKey
 
 AgentIdentity (identity-scoped helper)
@@ -407,6 +408,17 @@ inkbox.phone_numbers.update(
 hits = inkbox.phone_numbers.search_transcripts(number.id, q="refund", party="remote", limit=50)
 inkbox.phone_numbers.release(number.id)
 ```
+
+## Whoami
+
+```python
+# Check the authenticated caller's identity
+info = inkbox.whoami()
+print(info.auth_type)        # "api_key" or "jwt"
+print(info.organization_id)
+```
+
+Returns `WhoamiApiKeyResponse` (with `key_id`, `label`, `creator_type`, etc.) or `WhoamiJwtResponse` (with `email`, `org_role`, etc.) based on `auth_type`.
 
 ## Webhooks & Signature Verification
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -51,69 +51,11 @@ An identity must have a channel assigned before you can use mail/phone methods. 
 
 ## Agent Signup
 
-Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-All signup methods are **class methods** on `Inkbox` — no instance required.
+> **See:** `skills/agent-signup/SKILL.md`
 
-### Signup (public, no API key)
-
-```python
-from inkbox import Inkbox
-
-result = Inkbox.signup(
-    human_email="alex@example.com",
-    display_name="Sales Agent",
-    note_to_human="Hey Alex, this is your sales bot signing up!",
-)
-
-# Save these — the api_key is shown only once
-api_key = result.api_key
-email = result.email_address       # e.g. "sales-agent-a1b2c3@inkboxmail.com"
-handle = result.agent_handle       # e.g. "sales-agent-a1b2c3"
-org_id = result.organization_id    # provisional org
-```
-
-### Verify (requires the API key from signup)
-
-After the human receives the verification email and shares the 6-digit code:
-
-```python
-verify = Inkbox.verify_signup(api_key, verification_code="483921")
-# verify.claim_status → "agent_claimed"
-```
-
-### Resend Verification
-
-```python
-resend = Inkbox.resend_signup_verification(api_key)
-# 5-minute cooldown between resends
-```
-
-### Check Status
-
-```python
-status = Inkbox.get_signup_status(api_key)
-# status.claim_status      → "agent_unclaimed" or "agent_claimed"
-# status.human_state        → "human_no_account", "human_account_unverified", etc.
-# status.restrictions.max_sends_per_day → 10 (unclaimed) or 500 (claimed)
-# status.restrictions.allowed_recipients → ["alex@example.com"] (unclaimed)
-```
-
-### Using the API key after signup
-
-Once you have the API key, use it like any other Inkbox API key:
-
-```python
-with Inkbox(api_key=api_key) as inkbox:
-    identity = inkbox.get_identity(handle)
-    identity.send_email(
-        to=["alex@example.com"],
-        subject="Hello from your agent!",
-        body_text="I'm all set up.",
-    )
-```
-
-> **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
+Python SDK methods: `Inkbox.signup(...)`, `Inkbox.verify_signup(api_key, ...)`, `Inkbox.resend_signup_verification(api_key)`, `Inkbox.get_signup_status(api_key)`.
 
 ## Identities
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -48,6 +48,72 @@ AgentIdentity (identity-scoped helper)
 
 An identity must have a channel assigned before you can use mail/phone methods. If not assigned, an `InkboxError` is thrown.
 
+## Agent Signup
+
+Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+
+All signup methods are **static methods** on `Inkbox` — no instance required.
+
+### Signup (public, no API key)
+
+```ts
+import { Inkbox } from "@inkbox/sdk";
+
+const result = await Inkbox.signup({
+  humanEmail: "alex@example.com",
+  displayName: "Sales Agent",
+  noteToHuman: "Hey Alex, this is your sales bot signing up!",
+});
+
+// Save these — the apiKey is shown only once
+const apiKey = result.apiKey;
+const email = result.emailAddress;       // e.g. "sales-agent-a1b2c3@inkboxmail.com"
+const handle = result.agentHandle;       // e.g. "sales-agent-a1b2c3"
+const orgId = result.organizationId;     // provisional org
+```
+
+### Verify (requires the API key from signup)
+
+After the human receives the verification email and shares the 6-digit code:
+
+```ts
+const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
+// verify.claimStatus → "agent_claimed"
+```
+
+### Resend Verification
+
+```ts
+const resend = await Inkbox.resendSignupVerification(apiKey);
+// 5-minute cooldown between resends
+```
+
+### Check Status
+
+```ts
+const status = await Inkbox.getSignupStatus(apiKey);
+// status.claimStatus       → "agent_unclaimed" or "agent_claimed"
+// status.humanState         → "human_no_account", "human_account_unverified", etc.
+// status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
+// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
+```
+
+### Using the API key after signup
+
+Once you have the API key, use it like any other Inkbox API key:
+
+```ts
+const inkbox = new Inkbox({ apiKey });
+const identity = await inkbox.getIdentity(handle);
+await identity.sendEmail({
+  to: ["alex@example.com"],
+  subject: "Hello from your agent!",
+  bodyText: "I'm all set up.",
+});
+```
+
+> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
+
 ## Identities
 
 ```typescript

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -35,6 +35,7 @@ Inkbox (org-level client)
 ├── .phoneNumbers           → PhoneNumbersResource
 ├── .texts                  → TextsResource
 ├── .vault                  → VaultResource
+├── .whoami()               → Promise<WhoamiResponse>
 └── .createSigningKey()     → Promise<SigningKey>
 
 AgentIdentity (identity-scoped helper)
@@ -426,6 +427,21 @@ await inkbox.phoneNumbers.update(num.id, {
 const hits = await inkbox.phoneNumbers.searchTranscripts(num.id, { q: "refund", party: "remote", limit: 50 });
 await inkbox.phoneNumbers.release(num.id);
 ```
+
+## Whoami
+
+```typescript
+// Check the authenticated caller's identity
+const info = await inkbox.whoami();
+console.log(info.authType);        // "api_key" or "jwt"
+console.log(info.organizationId);
+
+if (info.authType === "api_key") {
+  console.log(info.keyId, info.label);
+}
+```
+
+Returns `WhoamiApiKeyResponse` (with `keyId`, `label`, `creatorType`, etc.) or `WhoamiJwtResponse` (with `email`, `orgRole`, etc.) — discriminated on `authType`.
 
 ## Webhooks & Signature Verification
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -50,69 +50,11 @@ An identity must have a channel assigned before you can use mail/phone methods. 
 
 ## Agent Signup
 
-Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-All signup methods are **static methods** on `Inkbox` — no instance required.
+> **See:** `skills/agent-signup/SKILL.md`
 
-### Signup (public, no API key)
-
-```ts
-import { Inkbox } from "@inkbox/sdk";
-
-const result = await Inkbox.signup({
-  humanEmail: "alex@example.com",
-  displayName: "Sales Agent",
-  noteToHuman: "Hey Alex, this is your sales bot signing up!",
-});
-
-// Save these — the apiKey is shown only once
-const apiKey = result.apiKey;
-const email = result.emailAddress;       // e.g. "sales-agent-a1b2c3@inkboxmail.com"
-const handle = result.agentHandle;       // e.g. "sales-agent-a1b2c3"
-const orgId = result.organizationId;     // provisional org
-```
-
-### Verify (requires the API key from signup)
-
-After the human receives the verification email and shares the 6-digit code:
-
-```ts
-const verify = await Inkbox.verifySignup(apiKey, { verificationCode: "483921" });
-// verify.claimStatus → "agent_claimed"
-```
-
-### Resend Verification
-
-```ts
-const resend = await Inkbox.resendSignupVerification(apiKey);
-// 5-minute cooldown between resends
-```
-
-### Check Status
-
-```ts
-const status = await Inkbox.getSignupStatus(apiKey);
-// status.claimStatus       → "agent_unclaimed" or "agent_claimed"
-// status.humanState         → "human_no_account", "human_account_unverified", etc.
-// status.restrictions.maxSendsPerDay → 10 (unclaimed) or 500 (claimed)
-// status.restrictions.allowedRecipients → ["alex@example.com"] (unclaimed)
-```
-
-### Using the API key after signup
-
-Once you have the API key, use it like any other Inkbox API key:
-
-```ts
-const inkbox = new Inkbox({ apiKey });
-const identity = await inkbox.getIdentity(handle);
-await identity.sendEmail({
-  to: ["alex@example.com"],
-  subject: "Hello from your agent!",
-  bodyText: "I'm all set up.",
-});
-```
-
-> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval, full capabilities are unlocked.
+TypeScript SDK methods: `Inkbox.signup({...})`, `Inkbox.verifySignup(apiKey, {...})`, `Inkbox.resendSignupVerification(apiKey)`, `Inkbox.getSignupStatus(apiKey)`.
 
 ## Identities
 


### PR DESCRIPTION
## Summary

- Add agent self-signup support to the Python SDK, TypeScript SDK, and CLI — matching the server-side endpoints shipped in inkbox-ai/servers#34
- Python SDK: 4 new classmethods on `Inkbox` (`signup`, `verify_signup`, `resend_signup_verification`, `get_signup_status`) + new `agent_signup` types module
- TypeScript SDK: 4 new static methods on `Inkbox` (`signup`, `verifySignup`, `resendSignupVerification`, `getSignupStatus`) + new `agent_signup` types with Raw/parse pattern
- CLI: new `inkbox signup` command group with `create`, `verify`, `resend-verification`, and `status` subcommands
- Documentation: Agent Signup sections added to all 3 SKILL files, all 4 SDK/CLI READMEs, and the top-level README

## Design decisions

- Signup methods are classmethods/static (not instance methods) because the agent doesn't have an API key until after `signup()` returns one — constructing a full `Inkbox` instance would require an API key that doesn't exist yet
- Post-signup methods (`verify`, `resend`, `status`) are also classmethods/static to keep the bootstrap flow lightweight — no need to spin up 6 HTTP transport pools just to submit a verification code
- `signup create` is the only CLI command that doesn't require `--api-key`
