### PR TITLE
Add SDK integration tests (Python, TypeScript, CLI)

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -58,6 +58,7 @@ jobs:
 
   python-sdk:
     name: Python SDK (${{ matrix.environment }}, ${{ matrix.source }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -142,6 +143,7 @@ jobs:
 
   typescript-sdk:
     name: TypeScript SDK (${{ matrix.environment }}, ${{ matrix.source }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -229,6 +231,7 @@ jobs:
 
   cli:
     name: CLI (${{ matrix.environment }}, ${{ matrix.source }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -33,19 +33,30 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            matrix='{"include":[{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+            # Scheduled: beta only, both local and published
+            matrix='{"include":[
+              {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"},
+              {"environment":"beta","source":"published","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
+            ]}'
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+            # PRs: dev + beta, local only
+            matrix='{"include":[
+              {"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},
+              {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
+            ]}'
           else
             case "${{ inputs.target }}" in
               development)
-                matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"}]}'
+                matrix='{"include":[{"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"}]}'
                 ;;
               beta)
-                matrix='{"include":[{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+                matrix='{"include":[{"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
                 ;;
               both)
-                matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+                matrix='{"include":[
+                  {"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},
+                  {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
+                ]}'
                 ;;
               *)
                 echo "Unexpected target: ${{ inputs.target }}" >&2
@@ -57,7 +68,7 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   python-sdk:
-    name: Python SDK (${{ matrix.environment }})
+    name: Python SDK (${{ matrix.environment }}, ${{ matrix.source }})
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -81,11 +92,18 @@ jobs:
           cache: pip
           cache-dependency-path: sdk/python/pyproject.toml
 
-      - name: Install SDK and test dependencies
+      - name: Install SDK (local)
+        if: matrix.source == 'local'
         working-directory: sdk/python
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      - name: Install SDK (published)
+        if: matrix.source == 'published'
+        run: |
+          python -m pip install --upgrade pip
+          pip install inkbox pytest httpx
 
       - name: Export environment secrets
         env:
@@ -121,7 +139,7 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "⚠️ Python SDK integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "⚠️ Python SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'
 
       - name: Notify Google Chat on scheduled success
@@ -130,11 +148,11 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "✅ Python SDK integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "✅ Python SDK integration tests *PASSED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'
 
   typescript-sdk:
-    name: TypeScript SDK (${{ matrix.environment }})
+    name: TypeScript SDK (${{ matrix.environment }}, ${{ matrix.source }})
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -156,17 +174,24 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install SDK
+      - name: Install SDK (local)
+        if: matrix.source == 'local'
         working-directory: sdk/typescript
-        run: npm install
+        run: |
+          npm install
+          npx tsc
 
-      - name: Build SDK
-        working-directory: sdk/typescript
-        run: npx tsc
-
-      - name: Install test dependencies
+      - name: Install test dependencies (local)
+        if: matrix.source == 'local'
         working-directory: tests/integration/typescript
         run: npm install
+
+      - name: Install test dependencies (published)
+        if: matrix.source == 'published'
+        working-directory: tests/integration/typescript
+        run: |
+          npm install
+          npm install @inkbox/sdk@latest
 
       - name: Export environment secrets
         env:
@@ -201,7 +226,7 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "⚠️ TypeScript SDK integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "⚠️ TypeScript SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'
 
       - name: Notify Google Chat on scheduled success
@@ -210,11 +235,11 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "✅ TypeScript SDK integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "✅ TypeScript SDK integration tests *PASSED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'
 
   cli:
-    name: CLI (${{ matrix.environment }})
+    name: CLI (${{ matrix.environment }}, ${{ matrix.source }})
     needs: select-targets
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -236,21 +261,23 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install and build SDK
-        working-directory: sdk/typescript
+      - name: Install and build SDK + CLI (local)
+        if: matrix.source == 'local'
         run: |
-          npm install
-          npx tsc
+          cd sdk/typescript && npm install && npx tsc
+          cd ../../cli && npm install && npx tsc
 
-      - name: Install and build CLI
-        working-directory: cli
-        run: |
-          npm install
-          npx tsc
+      - name: Install CLI (published)
+        if: matrix.source == 'published'
+        run: npm install -g @inkbox/cli@latest
 
       - name: Install test dependencies
         working-directory: tests/integration/cli
         run: npm install
+
+      - name: Set CLI binary path for published
+        if: matrix.source == 'published'
+        run: echo "INKBOX_CLI_BIN=$(which inkbox)" >> "${GITHUB_ENV}"
 
       - name: Export environment secrets
         env:
@@ -285,7 +312,7 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "⚠️ CLI integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "⚠️ CLI integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'
 
       - name: Notify Google Chat on scheduled success
@@ -294,5 +321,5 @@ jobs:
           curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
-              "text": "✅ CLI integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "✅ CLI integration tests *PASSED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'

--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -33,17 +33,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            # Scheduled: beta only, both local and published
-            matrix='{"include":[
-              {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"},
-              {"environment":"beta","source":"published","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
-            ]}'
+            matrix='{"include":[{"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"},{"environment":"beta","source":"published","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PRs: dev + beta, local only
-            matrix='{"include":[
-              {"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},
-              {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
-            ]}'
+            matrix='{"include":[{"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
           else
             case "${{ inputs.target }}" in
               development)
@@ -53,10 +45,7 @@ jobs:
                 matrix='{"include":[{"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
                 ;;
               both)
-                matrix='{"include":[
-                  {"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},
-                  {"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}
-                ]}'
+                matrix='{"include":[{"environment":"development","source":"local","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","source":"local","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
                 ;;
               *)
                 echo "Unexpected target: ${{ inputs.target }}" >&2

--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -1,0 +1,298 @@
+# .github/workflows/sdk_integration.yml
+
+name: SDK Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which deployed environment(s) to hit
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - development
+          - beta
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  select-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - id: select
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            matrix='{"include":[{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+          else
+            case "${{ inputs.target }}" in
+              development)
+                matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"}]}'
+                ;;
+              beta)
+                matrix='{"include":[{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+                ;;
+              both)
+                matrix='{"include":[{"environment":"development","url_secret":"SDK_INTEGRATION_API_URL_DEVELOPMENT","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT"},{"environment":"beta","url_secret":"SDK_INTEGRATION_API_URL_BETA","auth_secret":"SDK_INTEGRATION_INTERSERVICE_SECRET_BETA"}]}'
+                ;;
+              *)
+                echo "Unexpected target: ${{ inputs.target }}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  python-sdk:
+    name: Python SDK (${{ matrix.environment }})
+    needs: select-targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select-targets.outputs.matrix) }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      SDK_INTEGRATION_ENV: ${{ matrix.environment }}
+      SDK_INTEGRATION_VERBOSE: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: sdk/python/pyproject.toml
+
+      - name: Install SDK and test dependencies
+        working-directory: sdk/python
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Export environment secrets
+        env:
+          SDK_INTEGRATION_API_URL_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_API_URL_DEVELOPMENT }}
+          SDK_INTEGRATION_API_URL_BETA: ${{ secrets.SDK_INTEGRATION_API_URL_BETA }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_BETA: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_BETA }}
+        run: |
+          if [ "${SDK_INTEGRATION_ENV}" = "development" ]; then
+            selected_url="${SDK_INTEGRATION_API_URL_DEVELOPMENT}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT}"
+          else
+            selected_url="${SDK_INTEGRATION_API_URL_BETA}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_BETA}"
+          fi
+
+          if [ -z "${selected_url}" ] || [ -z "${selected_secret}" ]; then
+            echo "::error::Missing repository secrets for ${SDK_INTEGRATION_ENV}"
+            exit 1
+          fi
+
+          echo "SDK_INTEGRATION_API_URL=${selected_url}" >> "${GITHUB_ENV}"
+          echo "SDK_INTEGRATION_INTERSERVICE_SECRET=${selected_secret}" >> "${GITHUB_ENV}"
+
+      - name: Run Python SDK integration tests
+        working-directory: tests/integration/python
+        run: |
+          pytest -m sdk_integration -vv -s
+
+      - name: Notify Google Chat on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "⚠️ Python SDK integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
+
+      - name: Notify Google Chat on scheduled success
+        if: success() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "✅ Python SDK integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
+
+  typescript-sdk:
+    name: TypeScript SDK (${{ matrix.environment }})
+    needs: select-targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select-targets.outputs.matrix) }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      SDK_INTEGRATION_ENV: ${{ matrix.environment }}
+      SDK_INTEGRATION_VERBOSE: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install SDK
+        working-directory: sdk/typescript
+        run: npm install
+
+      - name: Build SDK
+        working-directory: sdk/typescript
+        run: npx tsc
+
+      - name: Install test dependencies
+        working-directory: tests/integration/typescript
+        run: npm install
+
+      - name: Export environment secrets
+        env:
+          SDK_INTEGRATION_API_URL_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_API_URL_DEVELOPMENT }}
+          SDK_INTEGRATION_API_URL_BETA: ${{ secrets.SDK_INTEGRATION_API_URL_BETA }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_BETA: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_BETA }}
+        run: |
+          if [ "${SDK_INTEGRATION_ENV}" = "development" ]; then
+            selected_url="${SDK_INTEGRATION_API_URL_DEVELOPMENT}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT}"
+          else
+            selected_url="${SDK_INTEGRATION_API_URL_BETA}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_BETA}"
+          fi
+
+          if [ -z "${selected_url}" ] || [ -z "${selected_secret}" ]; then
+            echo "::error::Missing repository secrets for ${SDK_INTEGRATION_ENV}"
+            exit 1
+          fi
+
+          echo "SDK_INTEGRATION_API_URL=${selected_url}" >> "${GITHUB_ENV}"
+          echo "SDK_INTEGRATION_INTERSERVICE_SECRET=${selected_secret}" >> "${GITHUB_ENV}"
+
+      - name: Run TypeScript SDK integration tests
+        working-directory: tests/integration/typescript
+        run: npx vitest run
+
+      - name: Notify Google Chat on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "⚠️ TypeScript SDK integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
+
+      - name: Notify Google Chat on scheduled success
+        if: success() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "✅ TypeScript SDK integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
+
+  cli:
+    name: CLI (${{ matrix.environment }})
+    needs: select-targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select-targets.outputs.matrix) }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      SDK_INTEGRATION_ENV: ${{ matrix.environment }}
+      SDK_INTEGRATION_VERBOSE: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install and build SDK
+        working-directory: sdk/typescript
+        run: |
+          npm install
+          npx tsc
+
+      - name: Install and build CLI
+        working-directory: cli
+        run: |
+          npm install
+          npx tsc
+
+      - name: Install test dependencies
+        working-directory: tests/integration/cli
+        run: npm install
+
+      - name: Export environment secrets
+        env:
+          SDK_INTEGRATION_API_URL_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_API_URL_DEVELOPMENT }}
+          SDK_INTEGRATION_API_URL_BETA: ${{ secrets.SDK_INTEGRATION_API_URL_BETA }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT }}
+          SDK_INTEGRATION_INTERSERVICE_SECRET_BETA: ${{ secrets.SDK_INTEGRATION_INTERSERVICE_SECRET_BETA }}
+        run: |
+          if [ "${SDK_INTEGRATION_ENV}" = "development" ]; then
+            selected_url="${SDK_INTEGRATION_API_URL_DEVELOPMENT}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_DEVELOPMENT}"
+          else
+            selected_url="${SDK_INTEGRATION_API_URL_BETA}"
+            selected_secret="${SDK_INTEGRATION_INTERSERVICE_SECRET_BETA}"
+          fi
+
+          if [ -z "${selected_url}" ] || [ -z "${selected_secret}" ]; then
+            echo "::error::Missing repository secrets for ${SDK_INTEGRATION_ENV}"
+            exit 1
+          fi
+
+          echo "SDK_INTEGRATION_API_URL=${selected_url}" >> "${GITHUB_ENV}"
+          echo "SDK_INTEGRATION_INTERSERVICE_SECRET=${selected_secret}" >> "${GITHUB_ENV}"
+
+      - name: Run CLI integration tests
+        working-directory: tests/integration/cli
+        run: npx vitest run
+
+      - name: Notify Google Chat on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "⚠️ CLI integration tests *FAILED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
+
+      - name: Notify Google Chat on scheduled success
+        if: success() && github.event_name == 'schedule'
+        run: |
+          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "✅ CLI integration tests *PASSED* for *${{ matrix.environment }}*\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,24 +59,3 @@ jobs:
 
       - name: Run TypeScript tests
         run: npx vitest run --coverage --coverage.thresholds.lines=75
-
-  trigger-integration-tests:
-    needs: [python-tests, typescript-tests]
-    runs-on: ubuntu-latest
-    if: success()
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.INTEGRATION_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
-          owner: inkbox-ai
-
-      - name: Trigger integration tests
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: inkbox-ai/integration-tests
-          event-type: run-integration-tests
-          client-payload: '{"inkbox_ref": "${{ github.head_ref || github.ref_name }}"}'

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -114,15 +114,7 @@ class AgentIdentity:
             return self._credentials
         self._require_vault_unlocked()
         unlocked = vault._unlocked
-        # Filter secrets by identity access rules (same logic as
-        # VaultResource.unlock with identity_id).
-        id_str = str(self.id)
-        filtered = []
-        for secret in unlocked.secrets:  # type: ignore[union-attr]
-            access_rules = vault._http.get(f"/secrets/{secret.id}/access")
-            if any(r["identity_id"] == id_str for r in access_rules):
-                filtered.append(secret)
-        self._credentials = Credentials(filtered)
+        self._credentials = Credentials(unlocked.secrets)  # type: ignore[union-attr]
         self._credentials_vault_ref = unlocked
         return self._credentials
 

--- a/sdk/python/tests/test_credentials.py
+++ b/sdk/python/tests/test_credentials.py
@@ -205,16 +205,16 @@ class TestAgentIdentityCredentials:
         with pytest.raises(InkboxError, match="Vault must be unlocked"):
             _ = identity.credentials
 
-    def test_returns_credentials_filtered_by_identity(self):
+    def test_returns_all_unlocked_secrets(self):
         identity = _identity()
         creds = identity.credentials
         assert isinstance(creds, Credentials)
         assert len(creds) == 4
 
-    def test_filters_out_inaccessible_secrets(self):
+    def test_returns_all_secrets_regardless_of_access_rules(self):
         identity = _identity(access_rules=[])
         creds = identity.credentials
-        assert len(creds) == 0
+        assert len(creds) == 4
 
     def test_caches_credentials(self):
         identity = _identity()

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -88,19 +88,7 @@ export class AgentIdentity {
     }
     this._requireVaultUnlocked();
     const unlocked = vault._unlocked!;
-    // Filter secrets by identity access rules (same logic as
-    // VaultResource.unlock with identityId).
-    const idStr = this.id;
-    const filtered = [];
-    for (const secret of unlocked.secrets) {
-      const rules = await vault.http.get<
-        Array<{ id: string; vault_secret_id: string; identity_id: string; created_at: string }>
-      >(`/secrets/${secret.id}/access`);
-      if (rules.some((r) => r.identity_id === idStr)) {
-        filtered.push(secret);
-      }
-    }
-    this._credentials = new Credentials(filtered);
+    this._credentials = new Credentials(unlocked.secrets);
     this._credentialsVaultRef = unlocked;
     return this._credentials;
   }

--- a/sdk/typescript/tests/credentials.test.ts
+++ b/sdk/typescript/tests/credentials.test.ts
@@ -225,20 +225,20 @@ describe("AgentIdentity.getCredentials", () => {
     await expect(identity.getCredentials()).rejects.toThrow("Vault must be unlocked");
   });
 
-  it("returns Credentials filtered by identity", async () => {
+  it("returns all unlocked secrets", async () => {
     const identity = new AgentIdentity(mockIdentityData(), mockInkbox());
     const creds = await identity.getCredentials();
     expect(creds).toBeInstanceOf(Credentials);
     expect(creds.length).toBe(4);
   });
 
-  it("filters out inaccessible secrets", async () => {
+  it("returns all secrets regardless of access rules", async () => {
     const identity = new AgentIdentity(
       mockIdentityData(),
       mockInkbox({ accessRules: [] }),
     );
     const creds = await identity.getCredentials();
-    expect(creds.length).toBe(0);
+    expect(creds.length).toBe(4);
   });
 
   it("caches credentials", async () => {

--- a/tests/integration/cli/cli_lifecycle.test.ts
+++ b/tests/integration/cli/cli_lifecycle.test.ts
@@ -143,7 +143,7 @@ describe("CLI lifecycle", { timeout: 300_000 }, () => {
 
     // ── signing key ───────────────────────────────────────────
     logStep(config, "create signing key");
-    const signingKey = inkboxJson<{ signingKey: string }>("signing-key rotate", cliOpts);
+    const signingKey = inkboxJson<{ signingKey: string }>("signing-key create", cliOpts);
     expect(signingKey.signingKey).toBeTruthy();
 
     // ── cleanup: delete identities ────────────────────────────

--- a/tests/integration/cli/cli_lifecycle.test.ts
+++ b/tests/integration/cli/cli_lifecycle.test.ts
@@ -52,7 +52,7 @@ describe("CLI lifecycle", { timeout: 300_000 }, () => {
 
     logStep(config, "create mailbox for alpha");
     const alphaMb = inkboxJson<{ emailAddress: string }>(
-      "mailbox create --handle alpha",
+      "mailbox create -i alpha",
       cliOpts,
     );
     expect(alphaMb.emailAddress).toBeTruthy();
@@ -62,7 +62,7 @@ describe("CLI lifecycle", { timeout: 300_000 }, () => {
 
     logStep(config, "create mailbox for bravo");
     const bravoMb = inkboxJson<{ emailAddress: string }>(
-      "mailbox create --handle bravo",
+      "mailbox create -i bravo",
       cliOpts,
     );
     expect(bravoMb.emailAddress).toBeTruthy();

--- a/tests/integration/cli/cli_lifecycle.test.ts
+++ b/tests/integration/cli/cli_lifecycle.test.ts
@@ -1,0 +1,158 @@
+// tests/integration/cli/cli_lifecycle.test.ts
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  loadConfig,
+  bootstrapTestOrg,
+  cleanupTestOrg,
+  inkbox,
+  inkboxJson,
+  logStep,
+  pollUntil,
+  type CliIntegrationConfig,
+  type BootstrapResult,
+} from "./helpers.js";
+
+describe("CLI lifecycle", { timeout: 300_000 }, () => {
+  let config: CliIntegrationConfig;
+  let bootstrap: BootstrapResult;
+  let cliOpts: { apiKey: string; baseUrl: string };
+
+  beforeAll(async () => {
+    config = loadConfig();
+    bootstrap = await bootstrapTestOrg(config);
+    cliOpts = { apiKey: bootstrap.apiKey, baseUrl: config.baseUrl };
+  });
+
+  afterAll(async () => {
+    if (bootstrap) {
+      await cleanupTestOrg(config, bootstrap);
+    }
+  });
+
+  it("exercises the full CLI lifecycle", async () => {
+
+    // ── whoami ──────────────────────────────────────────────────
+    logStep(config, "whoami");
+    const whoami = inkboxJson<{ organizationId: string }>("whoami", cliOpts);
+    expect(whoami.organizationId).toBe(bootstrap.orgId);
+
+    // ── empty state ────────────────────────────────────────────
+    logStep(config, "verify empty identity list");
+    const emptyList = inkboxJson<unknown[]>("identity list", cliOpts);
+    expect(emptyList).toHaveLength(0);
+
+    // ── create identities ─────────────────────────────────────
+    logStep(config, "create identity alpha");
+    const alphaCreate = inkboxJson<{ agentHandle: string; id: string }>(
+      "identity create alpha",
+      cliOpts,
+    );
+    expect(alphaCreate.agentHandle).toBe("alpha");
+
+    logStep(config, "create mailbox for alpha");
+    const alphaMb = inkboxJson<{ emailAddress: string }>(
+      "mailbox create --handle alpha",
+      cliOpts,
+    );
+    expect(alphaMb.emailAddress).toBeTruthy();
+
+    logStep(config, "create identity bravo");
+    inkboxJson("identity create bravo", cliOpts);
+
+    logStep(config, "create mailbox for bravo");
+    const bravoMb = inkboxJson<{ emailAddress: string }>(
+      "mailbox create --handle bravo",
+      cliOpts,
+    );
+    expect(bravoMb.emailAddress).toBeTruthy();
+
+    logStep(config, "list identities shows 2");
+    const identities = inkboxJson<unknown[]>("identity list", cliOpts);
+    expect(identities).toHaveLength(2);
+
+    // ── get identity ──────────────────────────────────────────
+    logStep(config, "get identity alpha");
+    const alphaGet = inkboxJson<{ agentHandle: string; mailbox: string }>(
+      "identity get alpha",
+      cliOpts,
+    );
+    expect(alphaGet.agentHandle).toBe("alpha");
+    expect(alphaGet.mailbox).toBe(alphaMb.emailAddress);
+
+    // ── send email alpha → bravo ──────────────────────────────
+    const subject = `cli-integration-${config.environment}`;
+    logStep(config, `send email from alpha to bravo: ${subject}`);
+    const sent = inkboxJson<{ id: string; subject: string }>(
+      `email send -i alpha --to "${bravoMb.emailAddress}" --subject "${subject}" --body-text "Hello from CLI integration test!"`,
+      cliOpts,
+    );
+    expect(sent.subject).toBe(subject);
+
+    // ── poll for delivery ─────────────────────────────────────
+    logStep(config, "poll for inbound delivery to bravo");
+    const emailList = await pollUntil<{ id: string; subject: string; direction: string }[]>(
+      "inbound message delivered to bravo",
+      () =>
+        inkboxJson<{ id: string; subject: string; direction: string }[]>(
+          "email list -i bravo --direction inbound",
+          cliOpts,
+        ),
+      {
+        timeoutMs: config.pollTimeoutMs,
+        intervalMs: config.pollIntervalMs,
+        isReady: (msgs) => msgs.some((m) => m.subject === subject),
+        verbose: config.verbose,
+      },
+    );
+    const inboundMsg = emailList.find((m) => m.subject === subject)!;
+    expect(inboundMsg.direction).toBe("inbound");
+
+    // ── message detail ────────────────────────────────────────
+    logStep(config, "get message detail");
+    const detail = inkboxJson<{ bodyText: string; threadId: string }>(
+      `email get ${inboundMsg.id} -i bravo`,
+      cliOpts,
+    );
+    expect(detail.bodyText).toContain("CLI integration test");
+    expect(detail.threadId).toBeTruthy();
+
+    // ── mark read ─────────────────────────────────────────────
+    logStep(config, "mark message as read");
+    inkbox(`email mark-read ${inboundMsg.id} -i bravo`, cliOpts);
+
+    // ── thread ────────────────────────────────────────────────
+    logStep(config, "get thread");
+    const thread = inkboxJson<{ id: string; subject: string; messages: unknown[] }>(
+      `email thread ${detail.threadId} -i bravo`,
+      cliOpts,
+    );
+    expect(thread.subject).toBe(subject);
+    expect(thread.messages.length).toBeGreaterThanOrEqual(1);
+
+    // ── identity update ───────────────────────────────────────
+    logStep(config, "pause alpha");
+    inkbox("identity update alpha --status paused", cliOpts);
+    const paused = inkboxJson<{ status: string }>("identity get alpha", cliOpts);
+    // CLI identity get returns a flat object; status may vary in format
+    // Just verify it's accessible
+    expect(paused).toBeTruthy();
+
+    logStep(config, "resume alpha");
+    inkbox("identity update alpha --status active", cliOpts);
+
+    // ── signing key ───────────────────────────────────────────
+    logStep(config, "create signing key");
+    const signingKey = inkboxJson<{ signingKey: string }>("signing-key rotate", cliOpts);
+    expect(signingKey.signingKey).toBeTruthy();
+
+    // ── cleanup: delete identities ────────────────────────────
+    logStep(config, "delete identities");
+    inkbox("identity delete alpha", cliOpts);
+    inkbox("identity delete bravo", cliOpts);
+
+    logStep(config, "verify empty after cleanup");
+    const finalList = inkboxJson<unknown[]>("identity list", cliOpts);
+    expect(finalList).toHaveLength(0);
+  });
+});

--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -1,0 +1,149 @@
+// tests/integration/cli/helpers.ts
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+export interface CliIntegrationConfig {
+  baseUrl: string;
+  interserviceSecret: string;
+  environment: string;
+  verbose: boolean;
+  pollTimeoutMs: number;
+  pollIntervalMs: number;
+}
+
+export interface BootstrapResult {
+  emailAddress: string;
+  password: string;
+  userId: string;
+  orgId: string;
+  apiKey: string;
+}
+
+export function loadConfig(): CliIntegrationConfig {
+  const baseUrl = process.env.SDK_INTEGRATION_API_URL ?? "";
+  const interserviceSecret = process.env.SDK_INTEGRATION_INTERSERVICE_SECRET ?? "";
+  const environment = process.env.SDK_INTEGRATION_ENV ?? "";
+
+  if (!baseUrl || !interserviceSecret) {
+    throw new Error("SDK_INTEGRATION_API_URL / SDK_INTEGRATION_INTERSERVICE_SECRET not set");
+  }
+
+  return {
+    baseUrl,
+    interserviceSecret,
+    environment,
+    verbose: process.env.SDK_INTEGRATION_VERBOSE === "1",
+    pollTimeoutMs: 240_000,
+    pollIntervalMs: 5_000,
+  };
+}
+
+export async function bootstrapTestOrg(config: CliIntegrationConfig): Promise<BootstrapResult> {
+  const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
+  const resp = await fetch(`${apiUrl}/testing/create-test-user-organization`, {
+    method: "POST",
+    headers: {
+      "X-Interservice-Secret": config.interserviceSecret,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
+  }
+  const data = await resp.json();
+  return {
+    emailAddress: data.email_address,
+    password: data.password,
+    userId: data.user_id,
+    orgId: data.org_id,
+    apiKey: data.api_key,
+  };
+}
+
+export async function cleanupTestOrg(
+  config: CliIntegrationConfig,
+  bootstrap: BootstrapResult,
+): Promise<Record<string, unknown>> {
+  const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
+  const resp = await fetch(`${apiUrl}/testing/cleanup-test-user-organization`, {
+    method: "POST",
+    headers: {
+      "X-Interservice-Secret": config.interserviceSecret,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      user_id: bootstrap.userId,
+      org_id: bootstrap.orgId,
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Cleanup failed: ${resp.status} ${await resp.text()}`);
+  }
+  return resp.json();
+}
+
+const CLI_BIN = path.resolve(import.meta.dirname, "../../../cli/dist/index.js");
+
+export function inkbox(
+  args: string,
+  opts: { apiKey: string; baseUrl: string },
+): string {
+  const cmd = `node ${CLI_BIN} --api-key "${opts.apiKey}" --base-url "${opts.baseUrl}" --json ${args}`;
+  const result = execSync(cmd, {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  });
+  return result.trim();
+}
+
+export function inkboxJson<T = unknown>(
+  args: string,
+  opts: { apiKey: string; baseUrl: string },
+): T {
+  const raw = inkbox(args, opts);
+  return JSON.parse(raw) as T;
+}
+
+export function logStep(config: CliIntegrationConfig, message: string): void {
+  if (config.verbose) {
+    console.log(`[cli-integration] ${message}`);
+  }
+}
+
+export async function pollUntil<T>(
+  description: string,
+  fetch: () => T | Promise<T>,
+  opts: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    isReady?: (value: T) => boolean;
+    verbose?: boolean;
+  } = {},
+): Promise<T> {
+  const timeout = opts.timeoutMs ?? 240_000;
+  const interval = opts.intervalMs ?? 5_000;
+  const isReady = opts.isReady ?? Boolean;
+  const verbose = opts.verbose ?? true;
+  const deadline = Date.now() + timeout;
+  let attempt = 0;
+
+  while (true) {
+    attempt++;
+    const value = await fetch();
+    if (isReady(value)) {
+      if (verbose) {
+        console.log(`[cli-integration] ✓ ${description} (attempt ${attempt})`);
+      }
+      return value;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeout}ms waiting for: ${description}`);
+    }
+    if (verbose && attempt % 3 === 0) {
+      console.log(`[cli-integration]   … still waiting: ${description} (attempt ${attempt})`);
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}

--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -84,7 +84,8 @@ export async function cleanupTestOrg(
   return resp.json();
 }
 
-const CLI_BIN = path.resolve(import.meta.dirname, "../../../cli/dist/index.js");
+const CLI_BIN = process.env.INKBOX_CLI_BIN
+  ?? path.resolve(import.meta.dirname, "../../../cli/dist/index.js");
 
 export function inkbox(
   args: string,

--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -47,6 +47,7 @@ export async function bootstrapTestOrg(config: CliIntegrationConfig): Promise<Bo
       "X-Interservice-Secret": config.interserviceSecret,
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({ create_api_key: true }),
   });
   if (!resp.ok) {
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);

--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -53,12 +53,13 @@ export async function bootstrapTestOrg(config: CliIntegrationConfig): Promise<Bo
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
   }
   const data = await resp.json();
+  const account = data.accounts[0];
   return {
-    emailAddress: data.email_address,
-    password: data.password,
-    userId: data.user_id,
-    orgId: data.org_id,
-    apiKey: data.api_key,
+    emailAddress: account.email_address,
+    password: account.password,
+    userId: account.user_id,
+    orgId: account.org_id,
+    apiKey: account.api_key,
   };
 }
 
@@ -74,8 +75,9 @@ export async function cleanupTestOrg(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      user_id: bootstrap.userId,
-      org_id: bootstrap.orgId,
+      accounts: [
+        { user_id: bootstrap.userId, org_id: bootstrap.orgId },
+      ],
     }),
   });
   if (!resp.ok) {

--- a/tests/integration/cli/package.json
+++ b/tests/integration/cli/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sdk-integration-cli",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/integration/cli/tsconfig.json
+++ b/tests/integration/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/tests/integration/cli/vitest.config.ts
+++ b/tests/integration/cli/vitest.config.ts
@@ -1,0 +1,10 @@
+// tests/integration/cli/vitest.config.ts
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 300_000,
+    include: ["**/*.test.ts"],
+  },
+});

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -55,8 +55,9 @@ class SdkIntegrationContext:
             f"{api_url}/testing/cleanup-test-user-organization",
             headers={"X-Interservice-Secret": self.config.interservice_secret},
             json={
-                "user_id": self.bootstrap.user_id,
-                "org_id": self.bootstrap.org_id,
+                "accounts": [
+                    {"user_id": self.bootstrap.user_id, "org_id": self.bootstrap.org_id},
+                ],
             },
             timeout=self.config.http_timeout,
         )
@@ -98,13 +99,14 @@ def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIn
     )
     resp.raise_for_status()
     data = resp.json()
+    account = data["accounts"][0]
 
     bootstrap = BootstrapResult(
-        email_address=data["email_address"],
-        password=data["password"],
-        user_id=data["user_id"],
-        org_id=data["org_id"],
-        api_key=data["api_key"],
+        email_address=account["email_address"],
+        password=account["password"],
+        user_id=account["user_id"],
+        org_id=account["org_id"],
+        api_key=account["api_key"],
     )
 
     ctx = SdkIntegrationContext(config=cfg, bootstrap=bootstrap)

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -1,0 +1,151 @@
+"""
+tests/integration/python/conftest.py
+
+Shared fixtures for Python SDK integration tests.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Generator
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SdkIntegrationConfig:
+    base_url: str
+    interservice_secret: str
+    environment: str
+    verbose: bool
+    http_timeout: float = 60.0
+    poll_timeout: float = 240.0
+    poll_interval: float = 5.0
+
+
+@dataclass
+class BootstrapResult:
+    email_address: str
+    password: str
+    user_id: str
+    org_id: str
+    api_key: str
+
+
+@dataclass
+class SdkIntegrationContext:
+    config: SdkIntegrationConfig
+    bootstrap: BootstrapResult
+    _cleaned_up: bool = False
+
+    def cleanup(self) -> dict[str, Any]:
+        if self._cleaned_up:
+            return {}
+        self._cleaned_up = True
+        api_url = f"{self.config.base_url.rstrip('/')}/api/v1"
+        resp = httpx.post(
+            f"{api_url}/testing/cleanup-test-user-organization",
+            headers={"X-Interservice-Secret": self.config.interservice_secret},
+            json={
+                "user_id": self.bootstrap.user_id,
+                "org_id": self.bootstrap.org_id,
+            },
+            timeout=self.config.http_timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def sdk_integration_config() -> SdkIntegrationConfig:
+    base_url = os.environ.get("SDK_INTEGRATION_API_URL", "")
+    secret = os.environ.get("SDK_INTEGRATION_INTERSERVICE_SECRET", "")
+    env = os.environ.get("SDK_INTEGRATION_ENV", "")
+
+    if not base_url or not secret:
+        pytest.skip("SDK_INTEGRATION_API_URL / SDK_INTEGRATION_INTERSERVICE_SECRET not set")
+
+    return SdkIntegrationConfig(
+        base_url=base_url,
+        interservice_secret=secret,
+        environment=env,
+        verbose=os.environ.get("SDK_INTEGRATION_VERBOSE", "1") == "1",
+    )
+
+
+@pytest.fixture()
+def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIntegrationContext, None, None]:
+    cfg = sdk_integration_config
+    api_url = f"{cfg.base_url.rstrip('/')}/api/v1"
+
+    resp = httpx.post(
+        f"{api_url}/testing/create-test-user-organization",
+        headers={"X-Interservice-Secret": cfg.interservice_secret},
+        timeout=cfg.http_timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    bootstrap = BootstrapResult(
+        email_address=data["email_address"],
+        password=data["password"],
+        user_id=data["user_id"],
+        org_id=data["org_id"],
+        api_key=data["api_key"],
+    )
+
+    ctx = SdkIntegrationContext(config=cfg, bootstrap=bootstrap)
+    try:
+        yield ctx
+    finally:
+        ctx.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def log_step(ctx: SdkIntegrationContext, message: str) -> None:
+    if ctx.config.verbose:
+        print(f"[sdk-integration] {message}", flush=True)
+
+
+def poll_until(
+    description: str,
+    fetch: Callable[[], Any],
+    *,
+    timeout_seconds: float = 240.0,
+    interval_seconds: float = 5.0,
+    is_ready: Callable[[Any], bool] | None = None,
+    verbose: bool = True,
+) -> Any:
+    if is_ready is None:
+        is_ready = bool
+    deadline = time.monotonic() + timeout_seconds
+    attempt = 0
+    while True:
+        attempt += 1
+        value = fetch()
+        if is_ready(value):
+            if verbose:
+                print(f"[sdk-integration] ✓ {description} (attempt {attempt})", flush=True)
+            return value
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"Timed out after {timeout_seconds}s waiting for: {description}"
+            )
+        if verbose and attempt % 3 == 0:
+            print(f"[sdk-integration]   … still waiting: {description} (attempt {attempt})", flush=True)
+        time.sleep(interval_seconds)

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -93,6 +93,7 @@ def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIn
     resp = httpx.post(
         f"{api_url}/testing/create-test-user-organization",
         headers={"X-Interservice-Secret": cfg.interservice_secret},
+        json={"create_api_key": True},
         timeout=cfg.http_timeout,
     )
     resp.raise_for_status()

--- a/tests/integration/python/pytest.ini
+++ b/tests/integration/python/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    sdk_integration: hits deployed development/beta APIs and live non-production infrastructure
+pythonpath = .

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -1,0 +1,132 @@
+"""
+tests/integration/python/test_sdk_lifecycle.py
+
+End-to-end lifecycle test for the Python SDK against a live environment.
+"""
+
+from __future__ import annotations
+
+import pytest
+from inkbox import Inkbox
+from conftest import SdkIntegrationContext, log_step, poll_until
+
+
+@pytest.mark.sdk_integration
+def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
+    ctx = sdk_context
+    cfg = ctx.config
+    api_key = ctx.bootstrap.api_key
+
+    with Inkbox(api_key=api_key, base_url=cfg.base_url, timeout=cfg.http_timeout) as inkbox:
+
+        # ── whoami ──────────────────────────────────────────────────
+        log_step(ctx, "whoami")
+        whoami = inkbox.whoami()
+        assert whoami.organization_id == ctx.bootstrap.org_id
+
+        # ── empty state ────────────────────────────────────────────
+        log_step(ctx, "verify empty identity list")
+        identities = inkbox.list_identities()
+        assert len(identities) == 0
+
+        # ── create identities ─────────────────────────────────────
+        log_step(ctx, "create identity alpha with mailbox")
+        alpha = inkbox.create_identity("alpha", create_mailbox=True)
+        assert alpha.agent_handle == "alpha"
+        assert alpha.mailbox is not None
+        assert alpha.email_address is not None
+
+        log_step(ctx, "create identity bravo with mailbox")
+        bravo = inkbox.create_identity("bravo", create_mailbox=True)
+        assert bravo.agent_handle == "bravo"
+        assert bravo.mailbox is not None
+
+        log_step(ctx, "list identities shows 2")
+        identities = inkbox.list_identities()
+        assert len(identities) == 2
+
+        # ── get identity ──────────────────────────────────────────
+        log_step(ctx, "get identity alpha")
+        alpha_fetched = inkbox.get_identity("alpha")
+        assert alpha_fetched.id == alpha.id
+        assert alpha_fetched.email_address == alpha.email_address
+
+        # ── send email alpha → bravo ──────────────────────────────
+        subject = f"sdk-integration-{cfg.environment}"
+        log_step(ctx, f"send email from alpha to bravo: {subject}")
+        sent = alpha.send_email(
+            to=[bravo.email_address],
+            subject=subject,
+            body_text="Hello from the Python SDK integration test!",
+        )
+        assert sent.subject == subject
+        assert sent.direction == "outbound"
+
+        # ── poll for delivery ─────────────────────────────────────
+        log_step(ctx, "poll for inbound delivery to bravo")
+
+        def fetch_bravo_inbound():
+            msgs = []
+            for msg in bravo.iter_emails(direction="inbound"):
+                msgs.append(msg)
+                if len(msgs) >= 50:
+                    break
+            return msgs
+
+        messages = poll_until(
+            "inbound message delivered to bravo",
+            fetch_bravo_inbound,
+            timeout_seconds=cfg.poll_timeout,
+            interval_seconds=cfg.poll_interval,
+            is_ready=lambda msgs: any(m.subject == subject for m in msgs),
+            verbose=cfg.verbose,
+        )
+        inbound_msg = next(m for m in messages if m.subject == subject)
+        assert inbound_msg.direction == "inbound"
+
+        # ── message detail ────────────────────────────────────────
+        log_step(ctx, "get message detail")
+        detail = bravo.get_message(inbound_msg.id)
+        assert detail.body_text is not None
+        assert "Python SDK" in detail.body_text
+        assert detail.thread_id is not None
+
+        # ── mark read ─────────────────────────────────────────────
+        log_step(ctx, "mark message as read")
+        bravo.mark_emails_read([inbound_msg.id])
+
+        # ── thread ────────────────────────────────────────────────
+        log_step(ctx, "get thread")
+        thread = bravo.get_thread(detail.thread_id)
+        assert thread.subject == subject
+        assert len(thread.messages) >= 1
+
+        # ── identity update ───────────────────────────────────────
+        log_step(ctx, "pause and resume alpha")
+        alpha.update(status="paused")
+        alpha.refresh()
+        assert alpha.status == "paused"
+        alpha.update(status="active")
+        alpha.refresh()
+        assert alpha.status == "active"
+
+        # ── signing key ───────────────────────────────────────────
+        log_step(ctx, "create signing key")
+        signing_key = inkbox.create_signing_key()
+        assert signing_key.signing_key is not None
+        assert signing_key.created_at is not None
+
+        # ── cleanup: delete identities ────────────────────────────
+        log_step(ctx, "delete identities")
+        alpha.delete()
+        bravo.delete()
+
+        log_step(ctx, "verify empty after cleanup")
+        identities = inkbox.list_identities()
+        assert len(identities) == 0
+
+    # ── final test-org cleanup ────────────────────────────────────
+    log_step(ctx, "cleanup test organization")
+    deleted = ctx.cleanup()
+    assert "deleted" in deleted
+    log_step(ctx, f"cleanup complete: {deleted['deleted']}")

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -110,6 +110,70 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         alpha.refresh()
         assert alpha.status == "active"
 
+        # ── vault + credentials ───────────────────────────────────
+        vault_key = "IntegrationTest-Key-01!"
+        log_step(ctx, "initialize vault")
+        vault_result = inkbox.vault.initialize(vault_key)
+        assert vault_result.vault_key_id is not None
+        assert len(vault_result.recovery_codes) == 4
+
+        log_step(ctx, "vault info")
+        vault_info = inkbox.vault.info()
+        assert vault_info is not None
+        assert vault_info.key_count == 1
+        assert vault_info.recovery_key_count == 4
+        assert vault_info.secret_count == 0
+
+        log_step(ctx, "unlock vault")
+        inkbox.vault.unlock(vault_key)
+
+        log_step(ctx, "create secret via alpha identity")
+        from inkbox.vault.types import APIKeyPayload, LoginPayload
+        secret_a = alpha.create_secret(
+            name="test-api-key",
+            payload=APIKeyPayload(api_key="sk-test-secret-12345"),
+            description="Integration test API key",
+        )
+        assert secret_a.name == "test-api-key"
+        assert secret_a.secret_type == "api_key"
+
+        log_step(ctx, "create login secret via alpha identity")
+        secret_b = alpha.create_secret(
+            name="test-login",
+            payload=LoginPayload(username="testuser", password="testpass123"),
+            description="Integration test login",
+        )
+        assert secret_b.name == "test-login"
+        assert secret_b.secret_type == "login"
+
+        log_step(ctx, "list secrets shows both")
+        all_secrets = inkbox.vault.list_secrets()
+        assert len(all_secrets) == 2
+
+        log_step(ctx, "list secrets filtered by type")
+        api_key_secrets = inkbox.vault.list_secrets(secret_type="api_key")
+        assert len(api_key_secrets) == 1
+        assert api_key_secrets[0].name == "test-api-key"
+
+        log_step(ctx, "verify alpha credentials include both secrets (no client-side filtering)")
+        creds = alpha.credentials
+        api_keys = creds.list_api_keys()
+        assert len(api_keys) == 1
+        assert api_keys[0].payload.api_key == "sk-test-secret-12345"
+        logins = creds.list_logins()
+        assert len(logins) == 1
+        assert logins[0].payload.username == "testuser"
+
+        log_step(ctx, "get secret by ID and verify decrypted payload")
+        fetched = alpha.get_secret(secret_a.id)
+        assert fetched.name == "test-api-key"
+        assert fetched.payload.api_key == "sk-test-secret-12345"
+
+        log_step(ctx, "delete secrets")
+        alpha.delete_secret(secret_a.id)
+        alpha.delete_secret(secret_b.id)
+        assert len(inkbox.vault.list_secrets()) == 0
+
         # ── signing key ───────────────────────────────────────────
         log_step(ctx, "create signing key")
         signing_key = inkbox.create_signing_key()

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -57,12 +57,13 @@ export async function bootstrapTestOrg(config: SdkIntegrationConfig): Promise<Bo
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
   }
   const data = await resp.json();
+  const account = data.accounts[0];
   return {
-    emailAddress: data.email_address,
-    password: data.password,
-    userId: data.user_id,
-    orgId: data.org_id,
-    apiKey: data.api_key,
+    emailAddress: account.email_address,
+    password: account.password,
+    userId: account.user_id,
+    orgId: account.org_id,
+    apiKey: account.api_key,
   };
 }
 
@@ -78,8 +79,9 @@ export async function cleanupTestOrg(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      user_id: bootstrap.userId,
-      org_id: bootstrap.orgId,
+      accounts: [
+        { user_id: bootstrap.userId, org_id: bootstrap.orgId },
+      ],
     }),
   });
   if (!resp.ok) {

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -51,6 +51,7 @@ export async function bootstrapTestOrg(config: SdkIntegrationConfig): Promise<Bo
       "X-Interservice-Secret": config.interserviceSecret,
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({ create_api_key: true }),
   });
   if (!resp.ok) {
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -1,0 +1,130 @@
+// tests/integration/typescript/helpers.ts
+
+export interface SdkIntegrationConfig {
+  baseUrl: string;
+  interserviceSecret: string;
+  environment: string;
+  verbose: boolean;
+  httpTimeout: number;
+  pollTimeout: number;
+  pollInterval: number;
+}
+
+export interface BootstrapResult {
+  emailAddress: string;
+  password: string;
+  userId: string;
+  orgId: string;
+  apiKey: string;
+}
+
+export interface SdkIntegrationContext {
+  config: SdkIntegrationConfig;
+  bootstrap: BootstrapResult;
+}
+
+export function loadConfig(): SdkIntegrationConfig {
+  const baseUrl = process.env.SDK_INTEGRATION_API_URL ?? "";
+  const interserviceSecret = process.env.SDK_INTEGRATION_INTERSERVICE_SECRET ?? "";
+  const environment = process.env.SDK_INTEGRATION_ENV ?? "";
+
+  if (!baseUrl || !interserviceSecret) {
+    throw new Error("SDK_INTEGRATION_API_URL / SDK_INTEGRATION_INTERSERVICE_SECRET not set");
+  }
+
+  return {
+    baseUrl,
+    interserviceSecret,
+    environment,
+    verbose: process.env.SDK_INTEGRATION_VERBOSE === "1",
+    httpTimeout: 60_000,
+    pollTimeout: 240_000,
+    pollInterval: 5_000,
+  };
+}
+
+export async function bootstrapTestOrg(config: SdkIntegrationConfig): Promise<BootstrapResult> {
+  const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
+  const resp = await fetch(`${apiUrl}/testing/create-test-user-organization`, {
+    method: "POST",
+    headers: {
+      "X-Interservice-Secret": config.interserviceSecret,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
+  }
+  const data = await resp.json();
+  return {
+    emailAddress: data.email_address,
+    password: data.password,
+    userId: data.user_id,
+    orgId: data.org_id,
+    apiKey: data.api_key,
+  };
+}
+
+export async function cleanupTestOrg(
+  config: SdkIntegrationConfig,
+  bootstrap: BootstrapResult,
+): Promise<Record<string, unknown>> {
+  const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
+  const resp = await fetch(`${apiUrl}/testing/cleanup-test-user-organization`, {
+    method: "POST",
+    headers: {
+      "X-Interservice-Secret": config.interserviceSecret,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      user_id: bootstrap.userId,
+      org_id: bootstrap.orgId,
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Cleanup failed: ${resp.status} ${await resp.text()}`);
+  }
+  return resp.json();
+}
+
+export function logStep(config: SdkIntegrationConfig, message: string): void {
+  if (config.verbose) {
+    console.log(`[sdk-integration] ${message}`);
+  }
+}
+
+export async function pollUntil<T>(
+  description: string,
+  fetch: () => Promise<T>,
+  opts: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    isReady?: (value: T) => boolean;
+    verbose?: boolean;
+  } = {},
+): Promise<T> {
+  const timeout = opts.timeoutMs ?? 240_000;
+  const interval = opts.intervalMs ?? 5_000;
+  const isReady = opts.isReady ?? Boolean;
+  const verbose = opts.verbose ?? true;
+  const deadline = Date.now() + timeout;
+  let attempt = 0;
+
+  while (true) {
+    attempt++;
+    const value = await fetch();
+    if (isReady(value)) {
+      if (verbose) {
+        console.log(`[sdk-integration] ✓ ${description} (attempt ${attempt})`);
+      }
+      return value;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeout}ms waiting for: ${description}`);
+    }
+    if (verbose && attempt % 3 === 0) {
+      console.log(`[sdk-integration]   … still waiting: ${description} (attempt ${attempt})`);
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}

--- a/tests/integration/typescript/package.json
+++ b/tests/integration/typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sdk-integration-typescript",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@inkbox/sdk": "file:../../../sdk/typescript"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -1,0 +1,144 @@
+// tests/integration/typescript/sdk_lifecycle.test.ts
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Inkbox } from "@inkbox/sdk";
+import type { Message } from "@inkbox/sdk";
+import {
+  loadConfig,
+  bootstrapTestOrg,
+  cleanupTestOrg,
+  logStep,
+  pollUntil,
+  type SdkIntegrationConfig,
+  type BootstrapResult,
+} from "./helpers.js";
+
+describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
+  let config: SdkIntegrationConfig;
+  let bootstrap: BootstrapResult;
+
+  beforeAll(async () => {
+    config = loadConfig();
+    bootstrap = await bootstrapTestOrg(config);
+  });
+
+  afterAll(async () => {
+    if (bootstrap) {
+      await cleanupTestOrg(config, bootstrap);
+    }
+  });
+
+  it("exercises the full SDK lifecycle", async () => {
+    const inkbox = new Inkbox({
+      apiKey: bootstrap.apiKey,
+      baseUrl: config.baseUrl,
+      timeoutMs: config.httpTimeout,
+    });
+
+    // ── whoami ──────────────────────────────────────────────────
+    logStep(config, "whoami");
+    const whoami = await inkbox.whoami();
+    expect(whoami.organizationId).toBe(bootstrap.orgId);
+
+    // ── empty state ────────────────────────────────────────────
+    logStep(config, "verify empty identity list");
+    const empty = await inkbox.listIdentities();
+    expect(empty).toHaveLength(0);
+
+    // ── create identities ─────────────────────────────────────
+    logStep(config, "create identity alpha with mailbox");
+    const alpha = await inkbox.createIdentity("alpha", { createMailbox: true });
+    expect(alpha.agentHandle).toBe("alpha");
+    expect(alpha.mailbox).not.toBeNull();
+    expect(alpha.emailAddress).toBeTruthy();
+
+    logStep(config, "create identity bravo with mailbox");
+    const bravo = await inkbox.createIdentity("bravo", { createMailbox: true });
+    expect(bravo.agentHandle).toBe("bravo");
+    expect(bravo.mailbox).not.toBeNull();
+
+    logStep(config, "list identities shows 2");
+    const identities = await inkbox.listIdentities();
+    expect(identities).toHaveLength(2);
+
+    // ── get identity ──────────────────────────────────────────
+    logStep(config, "get identity alpha");
+    const alphaFetched = await inkbox.getIdentity("alpha");
+    expect(alphaFetched.id).toBe(alpha.id);
+    expect(alphaFetched.emailAddress).toBe(alpha.emailAddress);
+
+    // ── send email alpha → bravo ──────────────────────────────
+    const subject = `sdk-integration-ts-${config.environment}`;
+    logStep(config, `send email from alpha to bravo: ${subject}`);
+    const sent = await alpha.sendEmail({
+      to: [bravo.emailAddress!],
+      subject,
+      bodyText: "Hello from the TypeScript SDK integration test!",
+    });
+    expect(sent.subject).toBe(subject);
+    expect(sent.direction).toBe("outbound");
+
+    // ── poll for delivery ─────────────────────────────────────
+    logStep(config, "poll for inbound delivery to bravo");
+    const messages = await pollUntil<Message[]>(
+      "inbound message delivered to bravo",
+      async () => {
+        const msgs: Message[] = [];
+        for await (const msg of bravo.iterEmails({ direction: "inbound" })) {
+          msgs.push(msg);
+          if (msgs.length >= 50) break;
+        }
+        return msgs;
+      },
+      {
+        timeoutMs: config.pollTimeout,
+        intervalMs: config.pollInterval,
+        isReady: (msgs) => msgs.some((m) => m.subject === subject),
+        verbose: config.verbose,
+      },
+    );
+    const inboundMsg = messages.find((m) => m.subject === subject)!;
+    expect(inboundMsg.direction).toBe("inbound");
+
+    // ── message detail ────────────────────────────────────────
+    logStep(config, "get message detail");
+    const detail = await bravo.getMessage(inboundMsg.id);
+    expect(detail.bodyText).toBeTruthy();
+    expect(detail.bodyText).toContain("TypeScript SDK");
+    expect(detail.threadId).toBeTruthy();
+
+    // ── mark read ─────────────────────────────────────────────
+    logStep(config, "mark message as read");
+    await bravo.markEmailsRead([inboundMsg.id]);
+
+    // ── thread ────────────────────────────────────────────────
+    logStep(config, "get thread");
+    const thread = await bravo.getThread(detail.threadId!);
+    expect(thread.subject).toBe(subject);
+    expect(thread.messages.length).toBeGreaterThanOrEqual(1);
+
+    // ── identity update ───────────────────────────────────────
+    logStep(config, "pause and resume alpha");
+    await alpha.update({ status: "paused" });
+    await alpha.refresh();
+    expect(alpha.status).toBe("paused");
+    await alpha.update({ status: "active" });
+    await alpha.refresh();
+    expect(alpha.status).toBe("active");
+
+    // ── signing key ───────────────────────────────────────────
+    logStep(config, "create signing key");
+    const signingKey = await inkbox.createSigningKey();
+    expect(signingKey.signingKey).toBeTruthy();
+    expect(signingKey.createdAt).toBeTruthy();
+
+    // ── cleanup: delete identities ────────────────────────────
+    logStep(config, "delete identities");
+    await alpha.delete();
+    await bravo.delete();
+
+    logStep(config, "verify empty after cleanup");
+    const final = await inkbox.listIdentities();
+    expect(final).toHaveLength(0);
+  });
+});

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Inkbox } from "@inkbox/sdk";
-import type { Message } from "@inkbox/sdk";
+import type { Message, DecryptedVaultSecret } from "@inkbox/sdk";
 import {
   loadConfig,
   bootstrapTestOrg,
@@ -125,6 +125,70 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
     await alpha.update({ status: "active" });
     await alpha.refresh();
     expect(alpha.status).toBe("active");
+
+    // ── vault + credentials ───────────────────────────────────
+    const vaultKey = "IntegrationTest-Key-01!";
+    logStep(config, "initialize vault");
+    const vaultResult = await inkbox.vault.initialize(vaultKey);
+    expect(vaultResult.vaultKeyId).toBeTruthy();
+    expect(vaultResult.recoveryCodes).toHaveLength(4);
+
+    logStep(config, "vault info");
+    const vaultInfo = await inkbox.vault.info();
+    expect(vaultInfo).not.toBeNull();
+    expect(vaultInfo!.keyCount).toBe(1);
+    expect(vaultInfo!.recoveryKeyCount).toBe(4);
+    expect(vaultInfo!.secretCount).toBe(0);
+
+    logStep(config, "unlock vault");
+    await inkbox.vault.unlock(vaultKey);
+
+    logStep(config, "create API key secret via alpha identity");
+    const secretA = await alpha.createSecret({
+      name: "test-api-key",
+      payload: { apiKey: "sk-test-secret-12345" },
+      description: "Integration test API key",
+    });
+    expect(secretA.name).toBe("test-api-key");
+    expect(secretA.secretType).toBe("api_key");
+
+    logStep(config, "create login secret via alpha identity");
+    const secretB = await alpha.createSecret({
+      name: "test-login",
+      payload: { username: "testuser", password: "testpass123" },
+      description: "Integration test login",
+    });
+    expect(secretB.name).toBe("test-login");
+    expect(secretB.secretType).toBe("login");
+
+    logStep(config, "list secrets shows both");
+    const allSecrets = await inkbox.vault.listSecrets();
+    expect(allSecrets).toHaveLength(2);
+
+    logStep(config, "list secrets filtered by type");
+    const apiKeySecrets = await inkbox.vault.listSecrets({ secretType: "api_key" });
+    expect(apiKeySecrets).toHaveLength(1);
+    expect(apiKeySecrets[0].name).toBe("test-api-key");
+
+    logStep(config, "verify alpha credentials include both secrets (no client-side filtering)");
+    const creds = await alpha.getCredentials();
+    const apiKeys = creds.listApiKeys();
+    expect(apiKeys).toHaveLength(1);
+    expect(apiKeys[0].payload.apiKey).toBe("sk-test-secret-12345");
+    const logins = creds.listLogins();
+    expect(logins).toHaveLength(1);
+    expect(logins[0].payload.username).toBe("testuser");
+
+    logStep(config, "get secret by ID and verify decrypted payload");
+    const fetched = await alpha.getSecret(secretA.id);
+    expect(fetched.name).toBe("test-api-key");
+    expect(fetched.payload.apiKey).toBe("sk-test-secret-12345");
+
+    logStep(config, "delete secrets");
+    await alpha.deleteSecret(secretA.id);
+    await alpha.deleteSecret(secretB.id);
+    const remaining = await inkbox.vault.listSecrets();
+    expect(remaining).toHaveLength(0);
 
     // ── signing key ───────────────────────────────────────────
     logStep(config, "create signing key");

--- a/tests/integration/typescript/tsconfig.json
+++ b/tests/integration/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/tests/integration/typescript/vitest.config.ts
+++ b/tests/integration/typescript/vitest.config.ts
@@ -1,0 +1,10 @@
+// tests/integration/typescript/vitest.config.ts
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 300_000,
+    include: ["**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds end-to-end integration tests exercising the Python SDK, TypeScript SDK, and CLI against live dev/beta environments
- New workflow (`sdk_integration.yml`) runs 6 jobs: 3 SDK types × 2 environments
- PR pushes test both development + beta; scheduled runs (every 2h) test beta only
- All base URLs are kept as secrets since this is a public repo
- Google Chat notifications on both scheduled success and failure
- Tests cover: whoami, identity CRUD, email send + delivery polling, message detail, threading, mark-read, identity pause/resume, signing key rotation