### PR TITLE
Fix CLI SDK packaging and bump SDK/CLI to 0.2.7

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "file:../sdk/typescript",
+    "@inkbox/sdk": "^0.2.7",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/publish.sh
+++ b/cli/publish.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 DRY_RUN="--dry-run"
 if [[ "${1:-}" == "--prod" ]]; then
   DRY_RUN=""
 fi
 
 # Load .env from repo root if present
-ENV_FILE="$(dirname "$0")/../.env"
+ENV_FILE="$REPO_ROOT/.env"
 if [[ -f "$ENV_FILE" ]]; then
   set -a; source "$ENV_FILE"; set +a
+fi
+
+CLI_SDK_DEP="$(node -p "require('$REPO_ROOT/cli/package.json').dependencies['@inkbox/sdk']")"
+SDK_VERSION="$(node -p "require('$REPO_ROOT/sdk/typescript/package.json').version")"
+EXPECTED_CLI_SDK_DEP="^${SDK_VERSION}"
+
+if [[ "$CLI_SDK_DEP" != "$EXPECTED_CLI_SDK_DEP" ]]; then
+  echo "Error: cli/package.json depends on @inkbox/sdk@$CLI_SDK_DEP, but sdk/typescript/package.json is version $SDK_VERSION."
+  echo "Expected cli/package.json to declare @inkbox/sdk as $EXPECTED_CLI_SDK_DEP before publishing."
+  exit 1
 fi
 
 echo "==> Cleaning previous builds"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- change the CLI package to depend on published `@inkbox/sdk` releases instead of a local `file:` path
- bump the CLI, TypeScript SDK, and Python SDK from `0.2.6` to `0.2.7`
- keep the release manifests aligned so the next publish sequence can ship cleanly

## Verification
- `npm_config_cache=/tmp/npm-cache npm pack` in `cli/`
- `npm_config_cache=/tmp/npm-cache npm pack` in `sdk/typescript/`
- inspected the packed CLI `package.json` to confirm it now ships `"@inkbox/sdk": "^0.2.7"`

## Notes
- publish `@inkbox/sdk@0.2.7` before `@inkbox/cli@0.2.7`