### PR TITLE
CI: gate PR SDK integration tests on unit tests + require ready-for-review

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -4,7 +4,7 @@ name: SDK Integration Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 */2 * * *"
   workflow_dispatch:
@@ -22,9 +22,38 @@ on:
 permissions:
   contents: read
   packages: read
+  checks: read  # required by lewagon/wait-on-check-action to poll check-runs
 
 jobs:
+  # On PRs, gate the rest of the workflow on the unit-test workflow
+  # succeeding first. Skipped for scheduled and manual runs, and for
+  # draft PRs (tests run once marked ready for review).
+  wait-for-unit-tests:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Python unit tests
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: Python Tests
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
+      - name: Wait for TypeScript unit tests
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: TypeScript Tests
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
   select-targets:
+    needs: [wait-for-unit-tests]
+    if: |
+      always() &&
+      (needs.wait-for-unit-tests.result == 'success' || needs.wait-for-unit-tests.result == 'skipped') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}


### PR DESCRIPTION
## Summary

Replicates the PR gating pattern from [inkbox-ai/servers@a192c76](https://github.com/inkbox-ai/servers/commit/a192c76) so that Clerk isn't hit by integration runs from draft PRs or from PRs where unit tests haven't been validated yet.

- Added `ready_for_review` to `pull_request.types` so converting a draft to ready triggers the workflow.
- New `wait-for-unit-tests` job waits for both `Python Tests` and `TypeScript Tests` checks to succeed before downstream jobs start. Only runs for non-draft PRs.
- `select-targets` now depends on `wait-for-unit-tests` and skips entirely for draft PRs, which in turn skips `python-sdk` / `typescript-sdk` / `cli`.
- Added `checks: read` permission for `lewagon/wait-on-check-action`.
- Schedule/workflow_dispatch runs are unaffected — `wait-for-unit-tests` is pull_request-only and `select-targets`' condition explicitly allows non-PR events.

## Context

We've been seeing Clerk rate-limit failures on beta integration runs (e.g. run 24613509337 — all six SDK/CLI jobs × local/published × Python/TS/CLI). Gating integration on unit tests passing + non-draft status matches what servers already does and should keep Clerk traffic manageable.

Companion PR in console repo does the same for the console integration workflow.