### PR TITLE
Fix inkbox-openclaw skill name and description

### DIFF
--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: inkbox
-description: Use when writing TypeScript or JavaScript code that imports from `@inkbox/sdk`, uses `npm install @inkbox/sdk`, or when adding email, phone, text/SMS, vault, or agent identity features using the Inkbox TypeScript SDK.
+name: inkbox-openclaw
+description: Openclaw-distributed Inkbox skill — use when adding email, phone, text/SMS, encrypted vault, or agent identity features via the Inkbox TypeScript SDK (`@inkbox/sdk`) with openclaw environment and dependency provisioning.
 metadata:
   openclaw:
     emoji: "📬"


### PR DESCRIPTION
The frontmatter `name` field was `inkbox`, causing the skills CLI (and likely skills.sh) to list it as "inkbox" instead of "inkbox-openclaw", and the description was a verbatim copy of inkbox-ts so the two collided. Align the name with the directory and rewrite the description to call out the openclaw distribution.