### PR TITLE
Skills updates

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -43,6 +43,8 @@ Once the skills are installed, your coding agent will automatically know how to 
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, webhooks using the `inkbox` Python SDK |
 | **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
 | **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email and phone for your OpenClaw agent |
+| **inkbox-cli** | TypeScript / Node ≥ 18 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, vault, mailboxes, numbers, webhooks, and signing keys |
+| **inkbox-all** | Language-agnostic | Index of all Inkbox skills in this repository, including example skills and links for choosing the right one |
 | **agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
 
 ## Documentation

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,7 +43,7 @@ Once the skills are installed, your coding agent will automatically know how to 
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, webhooks using the `inkbox` Python SDK |
 | **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
 | **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email and phone for your OpenClaw agent |
-| **agent-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
+| **agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
 
 ## Documentation
 

--- a/skills/agent-self-signup/SKILL.md
+++ b/skills/agent-self-signup/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: agent-signup
+name: agent-self-signup
 description: Use when guiding or implementing the Inkbox agent self-signup flow, including verification, resend-verification, signup restrictions, and optional signup fields like agent handles or mailbox local parts.
 ---
 
-# Agent Signup
+# Agent Self-Signup
 
 ## Overview
 
-Agents can self-register for an Inkbox account without a pre-existing API key. The signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
+Agents can self-register for an Inkbox account without a pre-existing API key. The self-signup flow provisions a mailbox, identity, and API key in a single call. A verification email is sent to the specified human for approval.
 
 The flow has four steps:
 

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: inkbox-all
+description: Index of all Inkbox skills in this repository, including the example skills under `examples/`, with GitHub links and short guidance on when to use each one.
+user-invocable: false
+---
+
+# Inkbox Skills Index
+
+This skill is just a directory of the other Inkbox skills in this repository. Use it when you want to see the full menu before choosing a more specific skill. In practice, the SDK skills are the main references for application code, `agent-self-signup` covers the self-registration flow, `inkbox-cli` covers shell usage, and the example skills under `examples/` are prompt templates for browser-capable agents.
+
+## Core Skills
+
+- `agent-self-signup`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/agent-self-signup/SKILL.md
+  Shared reference for Inkbox agent self-signup, verification, resend-verification, and claim-status flows.
+
+- `inkbox-cli`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-cli/SKILL.md
+  Reference for running the Inkbox CLI (`inkbox` / `@inkbox/cli`) for identities, email, phone, text, vault, mailbox, number, signing key, and webhook operations.
+
+- `inkbox-openclaw`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-openclaw/SKILL.md
+  OpenClaw-oriented Inkbox skill for TypeScript usage with environment and dependency setup guidance.
+
+- `inkbox-python`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-python/SKILL.md
+  Python SDK reference for `inkbox`, including identities, email, phone, text/SMS, vault, and signing keys.
+
+- `inkbox-ts`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-ts/SKILL.md
+  TypeScript/JavaScript SDK reference for `@inkbox/sdk`, including identities, email, phone, text/SMS, vault, and signing keys.
+
+## Example Skills
+
+- `browser-use`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/examples/use-inkbox-browser-use/SKILL.md
+  Prompt template for an agent that has Browser Use browser automation plus an Inkbox-backed email identity and vault access.
+
+- `kernel`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/examples/use-inkbox-kernel/SKILL.md
+  Prompt template for an agent that has a Kernel cloud browser plus an Inkbox-backed email identity.
+
+## Related Examples
+
+These are example directories in the repo that are useful alongside the skills above:
+
+- `use-inkbox-browser-use`
+  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-browser-use
+
+- `use-inkbox-cli`
+  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-cli
+
+- `use-inkbox-kernel`
+  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-kernel
+
+## How To Choose
+
+- Use `inkbox-python` when writing Python application code against the SDK.
+- Use `inkbox-ts` when writing TypeScript or JavaScript application code against the SDK.
+- Use `inkbox-cli` when the task is operational and best handled with shell commands.
+- Use `agent-self-signup` when the agent does not have an API key yet and needs to self-register.
+- Use `inkbox-openclaw` when the environment is specifically OpenClaw.
+- Use the example skills when you want a reusable agent prompt rather than SDK integration code.

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -6,6 +6,14 @@ user-invocable: false
 
 # Inkbox Skills Index
 
+Inkbox is an identity layer for AI agents. It gives agents a persistent identity with a real inbox, phone number, and secure vault, so they can send emails, receive replies, answer calls, store credentials, and manage conversations as a single, consistent entity. Learn more at https://inkbox.ai.
+
+Useful links:
+
+- Website: https://inkbox.ai
+- LLMs: https://inkbox.ai/llms.txt
+- OpenAPI: https://inkbox.ai/api/openapi.json
+
 This skill is just a directory of the other Inkbox skills in this repository. Use it when you want to see the full menu before choosing a more specific skill. In practice, the SDK skills are the main references for application code, `agent-self-signup` covers the self-registration flow, `inkbox-cli` covers shell usage, and the example skills under `examples/` are prompt templates for browser-capable agents.
 
 ## Core Skills

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -40,26 +40,25 @@ This skill is just a directory of the other Inkbox skills in this repository. Us
 
 ## Example Skills
 
-- `browser-use`
+- `use-inkbox-browser-use`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/examples/use-inkbox-browser-use/SKILL.md
   Prompt template for an agent that has Browser Use browser automation plus an Inkbox-backed email identity and vault access.
 
-- `kernel`
+- `use-inkbox-kernel`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/examples/use-inkbox-kernel/SKILL.md
   Prompt template for an agent that has a Kernel cloud browser plus an Inkbox-backed email identity.
 
 ## Related Examples
 
-These are example directories in the repo that are useful alongside the skills above:
-
-- `use-inkbox-browser-use`
-  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-browser-use
+These example directories are useful references, but they are not standalone skills because they do not contain a `SKILL.md` file.
 
 - `use-inkbox-cli`
   GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-cli
+  Shell script examples for automating Inkbox from terminal workflows, CI, and agent shell execution using `@inkbox/cli` plus `jq`.
 
-- `use-inkbox-kernel`
-  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-kernel
+- `use-inkbox-vault`
+  GitHub: https://github.com/inkbox-ai/inkbox/tree/main/examples/use-inkbox-vault
+  Small Python and TypeScript examples showing how to create a login credential with TOTP, generate codes, and clean up.
 
 ## How To Choose
 
@@ -69,3 +68,4 @@ These are example directories in the repo that are useful alongside the skills a
 - Use `agent-self-signup` when the agent does not have an API key yet and needs to self-register.
 - Use `inkbox-openclaw` when the environment is specifically OpenClaw.
 - Use the example skills when you want a reusable agent prompt rather than SDK integration code.
+- Use the related examples when you want runnable scripts or end-to-end sample workflows instead of a reusable skill prompt.

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: inkbox-cli
+description: Use when running or writing shell commands with the Inkbox CLI (`inkbox` / `@inkbox/cli`) for identities, email, phone, text/SMS, vault, mailbox, phone number, webhook, or signup workflows.
+user-invocable: false
+---
+
+# Inkbox CLI
+
+Command-line interface for the Inkbox API — identities, email, phone, text/SMS, encrypted vault, mailboxes, phone numbers, signing keys, and webhook utilities.
+
+## Auth & Runtime
+
+Set credentials via env vars or global flags:
+
+```bash
+export INKBOX_API_KEY="ApiKey_..."
+export INKBOX_VAULT_KEY="my-vault-key"   # only needed for vault decrypt/create flows
+```
+
+Global options:
+
+```text
+--api-key <key>      Inkbox API key (or set INKBOX_API_KEY)
+--vault-key <key>    Vault key for decrypt operations (or set INKBOX_VAULT_KEY)
+--base-url <url>     Override API base URL
+--json               Output as JSON instead of formatted tables
+```
+
+If `INKBOX_API_KEY` is missing and `--api-key` is not passed, the CLI exits with an error.
+
+Prefer `--json` when the result will be parsed or fed into another tool. Use the default table/record output when the user wants a quick human-readable summary.
+
+## Install & Local Repo Usage
+
+Published package:
+
+```bash
+npm install -g @inkbox/cli
+```
+
+Or run without a global install:
+
+```bash
+npx @inkbox/cli <command>
+```
+
+Requires Node.js >= 18.
+
+Inside this repository, prefer running the local source instead of assuming a global install:
+
+```bash
+npm --prefix cli run dev -- <command>
+```
+
+Examples:
+
+```bash
+npm --prefix cli run dev -- --json identity list
+npm --prefix cli run dev -- email list -i support-bot --limit 10
+```
+
+## High-Risk Operations
+
+These commands can send real traffic or mutate real resources. Confirm with the user before running them:
+
+- `signup create`
+- `email send`
+- `phone call`
+- `identity delete`
+- `email delete`
+- `email delete-thread`
+- `vault delete`
+- `mailbox delete`
+- `number release`
+- `signing-key create`
+
+Also confirm before creating or rotating secrets if the values were not explicitly provided by the user.
+
+## Agent Signup
+
+For the full self-signup flow and API semantics, read the shared reference:
+
+> **See:** `skills/agent-signup/SKILL.md`
+
+CLI commands:
+
+```bash
+inkbox signup create
+inkbox signup verify --code <code>
+inkbox signup resend-verification
+inkbox signup status
+```
+
+`signup create` is the main command that does not require an API key. The later signup commands authenticate using the signup-issued credentials persisted by the CLI flow.
+
+## Identities
+
+```bash
+inkbox identity list
+inkbox identity get <handle>
+inkbox identity create <handle>
+inkbox identity delete <handle>
+inkbox identity update <handle> --new-handle <handle>
+inkbox identity refresh <handle>
+```
+
+Notes:
+
+- Creating an identity creates the agent identity; mailbox creation is handled automatically by the backend flow described in the CLI docs.
+- `identity get` and `identity refresh` return mailbox and phone number assignments when present.
+- Most email, phone, and text commands require `-i, --identity <handle>`.
+
+### Identity-Scoped Secrets
+
+These require a vault key:
+
+```bash
+inkbox identity create-secret <handle> --name <name> --type <type> ...
+inkbox identity get-secret <handle> <secret-id>
+inkbox identity delete-secret <handle> <secret-id>
+inkbox identity revoke-access <handle> <secret-id>
+inkbox identity set-totp <handle> <secret-id> --uri <otpauth-uri>
+inkbox identity remove-totp <handle> <secret-id>
+inkbox identity totp-code <handle> <secret-id>
+```
+
+Secret types:
+
+```text
+login, api_key, ssh_key, key_pair, other
+```
+
+## Email
+
+All email commands are identity-scoped and require `-i <handle>`.
+
+```bash
+inkbox email send -i <handle> \
+  --to user@example.com \
+  --subject "Hello" \
+  --body-text "Hi"
+
+inkbox email list -i <handle> --limit 10
+inkbox email get <message-id> -i <handle>
+inkbox email search -i <handle> -q "invoice"
+inkbox email unread -i <handle> --limit 10
+inkbox email mark-read <ids...> -i <handle>
+inkbox email delete <message-id> -i <handle>
+inkbox email delete-thread <thread-id> -i <handle>
+inkbox email star <message-id> -i <handle>
+inkbox email unstar <message-id> -i <handle>
+inkbox email thread <thread-id> -i <handle>
+```
+
+Use `email search` only when the identity already has a mailbox assigned.
+
+Before sending, confirm recipients, subject, and body with the user.
+
+## Phone
+
+All phone commands are identity-scoped and require `-i <handle>`.
+
+```bash
+inkbox phone call -i <handle> --to +15167251294 --ws-url wss://example.com/ws
+inkbox phone calls -i <handle> --limit 10 --offset 0
+inkbox phone transcripts <call-id> -i <handle>
+inkbox phone search-transcripts -i <handle> -q "refund" --party remote
+```
+
+Before placing a call, confirm the destination number and websocket URL with the user.
+
+## Text Messages
+
+All text commands are identity-scoped and require `-i <handle>`.
+
+```bash
+inkbox text list -i <handle> --limit 20
+inkbox text get <text-id> -i <handle>
+inkbox text conversations -i <handle> --limit 20
+inkbox text conversation <remote-number> -i <handle> --limit 50
+inkbox text search -i <handle> -q "invoice"
+inkbox text mark-read <text-id> -i <handle>
+inkbox text mark-conversation-read <remote-number> -i <handle>
+```
+
+## Vault
+
+Vault decryption and secret creation require a vault key via `INKBOX_VAULT_KEY` or `--vault-key`.
+
+```bash
+inkbox vault init --vault-key <key>
+inkbox vault info
+inkbox vault secrets
+inkbox vault get <secret-id>
+inkbox vault create --name <name> --type <type> ...
+inkbox vault delete <secret-id>
+inkbox vault keys
+inkbox vault grant-access <secret-id> -i <handle>
+inkbox vault revoke-access <secret-id> -i <handle>
+inkbox vault access-list <secret-id>
+inkbox vault logins -i <handle>
+inkbox vault api-keys -i <handle>
+inkbox vault ssh-keys -i <handle>
+inkbox vault key-pairs -i <handle>
+```
+
+Secret type flags:
+
+```bash
+# login
+--password <pass> [--username <user>] [--email <email>] [--url <url>] [--totp-uri <uri>] [--notes <text>]
+
+# api_key
+--key <key> [--endpoint <url>] [--notes <text>]
+
+# key_pair
+--access-key <key> --secret-key <key> [--endpoint <url>] [--notes <text>]
+
+# ssh_key
+--private-key <key> [--public-key <key>] [--fingerprint <fp>] [--passphrase <pass>] [--notes <text>]
+
+# other
+--data <json> [--notes <text>]
+```
+
+## Org-Level Mailboxes
+
+```bash
+inkbox mailbox list
+inkbox mailbox get <email-address>
+inkbox mailbox create -i <handle> [--display-name <name>] [--local-part <part>]
+inkbox mailbox update <email-address> [--display-name <name>] [--webhook-url <url>]
+inkbox mailbox delete <email-address>
+```
+
+## Org-Level Phone Numbers
+
+```bash
+inkbox number list
+inkbox number get <id>
+inkbox number provision --handle <handle> [--type toll_free|local] [--state NY]
+inkbox number update <id> [--incoming-call-action auto_accept|auto_reject|webhook] ...
+inkbox number release <number-id>
+```
+
+Use `--state` only when provisioning a local number.
+
+## Whoami, Signing Keys, Webhooks
+
+```bash
+inkbox whoami
+inkbox signing-key create
+inkbox webhook verify --payload <payload> --secret <secret> -H "X-Header: value"
+```
+
+Use `whoami --json` when you need the authenticated caller shape exactly.
+
+## Practical Guidance
+
+- Prefer the local repo command `npm --prefix cli run dev -- ...` when working in this codebase.
+- Prefer `--json` for anything that needs stable parsing.
+- Use the identity handle, not mailbox address or phone number, for identity-scoped commands.
+- If a command fails because the identity lacks a mailbox or phone number, inspect it first with `inkbox identity get <handle>`.

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -91,7 +91,7 @@ inkbox signup resend-verification
 inkbox signup status
 ```
 
-`signup create` is the main command that does not require an API key. The later signup commands authenticate using the signup-issued credentials persisted by the CLI flow.
+`signup create` is the main command that does not require an API key. The later signup commands require the signup-issued API key to be passed back via `--api-key` or exported as `INKBOX_API_KEY`; the CLI does not persist it automatically.
 
 ## Identities
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -80,7 +80,7 @@ Also confirm before creating or rotating secrets if the values were not explicit
 
 For the full self-signup flow and API semantics, read the shared reference:
 
-> **See:** `skills/agent-signup/SKILL.md`
+> **See:** `skills/agent-self-signup/SKILL.md`
 
 CLI commands:
 

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -84,7 +84,7 @@ An identity must have a channel assigned before you can use mail/phone/text meth
 
 For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-> **See:** `skills/agent-signup/SKILL.md`
+> **See:** `skills/agent-self-signup/SKILL.md`
 
 SDK methods: `Inkbox.signup({...})`, `Inkbox.verifySignup(apiKey, {...})`, `Inkbox.resendSignupVerification(apiKey)`, `Inkbox.getSignupStatus(apiKey)`.
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -54,7 +54,7 @@ An identity must have a channel assigned before you can use mail/phone methods. 
 
 For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-> **See:** `skills/agent-signup/SKILL.md`
+> **See:** `skills/agent-self-signup/SKILL.md`
 
 Python SDK methods: `Inkbox.signup(...)`, `Inkbox.verify_signup(api_key, ...)`, `Inkbox.resend_signup_verification(api_key)`, `Inkbox.get_signup_status(api_key)`.
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -53,7 +53,7 @@ An identity must have a channel assigned before you can use mail/phone methods. 
 
 For the full agent self-signup flow (register, verify, check status, restrictions, and direct API examples), read the shared reference:
 
-> **See:** `skills/agent-signup/SKILL.md`
+> **See:** `skills/agent-self-signup/SKILL.md`
 
 TypeScript SDK methods: `Inkbox.signup({...})`, `Inkbox.verifySignup(apiKey, {...})`, `Inkbox.resendSignupVerification(apiKey)`, `Inkbox.getSignupStatus(apiKey)`.
 


### PR DESCRIPTION
Updates include:
- Added `inkbox-cli` skill for Inkbox CLI usage, command coverage, and local repo execution guidance.
- Added `inkbox-all` skill as a simple index of all repo skills and example skills with GitHub links.
- Renamed `agent-signup` to `agent-self-signup` and updated internal skill references.
- Updated `skills/README.md` to reflect the new skill names and index.