### PR TITLE
Add contacts + notes + contact-rules SDK/CLI surface

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: ruff check .
 
       - name: Run Python tests
-        run: pytest --cov --cov-report=term-missing --cov-fail-under=75
+        run: pytest --cov --cov-report=term-missing --cov-fail-under=85
 
   typescript-tests:
     name: TypeScript Tests
@@ -58,4 +58,4 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Run TypeScript tests
-        run: npx vitest run --coverage --coverage.thresholds.lines=75
+        run: npx vitest run --coverage --coverage.thresholds.lines=85

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 VectorlyApp
+Copyright (c) 2026 Inkbox-AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.2.10",
+    "@inkbox/sdk": "^0.2.11",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -163,7 +163,7 @@ export function registerContactsCommands(program: Command): void {
 
   contacts
     .command("delete <contact-id>")
-    .description("Soft-delete a contact")
+    .description("Delete a contact")
     .action(
       withErrorHandler(async function (this: Command, contactId: string) {
         const opts = getGlobalOpts(this);

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -1,0 +1,245 @@
+import { Command } from "commander";
+import { readFileSync, writeFileSync } from "node:fs";
+import type { CreateContactOptions } from "@inkbox/sdk";
+import { createClient, getGlobalOpts } from "../client.js";
+import { output } from "../output.js";
+import { withErrorHandler } from "../errors.js";
+
+function parseJsonArg<T>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(
+      `Could not parse ${label} as JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function registerContactsAccessCommands(parent: Command): void {
+  const access = parent
+    .command("access")
+    .description("Per-contact access grants");
+
+  access
+    .command("list <contact-id>")
+    .description("List grants on a contact")
+    .action(
+      withErrorHandler(async function (this: Command, contactId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.contacts.access.list(contactId);
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "contactId", "identityId", "createdAt"],
+        });
+      }),
+    );
+
+  access
+    .command("grant <contact-id>")
+    .description("Grant access on a contact (admin + JWT only)")
+    .option("--identity <uuid>", "Identity UUID to grant")
+    .option("--wildcard", "Reset to wildcard grant (every active identity)", false)
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        contactId: string,
+        cmdOpts: { identity?: string; wildcard?: boolean },
+      ) {
+        if (cmdOpts.wildcard && cmdOpts.identity) {
+          throw new Error("Pass either --identity <uuid> or --wildcard, not both.");
+        }
+        if (!cmdOpts.wildcard && !cmdOpts.identity) {
+          throw new Error("One of --identity or --wildcard is required.");
+        }
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const grant = await inkbox.contacts.access.grant(contactId, {
+          identityId: cmdOpts.identity,
+          wildcard: cmdOpts.wildcard,
+        });
+        output(grant as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  access
+    .command("revoke <contact-id> <identity-id>")
+    .description("Revoke a specific identity's grant (self-only for agents)")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        contactId: string,
+        identityId: string,
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.contacts.access.revoke(contactId, identityId);
+        console.log(`Revoked identity ${identityId} on contact ${contactId}.`);
+      }),
+    );
+}
+
+export function registerContactsCommands(program: Command): void {
+  const contacts = program
+    .command("contacts")
+    .description("Org-wide address book (contacts + access + vCard)");
+
+  contacts
+    .command("list")
+    .description("List contacts")
+    .option("--q <query>", "Case-insensitive substring search (≤100 chars)")
+    .option("--order <order>", "name or recent")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: { q?: string; order?: string; limit?: number; offset?: number },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.contacts.list(cmdOpts);
+        output(rows, {
+          json: !!opts.json,
+          columns: [
+            "id",
+            "preferredName",
+            "givenName",
+            "familyName",
+            "companyName",
+            "jobTitle",
+            "updatedAt",
+          ],
+        });
+      }),
+    );
+
+  contacts
+    .command("get <contact-id>")
+    .description("Fetch a single contact")
+    .action(
+      withErrorHandler(async function (this: Command, contactId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const contact = await inkbox.contacts.get(contactId);
+        output(contact as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  contacts
+    .command("create")
+    .description("Create a contact (pass the full payload as JSON)")
+    .requiredOption("--json <payload>", "JSON payload matching CreateContactOptions")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: { json: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const payload = parseJsonArg<CreateContactOptions>(cmdOpts.json, "--json payload");
+        const inkbox = createClient(opts);
+        const contact = await inkbox.contacts.create(payload);
+        output(contact as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  contacts
+    .command("update <contact-id>")
+    .description("JSON-merge-patch update (pass the patch as JSON)")
+    .requiredOption("--json <payload>", "JSON patch matching UpdateContactOptions")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        contactId: string,
+        cmdOpts: { json: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const patch = parseJsonArg<Record<string, unknown>>(cmdOpts.json, "--json patch");
+        const inkbox = createClient(opts);
+        const contact = await inkbox.contacts.update(contactId, patch);
+        output(contact as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  contacts
+    .command("delete <contact-id>")
+    .description("Soft-delete a contact")
+    .action(
+      withErrorHandler(async function (this: Command, contactId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.contacts.delete(contactId);
+        console.log(`Deleted contact ${contactId}.`);
+      }),
+    );
+
+  contacts
+    .command("lookup")
+    .description("Reverse-lookup contacts (exactly one filter required)")
+    .option("--email <email>", "Exact email match")
+    .option("--email-contains <substr>", "Case-insensitive email substring")
+    .option("--email-domain <domain>", "Domain-part match")
+    .option("--phone <e164>", "Exact phone match")
+    .option("--phone-contains <substr>", "Phone substring")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          email?: string;
+          emailContains?: string;
+          emailDomain?: string;
+          phone?: string;
+          phoneContains?: string;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.contacts.lookup(cmdOpts);
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "preferredName", "givenName", "familyName", "updatedAt"],
+        });
+      }),
+    );
+
+  contacts
+    .command("import <file>")
+    .description("Bulk vCard import (text/vcard, ≤5 MiB, ≤1000 cards)")
+    .action(
+      withErrorHandler(async function (this: Command, file: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const body = readFileSync(file, "utf8");
+        const result = await inkbox.contacts.vcards.import(body);
+        output(result as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  contacts
+    .command("export <contact-id>")
+    .description("Export a single contact as vCard 4.0")
+    .option("--out <file>", "Write to file instead of stdout")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        contactId: string,
+        cmdOpts: { out?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const vcf = await inkbox.contacts.vcards.export(contactId);
+        if (cmdOpts.out) {
+          writeFileSync(cmdOpts.out, vcf, "utf8");
+          if (!opts.json) console.log(`Wrote ${cmdOpts.out}`);
+        } else {
+          if (opts.json) {
+            output({ vcard: vcf }, { json: true });
+          } else {
+            process.stdout.write(vcf);
+          }
+        }
+      }),
+    );
+
+  registerContactsAccessCommands(contacts);
+}

--- a/cli/src/commands/mailbox.ts
+++ b/cli/src/commands/mailbox.ts
@@ -1,7 +1,189 @@
 import { Command } from "commander";
+import {
+  FilterMode,
+  MailRuleAction,
+  MailRuleMatchType,
+  ContactRuleStatus,
+} from "@inkbox/sdk";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
+
+const MAILBOX_LIST_COLUMNS = [
+  "emailAddress",
+  "id",
+  "displayName",
+  "filterMode",
+  "createdAt",
+];
+
+function renderFilterModeChangeNotice(
+  mb: { filterModeChangeNotice: unknown } | { filterModeChangeNotice?: unknown },
+): void {
+  const notice = (mb as { filterModeChangeNotice?: {
+    redundantRuleCount: number;
+    redundantRuleAction: string;
+    newFilterMode: string;
+  } | null }).filterModeChangeNotice;
+  if (!notice) return;
+  console.error(
+    `Note: ${notice.redundantRuleCount} active '${notice.redundantRuleAction}' ` +
+      `rule(s) are now redundant under '${notice.newFilterMode}'. ` +
+      `Review with 'inkbox mailbox rules list --mailbox <email>'.`,
+  );
+}
+
+function assertFilterMode(raw: string): FilterMode {
+  if (raw !== FilterMode.WHITELIST && raw !== FilterMode.BLACKLIST) {
+    throw new Error(`--filter-mode must be 'whitelist' or 'blacklist' (got '${raw}')`);
+  }
+  return raw;
+}
+
+function registerMailboxRulesCommands(parent: Command): void {
+  const rules = parent
+    .command("rules")
+    .description("Contact rules scoped to a mailbox");
+
+  rules
+    .command("list")
+    .description("List rules for a mailbox, or org-wide with --all-mailboxes")
+    .option("--mailbox <email>", "Mailbox email address")
+    .option("--all-mailboxes", "List all rules across all mailboxes (admin-only)")
+    .option("--mailbox-id <id>", "Narrow the org-wide list to a single mailbox id")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_email or domain")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          mailbox?: string;
+          allMailboxes?: boolean;
+          mailboxId?: string;
+          action?: string;
+          matchType?: string;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        let rows;
+        if (cmdOpts.allMailboxes) {
+          rows = await inkbox.mailContactRules.listAll({
+            mailboxId: cmdOpts.mailboxId,
+            action: cmdOpts.action as MailRuleAction | undefined,
+            matchType: cmdOpts.matchType as MailRuleMatchType | undefined,
+            limit: cmdOpts.limit,
+            offset: cmdOpts.offset,
+          });
+        } else {
+          if (!cmdOpts.mailbox) {
+            throw new Error("--mailbox <email> or --all-mailboxes is required");
+          }
+          rows = await inkbox.mailContactRules.list(cmdOpts.mailbox, {
+            action: cmdOpts.action as MailRuleAction | undefined,
+            matchType: cmdOpts.matchType as MailRuleMatchType | undefined,
+            limit: cmdOpts.limit,
+            offset: cmdOpts.offset,
+          });
+        }
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "mailboxId", "action", "matchType", "matchTarget", "status"],
+        });
+      }),
+    );
+
+  rules
+    .command("get <rule-id>")
+    .description("Get a single rule")
+    .requiredOption("--mailbox <email>", "Mailbox email address")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { mailbox: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailContactRules.get(cmdOpts.mailbox, ruleId);
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("create")
+    .description("Create a rule")
+    .requiredOption("--mailbox <email>", "Mailbox email address")
+    .requiredOption("--action <action>", "allow or block")
+    .requiredOption("--match-type <type>", "exact_email or domain")
+    .requiredOption("--match-target <value>", "Address or domain to match")
+    .option("--status <status>", "active (default) or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          mailbox: string;
+          action: string;
+          matchType: string;
+          matchTarget: string;
+          status?: string;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailContactRules.create(cmdOpts.mailbox, {
+          action: cmdOpts.action as MailRuleAction,
+          matchType: cmdOpts.matchType as MailRuleMatchType,
+          matchTarget: cmdOpts.matchTarget,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("update <rule-id>")
+    .description("Update action and/or status on a rule (admin-only)")
+    .requiredOption("--mailbox <email>", "Mailbox email address")
+    .option("--action <action>", "allow or block")
+    .option("--status <status>", "active or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { mailbox: string; action?: string; status?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailContactRules.update(cmdOpts.mailbox, ruleId, {
+          action: cmdOpts.action as MailRuleAction | undefined,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("delete <rule-id>")
+    .description("Soft-delete a rule (admin-only)")
+    .requiredOption("--mailbox <email>", "Mailbox email address")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { mailbox: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.mailContactRules.delete(cmdOpts.mailbox, ruleId);
+        console.log(`Deleted mail contact rule '${ruleId}' on ${cmdOpts.mailbox}.`);
+      }),
+    );
+}
 
 export function registerMailboxCommands(program: Command): void {
   const mailbox = program
@@ -18,12 +200,7 @@ export function registerMailboxCommands(program: Command): void {
         const mailboxes = await inkbox.mailboxes.list();
         output(mailboxes, {
           json: !!opts.json,
-          columns: [
-            "emailAddress",
-            "id",
-            "displayName",
-            "createdAt",
-          ],
+          columns: MAILBOX_LIST_COLUMNS,
         });
       }),
     );
@@ -55,6 +232,7 @@ export function registerMailboxCommands(program: Command): void {
             emailAddress: mb.emailAddress,
             id: mb.id,
             displayName: mb.displayName,
+            filterMode: mb.filterMode,
             createdAt: mb.createdAt,
           },
           { json: !!opts.json },
@@ -79,6 +257,7 @@ export function registerMailboxCommands(program: Command): void {
             id: mb.id,
             displayName: mb.displayName,
             webhookUrl: mb.webhookUrl ?? null,
+            filterMode: mb.filterMode,
             createdAt: mb.createdAt,
           },
           { json: !!opts.json },
@@ -91,11 +270,12 @@ export function registerMailboxCommands(program: Command): void {
     .description("Update a mailbox")
     .option("--display-name <name>", "New display name")
     .option("--webhook-url <url>", 'Webhook URL (pass "" to clear)')
+    .option("--filter-mode <mode>", "Contact-rule filter mode: whitelist or blacklist (admin-only)")
     .action(
       withErrorHandler(async function (
         this: Command,
         emailAddress: string,
-        cmdOpts: { displayName?: string; webhookUrl?: string },
+        cmdOpts: { displayName?: string; webhookUrl?: string; filterMode?: string },
       ) {
         const opts = getGlobalOpts(this);
         const inkbox = createClient(opts);
@@ -103,6 +283,10 @@ export function registerMailboxCommands(program: Command): void {
           displayName: cmdOpts.displayName,
           webhookUrl:
             cmdOpts.webhookUrl === "" ? null : cmdOpts.webhookUrl,
+          filterMode:
+            cmdOpts.filterMode !== undefined
+              ? assertFilterMode(cmdOpts.filterMode)
+              : undefined,
         });
         output(
           {
@@ -110,9 +294,11 @@ export function registerMailboxCommands(program: Command): void {
             id: mb.id,
             displayName: mb.displayName,
             webhookUrl: mb.webhookUrl ?? null,
+            filterMode: mb.filterMode,
           },
           { json: !!opts.json },
         );
+        renderFilterModeChangeNotice(mb);
       }),
     );
 
@@ -130,4 +316,6 @@ export function registerMailboxCommands(program: Command): void {
         console.log(`Deleted mailbox '${emailAddress}'.`);
       }),
     );
+
+  registerMailboxRulesCommands(mailbox);
 }

--- a/cli/src/commands/mailbox.ts
+++ b/cli/src/commands/mailbox.ts
@@ -14,6 +14,7 @@ const MAILBOX_LIST_COLUMNS = [
   "id",
   "displayName",
   "filterMode",
+  "agentIdentityId",
   "createdAt",
 ];
 
@@ -233,6 +234,7 @@ export function registerMailboxCommands(program: Command): void {
             id: mb.id,
             displayName: mb.displayName,
             filterMode: mb.filterMode,
+            agentIdentityId: mb.agentIdentityId,
             createdAt: mb.createdAt,
           },
           { json: !!opts.json },
@@ -258,6 +260,7 @@ export function registerMailboxCommands(program: Command): void {
             displayName: mb.displayName,
             webhookUrl: mb.webhookUrl ?? null,
             filterMode: mb.filterMode,
+            agentIdentityId: mb.agentIdentityId,
             createdAt: mb.createdAt,
           },
           { json: !!opts.json },
@@ -295,6 +298,7 @@ export function registerMailboxCommands(program: Command): void {
             displayName: mb.displayName,
             webhookUrl: mb.webhookUrl ?? null,
             filterMode: mb.filterMode,
+            agentIdentityId: mb.agentIdentityId,
           },
           { json: !!opts.json },
         );

--- a/cli/src/commands/mailbox.ts
+++ b/cli/src/commands/mailbox.ts
@@ -170,7 +170,7 @@ function registerMailboxRulesCommands(parent: Command): void {
 
   rules
     .command("delete <rule-id>")
-    .description("Soft-delete a rule (admin-only)")
+    .description("Delete a rule (admin-only)")
     .requiredOption("--mailbox <email>", "Mailbox email address")
     .action(
       withErrorHandler(async function (

--- a/cli/src/commands/mailbox.ts
+++ b/cli/src/commands/mailbox.ts
@@ -117,12 +117,11 @@ function registerMailboxRulesCommands(parent: Command): void {
 
   rules
     .command("create")
-    .description("Create a rule")
+    .description("Create a rule (always starts active; use `update` to pause)")
     .requiredOption("--mailbox <email>", "Mailbox email address")
     .requiredOption("--action <action>", "allow or block")
     .requiredOption("--match-type <type>", "exact_email or domain")
     .requiredOption("--match-target <value>", "Address or domain to match")
-    .option("--status <status>", "active (default) or paused")
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -131,7 +130,6 @@ function registerMailboxRulesCommands(parent: Command): void {
           action: string;
           matchType: string;
           matchTarget: string;
-          status?: string;
         },
       ) {
         const opts = getGlobalOpts(this);
@@ -140,7 +138,6 @@ function registerMailboxRulesCommands(parent: Command): void {
           action: cmdOpts.action as MailRuleAction,
           matchType: cmdOpts.matchType as MailRuleMatchType,
           matchTarget: cmdOpts.matchTarget,
-          status: cmdOpts.status as ContactRuleStatus | undefined,
         });
         output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
       }),

--- a/cli/src/commands/notes.ts
+++ b/cli/src/commands/notes.ts
@@ -153,7 +153,7 @@ export function registerNotesCommands(program: Command): void {
 
   notes
     .command("delete <note-id>")
-    .description("Soft-delete a note")
+    .description("Delete a note")
     .action(
       withErrorHandler(async function (this: Command, noteId: string) {
         const opts = getGlobalOpts(this);

--- a/cli/src/commands/notes.ts
+++ b/cli/src/commands/notes.ts
@@ -1,0 +1,167 @@
+import { Command } from "commander";
+import { createClient, getGlobalOpts } from "../client.js";
+import { output } from "../output.js";
+import { withErrorHandler } from "../errors.js";
+
+function registerNotesAccessCommands(parent: Command): void {
+  const access = parent
+    .command("access")
+    .description("Per-note access grants");
+
+  access
+    .command("list <note-id>")
+    .description("List grants on a note")
+    .action(
+      withErrorHandler(async function (this: Command, noteId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.notes.access.list(noteId);
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "noteId", "identityId", "createdAt"],
+        });
+      }),
+    );
+
+  access
+    .command("grant <note-id> <identity-id>")
+    .description("Grant a specific identity access (admin + JWT only)")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        noteId: string,
+        identityId: string,
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const grant = await inkbox.notes.access.grant(noteId, identityId);
+        output(grant as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  access
+    .command("revoke <note-id> <identity-id>")
+    .description("Revoke a specific identity's grant (self-only for agents)")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        noteId: string,
+        identityId: string,
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.notes.access.revoke(noteId, identityId);
+        console.log(`Revoked identity ${identityId} on note ${noteId}.`);
+      }),
+    );
+}
+
+export function registerNotesCommands(program: Command): void {
+  const notes = program
+    .command("notes")
+    .description("Org-scoped notes with per-identity grants");
+
+  notes
+    .command("list")
+    .description("List accessible notes")
+    .option("--q <query>", "Substring search (≤200 chars)")
+    .option("--identity <uuid>", "Filter to notes visible to an identity")
+    .option("--order <order>", "recent (default) or created")
+    .option("--limit <n>", "Max rows (1–200, default 50)", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          q?: string;
+          identity?: string;
+          order?: string;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.notes.list({
+          q: cmdOpts.q,
+          identityId: cmdOpts.identity,
+          order: cmdOpts.order,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "title", "createdBy", "status", "createdAt", "updatedAt"],
+        });
+      }),
+    );
+
+  notes
+    .command("get <note-id>")
+    .description("Fetch a single note with inlined grants")
+    .action(
+      withErrorHandler(async function (this: Command, noteId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const note = await inkbox.notes.get(noteId);
+        output(note as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  notes
+    .command("create")
+    .description("Create a note")
+    .requiredOption("--body <text>", "Body text (1–100 000 chars, required)")
+    .option("--title <text>", "Optional title (≤200 chars)")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: { body: string; title?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const note = await inkbox.notes.create({
+          body: cmdOpts.body,
+          title: cmdOpts.title,
+        });
+        output(note as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  notes
+    .command("update <note-id>")
+    .description("Update title and/or body")
+    .option("--body <text>", "New body text")
+    .option("--title <text>", 'New title (pass "" to clear)')
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        noteId: string,
+        cmdOpts: { body?: string; title?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const patch: { body?: string; title?: string | null } = {};
+        if (cmdOpts.body !== undefined) patch.body = cmdOpts.body;
+        if (cmdOpts.title !== undefined) {
+          patch.title = cmdOpts.title === "" ? null : cmdOpts.title;
+        }
+        const note = await inkbox.notes.update(noteId, patch);
+        output(note as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  notes
+    .command("delete <note-id>")
+    .description("Soft-delete a note")
+    .action(
+      withErrorHandler(async function (this: Command, noteId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.notes.delete(noteId);
+        console.log(`Deleted note ${noteId}.`);
+      }),
+    );
+
+  registerNotesAccessCommands(notes);
+}

--- a/cli/src/commands/number.ts
+++ b/cli/src/commands/number.ts
@@ -108,12 +108,11 @@ function registerNumberRulesCommands(parent: Command): void {
 
   rules
     .command("create")
-    .description("Create a rule")
+    .description("Create a rule (always starts active; use `update` to pause)")
     .requiredOption("--number <id>", "Phone number id")
     .requiredOption("--action <action>", "allow or block")
     .requiredOption("--match-target <value>", "Phone number to match (E.164)")
     .option("--match-type <type>", "exact_number (default)", PhoneRuleMatchType.EXACT_NUMBER)
-    .option("--status <status>", "active (default) or paused")
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -122,7 +121,6 @@ function registerNumberRulesCommands(parent: Command): void {
           action: string;
           matchType: string;
           matchTarget: string;
-          status?: string;
         },
       ) {
         const opts = getGlobalOpts(this);
@@ -131,7 +129,6 @@ function registerNumberRulesCommands(parent: Command): void {
           action: cmdOpts.action as PhoneRuleAction,
           matchType: cmdOpts.matchType as PhoneRuleMatchType,
           matchTarget: cmdOpts.matchTarget,
-          status: cmdOpts.status as ContactRuleStatus | undefined,
         });
         output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
       }),

--- a/cli/src/commands/number.ts
+++ b/cli/src/commands/number.ts
@@ -1,7 +1,181 @@
 import { Command } from "commander";
+import {
+  ContactRuleStatus,
+  FilterMode,
+  PhoneRuleAction,
+  PhoneRuleMatchType,
+} from "@inkbox/sdk";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
+
+function renderFilterModeChangeNotice(
+  pn: { filterModeChangeNotice?: unknown },
+): void {
+  const notice = pn.filterModeChangeNotice as {
+    redundantRuleCount: number;
+    redundantRuleAction: string;
+    newFilterMode: string;
+  } | null | undefined;
+  if (!notice) return;
+  console.error(
+    `Note: ${notice.redundantRuleCount} active '${notice.redundantRuleAction}' ` +
+      `rule(s) are now redundant under '${notice.newFilterMode}'. ` +
+      `Review with 'inkbox number rules list --number <id>'.`,
+  );
+}
+
+function assertFilterMode(raw: string): FilterMode {
+  if (raw !== FilterMode.WHITELIST && raw !== FilterMode.BLACKLIST) {
+    throw new Error(`--filter-mode must be 'whitelist' or 'blacklist' (got '${raw}')`);
+  }
+  return raw;
+}
+
+function registerNumberRulesCommands(parent: Command): void {
+  const rules = parent
+    .command("rules")
+    .description("Contact rules scoped to a phone number");
+
+  rules
+    .command("list")
+    .description("List rules for a number, or org-wide with --all-numbers")
+    .option("--number <id>", "Phone number id")
+    .option("--all-numbers", "List all rules across all numbers (admin-only)")
+    .option("--phone-number-id <id>", "Narrow the org-wide list to a single number id")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_number")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          number?: string;
+          allNumbers?: boolean;
+          phoneNumberId?: string;
+          action?: string;
+          matchType?: string;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        let rows;
+        if (cmdOpts.allNumbers) {
+          rows = await inkbox.phoneContactRules.listAll({
+            phoneNumberId: cmdOpts.phoneNumberId,
+            action: cmdOpts.action as PhoneRuleAction | undefined,
+            matchType: cmdOpts.matchType as PhoneRuleMatchType | undefined,
+            limit: cmdOpts.limit,
+            offset: cmdOpts.offset,
+          });
+        } else {
+          if (!cmdOpts.number) {
+            throw new Error("--number <id> or --all-numbers is required");
+          }
+          rows = await inkbox.phoneContactRules.list(cmdOpts.number, {
+            action: cmdOpts.action as PhoneRuleAction | undefined,
+            matchType: cmdOpts.matchType as PhoneRuleMatchType | undefined,
+            limit: cmdOpts.limit,
+            offset: cmdOpts.offset,
+          });
+        }
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "phoneNumberId", "action", "matchType", "matchTarget", "status"],
+        });
+      }),
+    );
+
+  rules
+    .command("get <rule-id>")
+    .description("Get a single rule")
+    .requiredOption("--number <id>", "Phone number id")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { number: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneContactRules.get(cmdOpts.number, ruleId);
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("create")
+    .description("Create a rule")
+    .requiredOption("--number <id>", "Phone number id")
+    .requiredOption("--action <action>", "allow or block")
+    .requiredOption("--match-target <value>", "Phone number to match (E.164)")
+    .option("--match-type <type>", "exact_number (default)", PhoneRuleMatchType.EXACT_NUMBER)
+    .option("--status <status>", "active (default) or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          number: string;
+          action: string;
+          matchType: string;
+          matchTarget: string;
+          status?: string;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneContactRules.create(cmdOpts.number, {
+          action: cmdOpts.action as PhoneRuleAction,
+          matchType: cmdOpts.matchType as PhoneRuleMatchType,
+          matchTarget: cmdOpts.matchTarget,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("update <rule-id>")
+    .description("Update action and/or status on a rule (admin-only)")
+    .requiredOption("--number <id>", "Phone number id")
+    .option("--action <action>", "allow or block")
+    .option("--status <status>", "active or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { number: string; action?: string; status?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneContactRules.update(cmdOpts.number, ruleId, {
+          action: cmdOpts.action as PhoneRuleAction | undefined,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("delete <rule-id>")
+    .description("Soft-delete a rule (admin-only)")
+    .requiredOption("--number <id>", "Phone number id")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        ruleId: string,
+        cmdOpts: { number: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.phoneContactRules.delete(cmdOpts.number, ruleId);
+        console.log(`Deleted phone contact rule '${ruleId}' on ${cmdOpts.number}.`);
+      }),
+    );
+}
 
 export function registerNumberCommands(program: Command): void {
   const number = program
@@ -18,7 +192,7 @@ export function registerNumberCommands(program: Command): void {
         const numbers = await inkbox.phoneNumbers.list();
         output(numbers, {
           json: !!opts.json,
-          columns: ["number", "id", "type", "status", "createdAt"],
+          columns: ["number", "id", "type", "status", "filterMode", "createdAt"],
         });
       }),
     );
@@ -49,6 +223,7 @@ export function registerNumberCommands(program: Command): void {
             id: num.id,
             type: num.type,
             status: num.status,
+            filterMode: num.filterMode,
           },
           { json: !!opts.json },
         );
@@ -73,6 +248,7 @@ export function registerNumberCommands(program: Command): void {
             clientWebsocketUrl: num.clientWebsocketUrl ?? null,
             incomingCallWebhookUrl: num.incomingCallWebhookUrl ?? null,
             incomingTextWebhookUrl: num.incomingTextWebhookUrl ?? null,
+            filterMode: num.filterMode,
             createdAt: num.createdAt,
           },
           { json: !!opts.json },
@@ -90,6 +266,7 @@ export function registerNumberCommands(program: Command): void {
     .option("--client-websocket-url <url>", "Client WebSocket URL for audio bridging")
     .option("--incoming-call-webhook-url <url>", "Webhook URL for incoming calls")
     .option("--incoming-text-webhook-url <url>", "Webhook URL for incoming text messages")
+    .option("--filter-mode <mode>", "Contact-rule filter mode: whitelist or blacklist (admin-only)")
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -99,6 +276,7 @@ export function registerNumberCommands(program: Command): void {
           clientWebsocketUrl?: string;
           incomingCallWebhookUrl?: string;
           incomingTextWebhookUrl?: string;
+          filterMode?: string;
         },
       ) {
         const opts = getGlobalOpts(this);
@@ -108,6 +286,10 @@ export function registerNumberCommands(program: Command): void {
           clientWebsocketUrl: cmdOpts.clientWebsocketUrl,
           incomingCallWebhookUrl: cmdOpts.incomingCallWebhookUrl,
           incomingTextWebhookUrl: cmdOpts.incomingTextWebhookUrl,
+          filterMode:
+            cmdOpts.filterMode !== undefined
+              ? assertFilterMode(cmdOpts.filterMode)
+              : undefined,
         });
         output(
           {
@@ -119,9 +301,11 @@ export function registerNumberCommands(program: Command): void {
             clientWebsocketUrl: num.clientWebsocketUrl ?? null,
             incomingCallWebhookUrl: num.incomingCallWebhookUrl ?? null,
             incomingTextWebhookUrl: num.incomingTextWebhookUrl ?? null,
+            filterMode: num.filterMode,
           },
           { json: !!opts.json },
         );
+        renderFilterModeChangeNotice(num);
       }),
     );
 
@@ -136,4 +320,6 @@ export function registerNumberCommands(program: Command): void {
         console.log(`Released phone number '${id}'.`);
       }),
     );
+
+  registerNumberRulesCommands(number);
 }

--- a/cli/src/commands/number.ts
+++ b/cli/src/commands/number.ts
@@ -161,7 +161,7 @@ function registerNumberRulesCommands(parent: Command): void {
 
   rules
     .command("delete <rule-id>")
-    .description("Soft-delete a rule (admin-only)")
+    .description("Delete a rule (admin-only)")
     .requiredOption("--number <id>", "Phone number id")
     .action(
       withErrorHandler(async function (

--- a/cli/src/commands/number.ts
+++ b/cli/src/commands/number.ts
@@ -192,7 +192,7 @@ export function registerNumberCommands(program: Command): void {
         const numbers = await inkbox.phoneNumbers.list();
         output(numbers, {
           json: !!opts.json,
-          columns: ["number", "id", "type", "status", "filterMode", "createdAt"],
+          columns: ["number", "id", "type", "status", "filterMode", "agentIdentityId", "createdAt"],
         });
       }),
     );
@@ -224,6 +224,7 @@ export function registerNumberCommands(program: Command): void {
             type: num.type,
             status: num.status,
             filterMode: num.filterMode,
+            agentIdentityId: num.agentIdentityId,
           },
           { json: !!opts.json },
         );
@@ -249,6 +250,7 @@ export function registerNumberCommands(program: Command): void {
             incomingCallWebhookUrl: num.incomingCallWebhookUrl ?? null,
             incomingTextWebhookUrl: num.incomingTextWebhookUrl ?? null,
             filterMode: num.filterMode,
+            agentIdentityId: num.agentIdentityId,
             createdAt: num.createdAt,
           },
           { json: !!opts.json },
@@ -302,6 +304,7 @@ export function registerNumberCommands(program: Command): void {
             incomingCallWebhookUrl: num.incomingCallWebhookUrl ?? null,
             incomingTextWebhookUrl: num.incomingTextWebhookUrl ?? null,
             filterMode: num.filterMode,
+            agentIdentityId: num.agentIdentityId,
           },
           { json: !!opts.json },
         );

--- a/cli/src/errors.ts
+++ b/cli/src/errors.ts
@@ -1,4 +1,14 @@
-import { InkboxAPIError, InkboxError, InkboxVaultKeyError } from "@inkbox/sdk";
+import {
+  DuplicateContactRuleError,
+  InkboxAPIError,
+  InkboxError,
+  InkboxVaultKeyError,
+  RedundantContactAccessGrantError,
+} from "@inkbox/sdk";
+
+function renderDetail(detail: string | Record<string, unknown>): string {
+  return typeof detail === "string" ? detail : JSON.stringify(detail);
+}
 
 export function withErrorHandler<T extends unknown[]>(
   fn: (...args: T) => Promise<void>,
@@ -7,8 +17,16 @@ export function withErrorHandler<T extends unknown[]>(
     try {
       await fn.call(this, ...args);
     } catch (err) {
-      if (err instanceof InkboxAPIError) {
-        console.error(`Error: HTTP ${err.statusCode}: ${err.detail}`);
+      if (err instanceof DuplicateContactRuleError) {
+        console.error(
+          `Error: HTTP ${err.statusCode}: duplicate rule (existing_rule_id=${err.existingRuleId})`,
+        );
+      } else if (err instanceof RedundantContactAccessGrantError) {
+        console.error(
+          `Error: HTTP ${err.statusCode}: redundant grant — ${err.detailMessage}`,
+        );
+      } else if (err instanceof InkboxAPIError) {
+        console.error(`Error: HTTP ${err.statusCode}: ${renderDetail(err.detail)}`);
         if (err.statusCode === 401) {
           console.error("Hint: Check your API key.");
         }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,8 @@ import { registerMailboxCommands } from "./commands/mailbox.js";
 import { registerNumberCommands } from "./commands/number.js";
 import { registerSigningKeyCommands } from "./commands/signing-key.js";
 import { registerWebhookCommands } from "./commands/webhook.js";
+import { registerContactsCommands } from "./commands/contacts.js";
+import { registerNotesCommands } from "./commands/notes.js";
 
 const program = new Command()
   .name("inkbox")
@@ -33,5 +35,7 @@ registerMailboxCommands(program);
 registerNumberCommands(program);
 registerSigningKeyCommands(program);
 registerWebhookCommands(program);
+registerContactsCommands(program);
+registerNotesCommands(program);
 
 program.parse();

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -105,9 +105,9 @@ print(status.restrictions.max_sends_per_day)  # 10 (unclaimed) or 500 (claimed)
 
 `signup()` requires `human_email` and `note_to_human`. `display_name`, `agent_handle`, and `email_local_part` are optional. All methods accept optional `base_url` and `timeout` keyword arguments.
 
-> **Note:** Unclaimed agents can only send to the `human_email` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
+> **Note:** Unclaimed agents have a limited send quota and can only email the `human_email` specified at signup. After verification or human approval in the console, full capabilities are unlocked.
 
-> **Note:** The `organization_id` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. Always use the `organization_id` from the most recent response (`verify_signup` or `resend_signup_verification`) rather than caching the value from the initial `signup()` call.
+> **Note:** The `organization_id` returned at signup may change after verification or human approval. Always use the `organization_id` from the most recent response (`verify_signup` or `resend_signup_verification`) rather than caching the value from the initial `signup()` call.
 
 ---
 
@@ -262,7 +262,7 @@ unread = identity.list_texts(is_read=False)
 # Get a single text
 text = identity.get_text("text-uuid")
 print(text.type)  # "sms" or "mms"
-if text.media:    # MMS attachments (presigned S3 URLs, 1hr expiry)
+if text.media:    # MMS attachments (temporary signed URLs)
     for m in text.media:
         print(m.content_type, m.size, m.url)
 
@@ -446,7 +446,7 @@ inkbox.messages.unstar("abc@inkboxmail.com", "message-uuid")
 # Delete a message
 inkbox.messages.delete("abc@inkboxmail.com", "message-uuid")
 
-# Get an attachment presigned URL
+# Get a temporary signed URL for an attachment
 attachment = inkbox.messages.get_attachment("abc@inkboxmail.com", "message-uuid", "report.pdf")
 print(attachment["url"])
 

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -7,23 +7,39 @@ from inkbox.agent_identity import AgentIdentity
 from inkbox.credentials import Credentials
 
 # Exceptions (canonical source)
-from inkbox.exceptions import InkboxAPIError, InkboxError, InkboxVaultKeyError
+from inkbox.exceptions import (
+    DuplicateContactRuleError,
+    InkboxAPIError,
+    InkboxError,
+    InkboxVaultKeyError,
+    RedundantContactAccessGrantError,
+)
 
 # Mail types
 from inkbox.mail.types import (
+    ContactRuleStatus,
+    FilterMode,
+    FilterModeChangeNotice,
+    MailContactRule,
+    MailRuleAction,
+    MailRuleMatchType,
     Mailbox,
     Message,
     MessageDetail,
     MessageDirection,
     Thread,
     ThreadDetail,
+    ThreadFolder,
 )
 
 # Phone types
 from inkbox.phone.types import (
     PhoneCall,
     PhoneCallWithRateLimit,
+    PhoneContactRule,
     PhoneNumber,
+    PhoneRuleAction,
+    PhoneRuleMatchType,
     PhoneTranscript,
     RateLimitInfo,
     TextConversationSummary,
@@ -39,6 +55,23 @@ from inkbox.identities.types import (
     IdentityPhoneNumberCreateOptions,
     IdentityPhoneNumber,
 )
+
+# Contacts types
+from inkbox.contacts.types import (
+    Contact,
+    ContactAccess,
+    ContactAddress,
+    ContactCustomField,
+    ContactDate,
+    ContactEmail,
+    ContactImportResult,
+    ContactImportResultItem,
+    ContactPhone,
+    ContactWebsite,
+)
+
+# Notes types
+from inkbox.notes.types import Note, NoteAccess
 
 # Vault types
 from inkbox.vault.types import (
@@ -80,8 +113,11 @@ from inkbox.agent_signup.types import (
     SignupRestrictions,
 )
 
-# Whoami types
+# Whoami types and named auth_subtype constants
 from inkbox.whoami.types import (
+    AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED,
+    AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED,
+    AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED,
     WhoamiApiKeyResponse,
     WhoamiJwtResponse,
     WhoamiResponse,
@@ -99,17 +135,29 @@ __all__ = [
     "InkboxError",
     "InkboxAPIError",
     "InkboxVaultKeyError",
+    "DuplicateContactRuleError",
+    "RedundantContactAccessGrantError",
     # Mail types
+    "ContactRuleStatus",
+    "FilterMode",
+    "FilterModeChangeNotice",
+    "MailContactRule",
+    "MailRuleAction",
+    "MailRuleMatchType",
     "Mailbox",
     "Message",
     "MessageDetail",
     "MessageDirection",
     "Thread",
     "ThreadDetail",
+    "ThreadFolder",
     # Phone types
     "PhoneCall",
     "PhoneCallWithRateLimit",
+    "PhoneContactRule",
     "PhoneNumber",
+    "PhoneRuleAction",
+    "PhoneRuleMatchType",
     "PhoneTranscript",
     "RateLimitInfo",
     "TextConversationSummary",
@@ -121,6 +169,20 @@ __all__ = [
     "IdentityMailbox",
     "IdentityPhoneNumberCreateOptions",
     "IdentityPhoneNumber",
+    # Contacts types
+    "Contact",
+    "ContactAccess",
+    "ContactAddress",
+    "ContactCustomField",
+    "ContactDate",
+    "ContactEmail",
+    "ContactImportResult",
+    "ContactImportResultItem",
+    "ContactPhone",
+    "ContactWebsite",
+    # Notes types
+    "Note",
+    "NoteAccess",
     # Vault types
     "AccessRule",
     "VaultSecretType",
@@ -152,7 +214,10 @@ __all__ = [
     "AgentSignupResendResponse",
     "AgentSignupStatusResponse",
     "SignupRestrictions",
-    # Whoami types
+    # Whoami types + auth_subtype constants
+    "AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED",
+    "AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED",
+    "AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED",
     "WhoamiApiKeyResponse",
     "WhoamiJwtResponse",
     "WhoamiResponse",

--- a/sdk/python/inkbox/_http.py
+++ b/sdk/python/inkbox/_http.py
@@ -11,7 +11,11 @@ from typing import Any
 import httpx
 
 from inkbox._cookies import CookieJar
-from inkbox.exceptions import InkboxAPIError
+from inkbox.exceptions import (
+    DuplicateContactRuleError,
+    InkboxAPIError,
+    RedundantContactAccessGrantError,
+)
 
 _DEFAULT_TIMEOUT = 30.0
 
@@ -61,6 +65,43 @@ class HttpTransport:
         resp = self._send("DELETE", path)
         _raise_for_status(resp)
 
+    def post_bytes(
+        self,
+        path: str,
+        *,
+        content: bytes,
+        content_type: str,
+        accept: str = "application/json",
+    ) -> Any:
+        """POST arbitrary bytes with a caller-supplied Content-Type.
+
+        Used for non-JSON payloads like vCard imports. The response is
+        still decoded as JSON.
+        """
+        headers = {"Content-Type": content_type, "Accept": accept}
+        resp = self._send("POST", path, content=content, headers=headers)
+        _raise_for_status(resp)
+        if resp.status_code == 204:
+            return None
+        return resp.json()
+
+    def get_bytes(
+        self,
+        path: str,
+        *,
+        accept: str,
+        params: dict[str, Any] | None = None,
+    ) -> bytes:
+        """GET a non-JSON response and return the raw body.
+
+        Used for vCard export and any other binary/text endpoints.
+        """
+        cleaned = {k: v for k, v in (params or {}).items() if v is not None}
+        headers = {"Accept": accept}
+        resp = self._send("GET", path, params=cleaned, headers=headers)
+        _raise_for_status(resp)
+        return resp.content
+
     def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         request = self._client.build_request(method, path, **kwargs)
         cookie = self._cookie_jar.header_for_url(str(request.url))
@@ -83,8 +124,20 @@ class HttpTransport:
 def _raise_for_status(resp: httpx.Response) -> None:
     if resp.status_code < 400:
         return
+    raw_detail: Any
     try:
-        detail = resp.json().get("detail", resp.text)
+        raw_detail = resp.json().get("detail", resp.text)
     except Exception:
-        detail = resp.text
-    raise InkboxAPIError(status_code=resp.status_code, detail=str(detail))
+        raw_detail = resp.text
+
+    if resp.status_code == 409 and isinstance(raw_detail, dict):
+        if "existing_rule_id" in raw_detail:
+            raise DuplicateContactRuleError(
+                status_code=resp.status_code, detail=raw_detail,
+            )
+        if raw_detail.get("error") == "redundant_grant":
+            raise RedundantContactAccessGrantError(
+                status_code=resp.status_code, detail=raw_detail,
+            )
+
+    raise InkboxAPIError(status_code=resp.status_code, detail=raw_detail)

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -254,6 +254,7 @@ class AgentIdentity:
             filter_mode=mailbox.filter_mode,
             created_at=mailbox.created_at,
             updated_at=mailbox.updated_at,
+            agent_identity_id=mailbox.agent_identity_id,
             filter_mode_change_notice=mailbox.filter_mode_change_notice,
         )
         self._mailbox = linked

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -251,8 +251,10 @@ class AgentIdentity:
             id=mailbox.id,
             email_address=mailbox.email_address,
             display_name=mailbox.display_name,
+            filter_mode=mailbox.filter_mode,
             created_at=mailbox.created_at,
             updated_at=mailbox.updated_at,
+            filter_mode_change_notice=mailbox.filter_mode_change_notice,
         )
         self._mailbox = linked
         self._data.email_address = mailbox.email_address

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -15,6 +15,8 @@ import httpx
 from inkbox._http import HttpTransport
 from inkbox._cookies import CookieJar
 from inkbox.agent_identity import AgentIdentity
+from inkbox.contacts.resources.contacts import ContactsResource
+from inkbox.notes.resources.notes import NotesResource
 from inkbox.agent_signup.types import (
     AgentSignupResponse,
     AgentSignupVerifyResponse,
@@ -28,10 +30,12 @@ from inkbox.identities.types import (
     IdentityMailboxCreateOptions,
     IdentityPhoneNumberCreateOptions,
 )
+from inkbox.mail.resources.contact_rules import MailContactRulesResource
 from inkbox.mail.resources.mailboxes import MailboxesResource
 from inkbox.mail.resources.messages import MessagesResource
 from inkbox.mail.resources.threads import ThreadsResource
 from inkbox.phone.resources.calls import CallsResource
+from inkbox.phone.resources.contact_rules import PhoneContactRulesResource
 from inkbox.phone.resources.numbers import PhoneNumbersResource
 from inkbox.phone.resources.texts import TextsResource
 from inkbox.phone.resources.transcripts import TranscriptsResource
@@ -105,6 +109,12 @@ class Inkbox:
             timeout=timeout,
             cookie_jar=_cookie_jar,
         )
+        self._contacts_http = HttpTransport(
+            api_key=api_key,
+            base_url=_api_root,
+            timeout=timeout,
+            cookie_jar=_cookie_jar,
+        )
         self._phone_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/phone",
@@ -140,16 +150,21 @@ class Inkbox:
         self._mailboxes = MailboxesResource(self._mail_http)
         self._messages = MessagesResource(self._mail_http)
         self._threads = ThreadsResource(self._mail_http)
+        self._mail_contact_rules = MailContactRulesResource(self._mail_http)
 
         self._calls = CallsResource(self._phone_http)
         self._numbers = PhoneNumbersResource(self._phone_http)
         self._texts = TextsResource(self._phone_http)
         self._transcripts = TranscriptsResource(self._phone_http)
+        self._phone_contact_rules = PhoneContactRulesResource(self._phone_http)
 
         self._vault_resource = VaultResource(self._vault_http, api_http=self._root_api_http)
 
         self._signing_keys = SigningKeysResource(self._api_http)
         self._ids_resource = IdentitiesResource(self._ids_http)
+
+        self._contacts = ContactsResource(self._contacts_http)
+        self._notes = NotesResource(self._contacts_http)
 
         if vault_key is not None:
             self._vault_resource.unlock(vault_key)
@@ -170,6 +185,7 @@ class Inkbox:
         self._vault_http.close()
         self._root_api_http.close()
         self._api_http.close()
+        self._contacts_http.close()
 
     ## Public resource accessors
 
@@ -192,6 +208,26 @@ class Inkbox:
     def vault(self) -> VaultResource:
         """Access the encrypted vault (info, unlock, secrets)."""
         return self._vault_resource
+
+    @property
+    def contacts(self) -> ContactsResource:
+        """Org-wide contacts (list, get, create, update, delete, lookup, access, vCards)."""
+        return self._contacts
+
+    @property
+    def notes(self) -> NotesResource:
+        """Org-scoped notes with per-identity access grants."""
+        return self._notes
+
+    @property
+    def mail_contact_rules(self) -> MailContactRulesResource:
+        """Mail per-mailbox allow/block rules (+ org-wide list)."""
+        return self._mail_contact_rules
+
+    @property
+    def phone_contact_rules(self) -> PhoneContactRulesResource:
+        """Phone per-number allow/block rules (+ org-wide list)."""
+        return self._phone_contact_rules
 
     ## Org-level operations
 

--- a/sdk/python/inkbox/contacts/__init__.py
+++ b/sdk/python/inkbox/contacts/__init__.py
@@ -1,0 +1,3 @@
+"""
+inkbox/contacts — org-scoped address book (contacts + access + vCard).
+"""

--- a/sdk/python/inkbox/contacts/resources/__init__.py
+++ b/sdk/python/inkbox/contacts/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Resource modules for the contacts subsystem."""

--- a/sdk/python/inkbox/contacts/resources/contact_access.py
+++ b/sdk/python/inkbox/contacts/resources/contact_access.py
@@ -1,0 +1,62 @@
+"""
+inkbox/contacts/resources/contact_access.py
+
+Per-contact access grant management.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from inkbox.contacts.types import ContactAccess
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/contacts"
+
+
+class ContactAccessResource:
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def list(self, contact_id: UUID | str) -> list[ContactAccess]:
+        """List grants for a single contact.
+
+        Returns 404 from the server if the caller can't see the contact.
+        """
+        data = self._http.get(f"{_BASE}/{contact_id}/access")
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [ContactAccess._from_dict(a) for a in items]
+
+    def grant(
+        self,
+        contact_id: UUID | str,
+        *,
+        identity_id: UUID | str | None = None,
+        wildcard: bool = False,
+    ) -> ContactAccess:
+        """Grant access on a contact. Admin + JWT only.
+
+        Args:
+            identity_id: Identity to grant. Mutually exclusive with ``wildcard``.
+            wildcard: If True, reset the contact to the wildcard grant
+                (every active identity sees the contact).
+        """
+        if wildcard and identity_id is not None:
+            raise ValueError("Pass either identity_id or wildcard=True, not both.")
+        body: dict[str, Any] = {
+            "identity_id": None if wildcard else str(identity_id) if identity_id is not None else None,
+        }
+        data = self._http.post(f"{_BASE}/{contact_id}/access", json=body)
+        return ContactAccess._from_dict(data)
+
+    def revoke(self, contact_id: UUID | str, identity_id: UUID | str) -> None:
+        """Revoke a specific identity's access on a contact.
+
+        Claimed-agent keys may only revoke their own grant; peer revokes
+        receive 403.
+        """
+        self._http.delete(f"{_BASE}/{contact_id}/access/{identity_id}")

--- a/sdk/python/inkbox/contacts/resources/contacts.py
+++ b/sdk/python/inkbox/contacts/resources/contacts.py
@@ -248,5 +248,5 @@ class ContactsResource:
         return Contact._from_dict(data)
 
     def delete(self, contact_id: UUID | str) -> None:
-        """Soft-delete a contact."""
+        """Delete a contact."""
         self._http.delete(f"{_BASE}/{contact_id}")

--- a/sdk/python/inkbox/contacts/resources/contacts.py
+++ b/sdk/python/inkbox/contacts/resources/contacts.py
@@ -1,0 +1,252 @@
+"""
+inkbox/contacts/resources/contacts.py
+
+Contacts CRUD + search + lookup.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import UUID
+
+from inkbox.contacts.resources.contact_access import ContactAccessResource
+from inkbox.contacts.resources.vcards import VCardsResource
+from inkbox.contacts.types import (
+    Contact,
+    ContactAddress,
+    ContactCustomField,
+    ContactDate,
+    ContactEmail,
+    ContactPhone,
+    ContactWebsite,
+)
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/contacts"
+_UNSET = object()
+
+
+def _items_to_wire(items: list[Any] | None) -> list[dict[str, Any]] | None:
+    if items is None:
+        return None
+    return [item.to_wire() if hasattr(item, "to_wire") else item for item in items]
+
+
+class ContactsResource:
+    """Org-wide contacts list with per-identity access control."""
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+        self._access = ContactAccessResource(http)
+        self._vcards = VCardsResource(http)
+
+    @property
+    def access(self) -> ContactAccessResource:
+        """Per-contact access grant management."""
+        return self._access
+
+    @property
+    def vcards(self) -> VCardsResource:
+        """vCard import / export."""
+        return self._vcards
+
+    def list(
+        self,
+        *,
+        q: str | None = None,
+        order: Literal["name", "recent"] | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[Contact]:
+        """List contacts with optional substring search.
+
+        Args:
+            q: Optional case-insensitive substring filter across
+                ``preferred_name``, ``given_name``, ``family_name``,
+                ``company_name``, ``job_title``, and ``notes``. Max 100 chars.
+            order: ``"name"`` or ``"recent"`` sort order (server default applies).
+            limit: Max rows to return.
+            offset: Offset for paging.
+        """
+        params: dict[str, Any] = {}
+        if q is not None:
+            params["q"] = q
+        if order is not None:
+            params["order"] = order
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        data = self._http.get(_BASE, params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [Contact._from_dict(c) for c in items]
+
+    def lookup(
+        self,
+        *,
+        email: str | None = None,
+        email_contains: str | None = None,
+        email_domain: str | None = None,
+        phone: str | None = None,
+        phone_contains: str | None = None,
+    ) -> list[Contact]:
+        """Reverse-lookup contacts by a single field.
+
+        Exactly one of the five arguments must be supplied; passing zero or
+        more than one raises ``ValueError`` before hitting the server.
+        """
+        supplied = {
+            "email": email,
+            "email_contains": email_contains,
+            "email_domain": email_domain,
+            "phone": phone,
+            "phone_contains": phone_contains,
+        }
+        non_none = {k: v for k, v in supplied.items() if v is not None}
+        if len(non_none) != 1:
+            raise ValueError(
+                "lookup() requires exactly one of: email, email_contains, "
+                "email_domain, phone, phone_contains.",
+            )
+        data = self._http.get(f"{_BASE}/lookup", params=non_none)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [Contact._from_dict(c) for c in items]
+
+    def get(self, contact_id: UUID | str) -> Contact:
+        """Fetch a single contact by id."""
+        data = self._http.get(f"{_BASE}/{contact_id}")
+        return Contact._from_dict(data)
+
+    def create(
+        self,
+        *,
+        preferred_name: str | None = None,
+        name_prefix: str | None = None,
+        given_name: str | None = None,
+        middle_name: str | None = None,
+        family_name: str | None = None,
+        name_suffix: str | None = None,
+        company_name: str | None = None,
+        job_title: str | None = None,
+        birthday: date | str | None = None,
+        notes: str | None = None,
+        emails: list[ContactEmail] | None = None,
+        phones: list[ContactPhone] | None = None,
+        websites: list[ContactWebsite] | None = None,
+        dates: list[ContactDate] | None = None,
+        addresses: list[ContactAddress] | None = None,
+        custom_fields: list[ContactCustomField] | None = None,
+        access_identity_ids: list[UUID | str] | None | Literal["wildcard"] = "wildcard",
+    ) -> Contact:
+        """Create a new contact.
+
+        Args:
+            birthday: Optional ISO date (``YYYY-MM-DD``) or :class:`datetime.date`.
+            access_identity_ids: Controls access grants at create time.
+                - ``"wildcard"`` (default) / ``None`` — one wildcard row, every
+                  active identity sees the contact.
+                - ``[]`` — zero grants (only admin + human callers see it).
+                - Explicit list — one per-identity grant each. Capped at 500.
+        """
+        body: dict[str, Any] = {}
+        for name, value in (
+            ("preferred_name", preferred_name),
+            ("name_prefix", name_prefix),
+            ("given_name", given_name),
+            ("middle_name", middle_name),
+            ("family_name", family_name),
+            ("name_suffix", name_suffix),
+            ("company_name", company_name),
+            ("job_title", job_title),
+            ("notes", notes),
+        ):
+            if value is not None:
+                body[name] = value
+        if birthday is not None:
+            body["birthday"] = birthday.isoformat() if isinstance(birthday, date) else birthday
+        for name, items in (
+            ("emails", emails),
+            ("phones", phones),
+            ("websites", websites),
+            ("dates", dates),
+            ("addresses", addresses),
+            ("custom_fields", custom_fields),
+        ):
+            wire = _items_to_wire(items)
+            if wire is not None:
+                body[name] = wire
+        if access_identity_ids == "wildcard":
+            pass
+        elif access_identity_ids is None:
+            body["access_identity_ids"] = None
+        else:
+            body["access_identity_ids"] = [str(i) for i in access_identity_ids]
+        data = self._http.post(_BASE, json=body)
+        return Contact._from_dict(data)
+
+    def update(
+        self,
+        contact_id: UUID | str,
+        *,
+        preferred_name: str | None = _UNSET,  # type: ignore[assignment]
+        name_prefix: str | None = _UNSET,  # type: ignore[assignment]
+        given_name: str | None = _UNSET,  # type: ignore[assignment]
+        middle_name: str | None = _UNSET,  # type: ignore[assignment]
+        family_name: str | None = _UNSET,  # type: ignore[assignment]
+        name_suffix: str | None = _UNSET,  # type: ignore[assignment]
+        company_name: str | None = _UNSET,  # type: ignore[assignment]
+        job_title: str | None = _UNSET,  # type: ignore[assignment]
+        birthday: date | str | None = _UNSET,  # type: ignore[assignment]
+        notes: str | None = _UNSET,  # type: ignore[assignment]
+        emails: list[ContactEmail] | None = _UNSET,  # type: ignore[assignment]
+        phones: list[ContactPhone] | None = _UNSET,  # type: ignore[assignment]
+        websites: list[ContactWebsite] | None = _UNSET,  # type: ignore[assignment]
+        dates: list[ContactDate] | None = _UNSET,  # type: ignore[assignment]
+        addresses: list[ContactAddress] | None = _UNSET,  # type: ignore[assignment]
+        custom_fields: list[ContactCustomField] | None = _UNSET,  # type: ignore[assignment]
+    ) -> Contact:
+        """JSON-merge-patch update.
+
+        Only provided fields are sent; omit a field to leave it unchanged.
+        Pass a scalar as ``None`` to clear it.
+        """
+        body: dict[str, Any] = {}
+        scalar_fields = (
+            ("preferred_name", preferred_name),
+            ("name_prefix", name_prefix),
+            ("given_name", given_name),
+            ("middle_name", middle_name),
+            ("family_name", family_name),
+            ("name_suffix", name_suffix),
+            ("company_name", company_name),
+            ("job_title", job_title),
+            ("notes", notes),
+        )
+        for name, value in scalar_fields:
+            if value is not _UNSET:
+                body[name] = value
+        if birthday is not _UNSET:
+            body["birthday"] = (
+                birthday.isoformat() if isinstance(birthday, date) else birthday
+            )
+        list_fields = (
+            ("emails", emails),
+            ("phones", phones),
+            ("websites", websites),
+            ("dates", dates),
+            ("addresses", addresses),
+            ("custom_fields", custom_fields),
+        )
+        for name, items in list_fields:
+            if items is _UNSET:
+                continue
+            body[name] = _items_to_wire(items) if items is not None else None
+        data = self._http.patch(f"{_BASE}/{contact_id}", json=body)
+        return Contact._from_dict(data)
+
+    def delete(self, contact_id: UUID | str) -> None:
+        """Soft-delete a contact."""
+        self._http.delete(f"{_BASE}/{contact_id}")

--- a/sdk/python/inkbox/contacts/resources/vcards.py
+++ b/sdk/python/inkbox/contacts/resources/vcards.py
@@ -1,0 +1,57 @@
+"""
+inkbox/contacts/resources/vcards.py
+
+vCard import / export.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from inkbox.contacts.types import ContactImportResult
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/contacts"
+_VCARD_CONTENT_TYPE = "text/vcard"
+
+
+class VCardsResource:
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def import_vcards(
+        self,
+        content: str | bytes,
+        *,
+        content_type: str = _VCARD_CONTENT_TYPE,
+    ) -> ContactImportResult:
+        """Bulk-import vCards.
+
+        Args:
+            content: Raw vCard text or bytes. The server caps payload size at
+                5 MiB and at most 1000 cards. Zero cards returns 422.
+            content_type: MIME type to send. Defaults to ``text/vcard``;
+                ``text/x-vcard`` is also accepted.
+        """
+        body = content.encode("utf-8") if isinstance(content, str) else content
+        data = self._http.post_bytes(
+            f"{_BASE}/import",
+            content=body,
+            content_type=content_type,
+        )
+        return ContactImportResult._from_dict(data)
+
+    def export_vcard(self, contact_id: UUID | str) -> str:
+        """Export a single contact as vCard 4.0 text.
+
+        Returns the raw vCard body as a UTF-8 string.
+        """
+        data = self._http.get_bytes(
+            f"{_BASE}/{contact_id}.vcf",
+            accept=_VCARD_CONTENT_TYPE,
+        )
+        return data.decode("utf-8")

--- a/sdk/python/inkbox/contacts/types.py
+++ b/sdk/python/inkbox/contacts/types.py
@@ -1,0 +1,290 @@
+"""
+inkbox/contacts/types.py
+
+Dataclasses for the org-scoped Contacts API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
+
+
+def _opt_uuid(value: Any) -> UUID | None:
+    return UUID(str(value)) if value is not None else None
+
+
+def _opt_date(value: Any) -> date | None:
+    if not value:
+        return None
+    return date.fromisoformat(value) if isinstance(value, str) else value
+
+
+@dataclass
+class ContactEmail:
+    """An email address on a contact card."""
+
+    label: str | None
+    value: str
+    is_primary: bool = False
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactEmail:
+        return cls(
+            label=d.get("label"),
+            value=d["value"],
+            is_primary=bool(d.get("is_primary", False)),
+        )
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"value": self.value}
+        if self.label is not None:
+            body["label"] = self.label
+        if self.is_primary:
+            body["is_primary"] = True
+        return body
+
+
+@dataclass
+class ContactPhone:
+    """A phone number on a contact card (stored E.164)."""
+
+    label: str | None
+    value: str
+    is_primary: bool = False
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactPhone:
+        return cls(
+            label=d.get("label"),
+            value=d["value"],
+            is_primary=bool(d.get("is_primary", False)),
+        )
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"value": self.value}
+        if self.label is not None:
+            body["label"] = self.label
+        if self.is_primary:
+            body["is_primary"] = True
+        return body
+
+
+@dataclass
+class ContactWebsite:
+    label: str | None
+    value: str
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactWebsite:
+        return cls(label=d.get("label"), value=d["value"])
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"value": self.value}
+        if self.label is not None:
+            body["label"] = self.label
+        return body
+
+
+@dataclass
+class ContactDate:
+    label: str | None
+    value: date
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactDate:
+        return cls(label=d.get("label"), value=date.fromisoformat(d["value"]))
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {"value": self.value.isoformat()}
+        if self.label is not None:
+            body["label"] = self.label
+        return body
+
+
+@dataclass
+class ContactAddress:
+    label: str | None
+    street: str | None
+    city: str | None
+    region: str | None
+    postal_code: str | None
+    country: str | None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactAddress:
+        return cls(
+            label=d.get("label"),
+            street=d.get("street"),
+            city=d.get("city"),
+            region=d.get("region"),
+            postal_code=d.get("postal_code"),
+            country=d.get("country"),
+        )
+
+    def to_wire(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        for name in ("label", "street", "city", "region", "postal_code", "country"):
+            value = getattr(self, name)
+            if value is not None:
+                body[name] = value
+        return body
+
+
+@dataclass
+class ContactCustomField:
+    label: str
+    value: str
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactCustomField:
+        return cls(label=d["label"], value=d["value"])
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"label": self.label, "value": self.value}
+
+
+@dataclass
+class ContactAccess:
+    """A single access grant on a contact.
+
+    ``identity_id=None`` means the grant is a wildcard — every active
+    identity can see the contact.
+    """
+
+    id: UUID
+    contact_id: UUID
+    identity_id: UUID | None
+    created_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactAccess:
+        return cls(
+            id=UUID(d["id"]),
+            contact_id=UUID(d["contact_id"]),
+            identity_id=_opt_uuid(d.get("identity_id")),
+            created_at=datetime.fromisoformat(d["created_at"]),
+        )
+
+
+@dataclass
+class Contact:
+    """A contact (address-book entry) owned by your organisation."""
+
+    id: UUID
+    preferred_name: str | None
+    name_prefix: str | None
+    given_name: str | None
+    middle_name: str | None
+    family_name: str | None
+    name_suffix: str | None
+    company_name: str | None
+    job_title: str | None
+    birthday: date | None
+    notes: str | None
+    emails: list[ContactEmail] = field(default_factory=list)
+    phones: list[ContactPhone] = field(default_factory=list)
+    websites: list[ContactWebsite] = field(default_factory=list)
+    dates: list[ContactDate] = field(default_factory=list)
+    addresses: list[ContactAddress] = field(default_factory=list)
+    custom_fields: list[ContactCustomField] = field(default_factory=list)
+    access: list[ContactAccess] = field(default_factory=list)
+    organization_id: str | None = None
+    status: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.fromtimestamp(0))
+    updated_at: datetime = field(default_factory=lambda: datetime.fromtimestamp(0))
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> Contact:
+        return cls(
+            id=UUID(d["id"]),
+            preferred_name=d.get("preferred_name"),
+            name_prefix=d.get("name_prefix"),
+            given_name=d.get("given_name"),
+            middle_name=d.get("middle_name"),
+            family_name=d.get("family_name"),
+            name_suffix=d.get("name_suffix"),
+            company_name=d.get("company_name"),
+            job_title=d.get("job_title"),
+            birthday=_opt_date(d.get("birthday")),
+            notes=d.get("notes"),
+            emails=[ContactEmail._from_dict(e) for e in d.get("emails") or []],
+            phones=[ContactPhone._from_dict(p) for p in d.get("phones") or []],
+            websites=[ContactWebsite._from_dict(w) for w in d.get("websites") or []],
+            dates=[ContactDate._from_dict(dt) for dt in d.get("dates") or []],
+            addresses=[ContactAddress._from_dict(a) for a in d.get("addresses") or []],
+            custom_fields=[
+                ContactCustomField._from_dict(c) for c in d.get("custom_fields") or []
+            ],
+            access=[ContactAccess._from_dict(a) for a in d.get("access") or []],
+            organization_id=d.get("organization_id"),
+            status=d.get("status"),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+        )
+
+
+@dataclass
+class ContactImportResultItem:
+    """One card's result inside a bulk vCard import response.
+
+    Attributes:
+        index: 0-based position within the uploaded vCard stream.
+        status: ``"created"`` if the card was stored, ``"error"`` otherwise.
+        contact: The resulting :class:`Contact` when ``status == "created"``;
+            ``None`` otherwise.
+        error: The rejection reason when ``status == "error"``; ``None`` when
+            the card was created successfully.
+    """
+
+    index: int
+    status: str
+    contact: "Contact | None" = None
+    error: str | None = None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactImportResultItem:
+        contact_payload = d.get("contact")
+        return cls(
+            index=int(d["index"]),
+            status=str(d["status"]),
+            contact=Contact._from_dict(contact_payload) if contact_payload else None,
+            error=d.get("error"),
+        )
+
+
+@dataclass
+class ContactImportResult:
+    """Result of a bulk vCard import (always 200 when the request parsed).
+
+    Attributes:
+        created_count: Number of cards that were stored.
+        error_count: Number of cards that failed to parse / validate.
+        results: Per-card outcome in submission order.
+    """
+
+    created_count: int
+    error_count: int
+    results: list[ContactImportResultItem] = field(default_factory=list)
+
+    @property
+    def created_ids(self) -> list[UUID]:
+        """IDs of successfully-created contacts, in submission order."""
+        return [item.contact.id for item in self.results if item.contact is not None]
+
+    @property
+    def errors(self) -> list[ContactImportResultItem]:
+        """Only the items whose ``status == "error"``."""
+        return [item for item in self.results if item.status == "error"]
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ContactImportResult:
+        return cls(
+            created_count=int(d["created_count"]),
+            error_count=int(d["error_count"]),
+            results=[
+                ContactImportResultItem._from_dict(r) for r in d.get("results") or []
+            ],
+        )

--- a/sdk/python/inkbox/contacts/types.py
+++ b/sdk/python/inkbox/contacts/types.py
@@ -59,12 +59,12 @@ class ContactPhone:
     def _from_dict(cls, d: dict[str, Any]) -> ContactPhone:
         return cls(
             label=d.get("label"),
-            value=d["value"],
+            value=d["value_e164"],
             is_primary=bool(d.get("is_primary", False)),
         )
 
     def to_wire(self) -> dict[str, Any]:
-        body: dict[str, Any] = {"value": self.value}
+        body: dict[str, Any] = {"value_e164": self.value}
         if self.label is not None:
             body["label"] = self.label
         if self.is_primary:

--- a/sdk/python/inkbox/contacts/types.py
+++ b/sdk/python/inkbox/contacts/types.py
@@ -79,10 +79,10 @@ class ContactWebsite:
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> ContactWebsite:
-        return cls(label=d.get("label"), value=d["value"])
+        return cls(label=d.get("label"), value=d["url"])
 
     def to_wire(self) -> dict[str, Any]:
-        body: dict[str, Any] = {"value": self.value}
+        body: dict[str, Any] = {"url": self.value}
         if self.label is not None:
             body["label"] = self.label
         return body
@@ -95,10 +95,10 @@ class ContactDate:
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> ContactDate:
-        return cls(label=d.get("label"), value=date.fromisoformat(d["value"]))
+        return cls(label=d.get("label"), value=date.fromisoformat(d["date"]))
 
     def to_wire(self) -> dict[str, Any]:
-        body: dict[str, Any] = {"value": self.value.isoformat()}
+        body: dict[str, Any] = {"date": self.value.isoformat()}
         if self.label is not None:
             body["label"] = self.label
         return body
@@ -120,16 +120,18 @@ class ContactAddress:
             street=d.get("street"),
             city=d.get("city"),
             region=d.get("region"),
-            postal_code=d.get("postal_code"),
+            postal_code=d.get("postal"),
             country=d.get("country"),
         )
 
     def to_wire(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
-        for name in ("label", "street", "city", "region", "postal_code", "country"):
+        for name in ("label", "street", "city", "region", "country"):
             value = getattr(self, name)
             if value is not None:
                 body[name] = value
+        if self.postal_code is not None:
+            body["postal"] = self.postal_code
         return body
 
 

--- a/sdk/python/inkbox/exceptions.py
+++ b/sdk/python/inkbox/exceptions.py
@@ -6,6 +6,9 @@ Canonical exception types for the Inkbox SDK.
 
 from __future__ import annotations
 
+from typing import Any
+from uuid import UUID
+
 
 class InkboxError(Exception):
     """
@@ -25,12 +28,48 @@ class InkboxAPIError(InkboxError):
 
     Attributes:
         status_code: HTTP status code.
-        detail: Error detail from the response body.
+        detail: Error detail from the response body. May be a human-readable
+            string, or a structured ``dict`` for errors that carry extra
+            machine-readable fields (e.g. ``{"existing_rule_id": ..., ...}``).
     """
 
-    def __init__(self, status_code: int, detail: str) -> None:
+    def __init__(self, status_code: int, detail: str | dict[str, Any]) -> None:
         super().__init__(
             f"HTTP {status_code}: {detail}"
         )
         self.status_code = status_code
-        self.detail = detail
+        self.detail: str | dict[str, Any] = detail
+
+
+class DuplicateContactRuleError(InkboxAPIError):
+    """
+    Raised on 409 when creating a mail or phone contact rule that duplicates
+    an existing (match_type, match_target) pair on the same resource.
+
+    Attributes:
+        existing_rule_id: UUID of the already-existing rule.
+        detail: The full structured detail dict from the server.
+    """
+
+    def __init__(self, status_code: int, detail: dict[str, Any]) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+        self.existing_rule_id: UUID = UUID(str(detail["existing_rule_id"]))
+
+
+class RedundantContactAccessGrantError(InkboxAPIError):
+    """
+    Raised on 409 when posting a contact-access grant that is redundant
+    under the current access model (e.g. adding a per-identity grant on
+    top of an active wildcard).
+
+    Attributes:
+        error: Discriminator string from the server (``"redundant_grant"``).
+        detail_message: Human-readable explanation from the server's
+            ``detail`` field.
+        detail: The full structured detail dict from the server.
+    """
+
+    def __init__(self, status_code: int, detail: dict[str, Any]) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+        self.error: str = str(detail.get("error", "redundant_grant"))
+        self.detail_message: str = str(detail.get("detail", ""))

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
+from inkbox.mail.types import FilterMode, FilterModeChangeNotice
+
 
 @dataclass
 class IdentityMailboxCreateOptions:
@@ -102,17 +104,24 @@ class IdentityMailbox:
     id: UUID
     email_address: str
     display_name: str | None
+    filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> IdentityMailbox:
+        notice = d.get("filter_mode_change_notice")
         return cls(
             id=UUID(d["id"]),
             email_address=d["email_address"],
             display_name=d.get("display_name"),
+            filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            filter_mode_change_notice=(
+                FilterModeChangeNotice._from_dict(notice) if notice else None
+            ),
         )
 
 
@@ -127,11 +136,14 @@ class IdentityPhoneNumber:
     incoming_call_action: str
     client_websocket_url: str | None
     incoming_text_webhook_url: str | None
+    filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> IdentityPhoneNumber:
+        notice = d.get("filter_mode_change_notice")
         return cls(
             id=UUID(d["id"]),
             number=d["number"],
@@ -140,8 +152,12 @@ class IdentityPhoneNumber:
             incoming_call_action=d["incoming_call_action"],
             client_websocket_url=d.get("client_websocket_url"),
             incoming_text_webhook_url=d.get("incoming_text_webhook_url"),
+            filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            filter_mode_change_notice=(
+                FilterModeChangeNotice._from_dict(notice) if notice else None
+            ),
         )
 
 

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -99,7 +99,11 @@ def vault_secret_ids_to_wire(
 
 @dataclass
 class IdentityMailbox:
-    """Mailbox channel linked to an agent identity."""
+    """Mailbox channel linked to an agent identity.
+
+    ``agent_identity_id`` mirrors the same field on :class:`Mailbox`;
+    on the embedded variant it always equals the owning identity's ID.
+    """
 
     id: UUID
     email_address: str
@@ -107,11 +111,13 @@ class IdentityMailbox:
     filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    agent_identity_id: UUID | None = None
     filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> IdentityMailbox:
         notice = d.get("filter_mode_change_notice")
+        agent_identity_id = d.get("agent_identity_id")
         return cls(
             id=UUID(d["id"]),
             email_address=d["email_address"],
@@ -119,6 +125,7 @@ class IdentityMailbox:
             filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            agent_identity_id=UUID(agent_identity_id) if agent_identity_id else None,
             filter_mode_change_notice=(
                 FilterModeChangeNotice._from_dict(notice) if notice else None
             ),
@@ -127,7 +134,11 @@ class IdentityMailbox:
 
 @dataclass
 class IdentityPhoneNumber:
-    """Phone number channel linked to an agent identity."""
+    """Phone number channel linked to an agent identity.
+
+    ``agent_identity_id`` mirrors the same field on :class:`PhoneNumber`;
+    on the embedded variant it always equals the owning identity's ID.
+    """
 
     id: UUID
     number: str
@@ -139,11 +150,13 @@ class IdentityPhoneNumber:
     filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    agent_identity_id: UUID | None = None
     filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> IdentityPhoneNumber:
         notice = d.get("filter_mode_change_notice")
+        agent_identity_id = d.get("agent_identity_id")
         return cls(
             id=UUID(d["id"]),
             number=d["number"],
@@ -155,6 +168,7 @@ class IdentityPhoneNumber:
             filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            agent_identity_id=UUID(agent_identity_id) if agent_identity_id else None,
             filter_mode_change_notice=(
                 FilterModeChangeNotice._from_dict(notice) if notice else None
             ),

--- a/sdk/python/inkbox/mail/resources/contact_rules.py
+++ b/sdk/python/inkbox/mail/resources/contact_rules.py
@@ -70,9 +70,9 @@ class MailContactRulesResource:
         action: MailRuleAction | str,
         match_type: MailRuleMatchType | str,
         match_target: str,
-        status: ContactRuleStatus | str | None = None,
     ) -> MailContactRule:
-        """Create a rule.
+        """Create a rule. New rules are always ``active``; use
+        :meth:`update` to pause one after creation.
 
         Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
         rule with the same ``(match_type, match_target)`` already exists.
@@ -84,8 +84,6 @@ class MailContactRulesResource:
             ),
             "match_target": match_target,
         }
-        if status is not None:
-            body["status"] = status.value if isinstance(status, ContactRuleStatus) else status
         data = self._http.post(_rule_path(email_address), json=body)
         return MailContactRule._from_dict(data)
 

--- a/sdk/python/inkbox/mail/resources/contact_rules.py
+++ b/sdk/python/inkbox/mail/resources/contact_rules.py
@@ -1,0 +1,152 @@
+"""
+inkbox/mail/resources/contact_rules.py
+
+Mail contact rules (per-mailbox allow/block rules + org-wide list).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from inkbox.mail.types import (
+    ContactRuleStatus,
+    MailContactRule,
+    MailRuleAction,
+    MailRuleMatchType,
+)
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/mailboxes"
+_ORG_BASE = "/contact-rules"
+_UNSET = object()
+
+
+def _rule_path(email_address: str, rule_id: UUID | str | None = None) -> str:
+    base = f"{_BASE}/{email_address}/contact-rules"
+    return base if rule_id is None else f"{base}/{rule_id}"
+
+
+class MailContactRulesResource:
+    """Allow/block rules scoped to mail mailboxes."""
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def list(
+        self,
+        email_address: str,
+        *,
+        action: MailRuleAction | str | None = None,
+        match_type: MailRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[MailContactRule]:
+        params: dict[str, Any] = {}
+        if action is not None:
+            params["action"] = action.value if isinstance(action, MailRuleAction) else action
+        if match_type is not None:
+            params["match_type"] = (
+                match_type.value if isinstance(match_type, MailRuleMatchType) else match_type
+            )
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        data = self._http.get(_rule_path(email_address), params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [MailContactRule._from_dict(r) for r in items]
+
+    def get(self, email_address: str, rule_id: UUID | str) -> MailContactRule:
+        data = self._http.get(_rule_path(email_address, rule_id))
+        return MailContactRule._from_dict(data)
+
+    def create(
+        self,
+        email_address: str,
+        *,
+        action: MailRuleAction | str,
+        match_type: MailRuleMatchType | str,
+        match_target: str,
+        status: ContactRuleStatus | str | None = None,
+    ) -> MailContactRule:
+        """Create a rule.
+
+        Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
+        rule with the same ``(match_type, match_target)`` already exists.
+        """
+        body: dict[str, Any] = {
+            "action": action.value if isinstance(action, MailRuleAction) else action,
+            "match_type": (
+                match_type.value if isinstance(match_type, MailRuleMatchType) else match_type
+            ),
+            "match_target": match_target,
+        }
+        if status is not None:
+            body["status"] = status.value if isinstance(status, ContactRuleStatus) else status
+        data = self._http.post(_rule_path(email_address), json=body)
+        return MailContactRule._from_dict(data)
+
+    def update(
+        self,
+        email_address: str,
+        rule_id: UUID | str,
+        *,
+        action: MailRuleAction | str = _UNSET,  # type: ignore[assignment]
+        status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
+    ) -> MailContactRule:
+        """Update ``action`` or ``status`` (admin-only).
+
+        ``match_type`` and ``match_target`` are immutable — delete + re-create
+        to change them.
+        """
+        body: dict[str, Any] = {}
+        if action is not _UNSET:
+            body["action"] = (
+                action.value if isinstance(action, MailRuleAction) else action
+            )
+        if status is not _UNSET:
+            body["status"] = (
+                status.value if isinstance(status, ContactRuleStatus) else status
+            )
+        data = self._http.patch(_rule_path(email_address, rule_id), json=body)
+        return MailContactRule._from_dict(data)
+
+    def delete(self, email_address: str, rule_id: UUID | str) -> None:
+        """Soft-delete a rule (admin-only)."""
+        self._http.delete(_rule_path(email_address, rule_id))
+
+    def list_all(
+        self,
+        *,
+        mailbox_id: UUID | str | None = None,
+        action: MailRuleAction | str | None = None,
+        match_type: MailRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[MailContactRule]:
+        """Org-wide list of mail contact rules (admin-only).
+
+        Args:
+            mailbox_id: Narrow to a single mailbox by id.
+            action: Filter by ``allow`` or ``block``.
+            match_type: Filter by ``exact_email`` or ``domain``.
+        """
+        params: dict[str, Any] = {}
+        if mailbox_id is not None:
+            params["mailbox_id"] = str(mailbox_id)
+        if action is not None:
+            params["action"] = action.value if isinstance(action, MailRuleAction) else action
+        if match_type is not None:
+            params["match_type"] = (
+                match_type.value if isinstance(match_type, MailRuleMatchType) else match_type
+            )
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        data = self._http.get(_ORG_BASE, params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [MailContactRule._from_dict(r) for r in items]

--- a/sdk/python/inkbox/mail/resources/contact_rules.py
+++ b/sdk/python/inkbox/mail/resources/contact_rules.py
@@ -115,7 +115,7 @@ class MailContactRulesResource:
         return MailContactRule._from_dict(data)
 
     def delete(self, email_address: str, rule_id: UUID | str) -> None:
-        """Soft-delete a rule (admin-only)."""
+        """Delete a rule (admin-only)."""
         self._http.delete(_rule_path(email_address, rule_id))
 
     def list_all(

--- a/sdk/python/inkbox/mail/resources/mailboxes.py
+++ b/sdk/python/inkbox/mail/resources/mailboxes.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from inkbox.mail.types import Mailbox, Message
+from inkbox.mail.types import FilterMode, Mailbox, Message
 
 if TYPE_CHECKING:
     from inkbox._http import HttpTransport
@@ -66,6 +66,7 @@ class MailboxesResource:
         *,
         display_name: str | None = _UNSET,  # type: ignore[assignment]
         webhook_url: str | None = _UNSET,  # type: ignore[assignment]
+        filter_mode: FilterMode | str = _UNSET,  # type: ignore[assignment]
     ) -> Mailbox:
         """Update mutable mailbox fields.
 
@@ -76,15 +77,23 @@ class MailboxesResource:
             email_address: Full email address of the mailbox to update.
             display_name: New human-readable sender name.
             webhook_url: HTTPS URL to receive webhook events, or ``None`` to unsubscribe.
+            filter_mode: ``"whitelist"`` or ``"blacklist"``. Admin-only on the
+                server — agent-scoped keys will receive 403.
 
         Returns:
-            The updated mailbox.
+            The updated mailbox. When ``filter_mode`` was supplied and the
+            value actually changed, ``mailbox.filter_mode_change_notice`` is
+            populated; otherwise it's ``None``.
         """
         body: dict[str, Any] = {}
         if display_name is not _UNSET:
             body["display_name"] = display_name
         if webhook_url is not _UNSET:
             body["webhook_url"] = webhook_url
+        if filter_mode is not _UNSET:
+            body["filter_mode"] = (
+                filter_mode.value if isinstance(filter_mode, FilterMode) else filter_mode
+            )
         data = self._http.patch(
             f"{_BASE}/{email_address}",
             json=body,

--- a/sdk/python/inkbox/mail/resources/messages.py
+++ b/sdk/python/inkbox/mail/resources/messages.py
@@ -189,7 +189,7 @@ class MessagesResource:
         *,
         redirect: bool = False,
     ) -> dict[str, Any]:
-        """Get a presigned URL for a message attachment.
+        """Get a temporary signed URL for a message attachment.
 
         Args:
             email_address: Full email address of the owning mailbox.

--- a/sdk/python/inkbox/mail/resources/threads.py
+++ b/sdk/python/inkbox/mail/resources/threads.py
@@ -115,9 +115,9 @@ class ThreadsResource:
             email_address: Full email address of the owning mailbox.
             thread_id: UUID of the thread.
             folder: New folder — ``inbox`` | ``spam`` | ``archive``. The
-                ``blocked`` folder is server-assigned by the contact-rule
-                engine at ingest and cannot be set by clients; passing it
-                raises ``ValueError`` without making an HTTP call.
+                ``blocked`` folder is server-assigned and cannot be set by
+                clients; passing it raises ``ValueError`` without making an
+                HTTP call.
         """
         body: dict[str, Any] = {}
         if folder is not _UNSET:

--- a/sdk/python/inkbox/mail/resources/threads.py
+++ b/sdk/python/inkbox/mail/resources/threads.py
@@ -1,20 +1,22 @@
 """
 inkbox/mail/resources/threads.py
 
-Thread operations: list (auto-paginated), get with messages, delete.
+Thread operations: list (auto-paginated), get with messages, folder
+listing, per-thread update, and delete.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 from uuid import UUID
 
-from inkbox.mail.types import Thread, ThreadDetail
+from inkbox.mail.types import Thread, ThreadDetail, ThreadFolder
 
 if TYPE_CHECKING:
     from inkbox._http import HttpTransport
 
 _DEFAULT_PAGE_SIZE = 50
+_UNSET = object()
 
 
 class ThreadsResource:
@@ -26,40 +28,63 @@ class ThreadsResource:
         self,
         email_address: str,
         *,
+        folder: ThreadFolder | str | None = None,
         page_size: int = _DEFAULT_PAGE_SIZE,
     ) -> Iterator[Thread]:
-        """Iterator over all threads in a mailbox, most recent activity first.
+        """Iterator over threads in a mailbox, most recent activity first.
 
         Pagination is handled automatically — just iterate.
 
         Args:
             email_address: Full email address of the mailbox.
+            folder: Optional folder filter (``inbox`` | ``spam`` |
+                ``blocked`` | ``archive``). When omitted, the server returns
+                all visible folders for the caller.
             page_size: Number of threads fetched per API call (1–100).
-
-        Example::
-
-            for thread in client.threads.list(email_address):
-                print(thread.subject, thread.message_count)
         """
-        return self._paginate(email_address, page_size=page_size)
+        folder_value: str | None
+        if folder is None:
+            folder_value = None
+        elif isinstance(folder, ThreadFolder):
+            folder_value = folder.value
+        else:
+            folder_value = folder
+        return self._paginate(email_address, folder=folder_value, page_size=page_size)
 
     def _paginate(
         self,
         email_address: str,
         *,
+        folder: str | None,
         page_size: int,
     ) -> Iterator[Thread]:
         cursor: str | None = None
         while True:
+            params: dict[str, Any] = {"limit": page_size, "cursor": cursor}
+            if folder is not None:
+                params["folder"] = folder
             page = self._http.get(
                 f"/mailboxes/{email_address}/threads",
-                params={"limit": page_size, "cursor": cursor},
+                params=params,
             )
             for item in page["items"]:
                 yield Thread._from_dict(item)
             if not page["has_more"]:
                 break
             cursor = page["next_cursor"]
+
+    def list_folders(self, email_address: str) -> list[ThreadFolder]:
+        """Return the distinct folders that have at least one thread.
+
+        Args:
+            email_address: Full email address of the mailbox.
+
+        Returns:
+            Sorted list of :class:`ThreadFolder` values that currently hold
+            at least one non-deleted thread in this mailbox.
+        """
+        data = self._http.get(f"/mailboxes/{email_address}/threads/folders")
+        return [ThreadFolder(f) for f in data]
 
     def get(self, email_address: str, thread_id: UUID | str) -> ThreadDetail:
         """Get a thread with all its messages inlined.
@@ -73,6 +98,41 @@ class ThreadsResource:
         """
         data = self._http.get(f"/mailboxes/{email_address}/threads/{thread_id}")
         return ThreadDetail._from_dict(data)
+
+    def update(
+        self,
+        email_address: str,
+        thread_id: UUID | str,
+        *,
+        folder: ThreadFolder | str = _UNSET,  # type: ignore[assignment]
+    ) -> Thread:
+        """Update mutable thread fields.
+
+        Returns a bare :class:`Thread` (no inlined messages). Use
+        :meth:`get` to refetch the thread with messages attached.
+
+        Args:
+            email_address: Full email address of the owning mailbox.
+            thread_id: UUID of the thread.
+            folder: New folder — ``inbox`` | ``spam`` | ``archive``. The
+                ``blocked`` folder is server-assigned by the contact-rule
+                engine at ingest and cannot be set by clients; passing it
+                raises ``ValueError`` without making an HTTP call.
+        """
+        body: dict[str, Any] = {}
+        if folder is not _UNSET:
+            folder_value = folder.value if isinstance(folder, ThreadFolder) else folder
+            if folder_value == ThreadFolder.BLOCKED.value:
+                raise ValueError(
+                    "folder='blocked' is server-assigned and cannot be set by "
+                    "clients — the server will reject this PATCH.",
+                )
+            body["folder"] = folder_value
+        data = self._http.patch(
+            f"/mailboxes/{email_address}/threads/{thread_id}",
+            json=body,
+        )
+        return Thread._from_dict(data)
 
     def delete(self, email_address: str, thread_id: UUID | str) -> None:
         """Delete a thread."""

--- a/sdk/python/inkbox/mail/types.py
+++ b/sdk/python/inkbox/mail/types.py
@@ -114,7 +114,12 @@ def _dt(value: str | None) -> datetime | None:
 
 @dataclass
 class Mailbox:
-    """An Inkbox mailbox (an email address owned by your organisation)."""
+    """An Inkbox mailbox (an email address owned by your organisation).
+
+    ``agent_identity_id`` is the UUID of the owning agent identity, or
+    ``None`` if the mailbox is standalone (not tied to any agent).
+    Always populated on every mailbox response.
+    """
 
     id: UUID
     email_address: str
@@ -123,11 +128,13 @@ class Mailbox:
     filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    agent_identity_id: UUID | None = None
     filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> Mailbox:
         notice = d.get("filter_mode_change_notice")
+        agent_identity_id = d.get("agent_identity_id")
         return cls(
             id=UUID(d["id"]),
             email_address=d["email_address"],
@@ -136,6 +143,7 @@ class Mailbox:
             filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            agent_identity_id=UUID(agent_identity_id) if agent_identity_id else None,
             filter_mode_change_notice=(
                 FilterModeChangeNotice._from_dict(notice) if notice else None
             ),

--- a/sdk/python/inkbox/mail/types.py
+++ b/sdk/python/inkbox/mail/types.py
@@ -25,6 +25,89 @@ class MessageDirection(StrEnum):
     OUTBOUND = "outbound"
 
 
+class FilterMode(StrEnum):
+    """
+    Contact-rule filter mode on a mailbox or phone number.
+
+    Attributes:
+        WHITELIST: Only contacts matching an ``allow`` rule are delivered;
+            everything else is blocked.
+        BLACKLIST: Everything is delivered except contacts matching a
+            ``block`` rule. This is the default.
+    """
+
+    WHITELIST = "whitelist"
+    BLACKLIST = "blacklist"
+
+
+class ThreadFolder(StrEnum):
+    """
+    Logical folder a thread lives in.
+
+    ``BLOCKED`` is server-assigned by the contact-rule engine at ingest;
+    clients cannot move a thread into ``BLOCKED``.
+    """
+
+    INBOX = "inbox"
+    SPAM = "spam"
+    BLOCKED = "blocked"
+    ARCHIVE = "archive"
+
+
+class MailRuleAction(StrEnum):
+    """Whether a matching address is allowed through or blocked."""
+
+    ALLOW = "allow"
+    BLOCK = "block"
+
+
+class MailRuleMatchType(StrEnum):
+    """What a mail contact rule matches on."""
+
+    EXACT_EMAIL = "exact_email"
+    DOMAIN = "domain"
+
+
+class ContactRuleStatus(StrEnum):
+    """Whether a contact rule is currently enforced."""
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+
+
+@dataclass
+class FilterModeChangeNotice:
+    """Summary returned on PATCH when ``filter_mode`` actually changed.
+
+    Reports how many existing active rules are now redundant under the
+    new mode so the caller can prompt for cleanup. The blacklist <-> whitelist
+    flip does not touch the contact-rules table — redundant rules still
+    evaluate correctly, they just match the new default verdict.
+
+    Attributes:
+        new_filter_mode: The mode the resource was just flipped to.
+        redundant_rule_action: The action whose rules are now redundant —
+            ``"block"`` under whitelist, ``"allow"`` under blacklist. Typed as
+            a free-form string to tolerate new server values; match against
+            :class:`MailRuleAction` / :class:`PhoneRuleAction` values.
+        redundant_rule_count: Count of active rules whose action equals
+            ``redundant_rule_action``. ``0`` is a clean flip. Paused and
+            soft-deleted rules are not counted.
+    """
+
+    new_filter_mode: FilterMode
+    redundant_rule_action: str
+    redundant_rule_count: int
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> FilterModeChangeNotice:
+        return cls(
+            new_filter_mode=FilterMode(d["new_filter_mode"]),
+            redundant_rule_action=str(d["redundant_rule_action"]),
+            redundant_rule_count=int(d["redundant_rule_count"]),
+        )
+
+
 def _dt(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value) if value else None
 
@@ -37,18 +120,25 @@ class Mailbox:
     email_address: str
     display_name: str | None
     webhook_url: str | None
+    filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> Mailbox:
+        notice = d.get("filter_mode_change_notice")
         return cls(
             id=UUID(d["id"]),
             email_address=d["email_address"],
             display_name=d.get("display_name"),
             webhook_url=d.get("webhook_url"),
+            filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            filter_mode_change_notice=(
+                FilterModeChangeNotice._from_dict(notice) if notice else None
+            ),
         )
 
 
@@ -134,6 +224,7 @@ class Thread:
     id: UUID
     mailbox_id: UUID
     subject: str | None
+    folder: ThreadFolder
     message_count: int
     last_message_at: datetime
     created_at: datetime
@@ -144,6 +235,7 @@ class Thread:
             id=UUID(d["id"]),
             mailbox_id=UUID(d["mailbox_id"]),
             subject=d.get("subject"),
+            folder=ThreadFolder(d.get("folder", "inbox")),
             message_count=d["message_count"],
             last_message_at=datetime.fromisoformat(d["last_message_at"]),
             created_at=datetime.fromisoformat(d["created_at"]),
@@ -164,3 +256,29 @@ class ThreadDetail(Thread):
             messages=[Message._from_dict(m) for m in d.get("messages", [])],
         )
 
+
+@dataclass
+class MailContactRule:
+    """An inbound/outbound allow/block rule scoped to a mailbox."""
+
+    id: UUID
+    mailbox_id: UUID
+    action: MailRuleAction
+    match_type: MailRuleMatchType
+    match_target: str
+    status: ContactRuleStatus
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> MailContactRule:
+        return cls(
+            id=UUID(d["id"]),
+            mailbox_id=UUID(d["mailbox_id"]),
+            action=MailRuleAction(d["action"]),
+            match_type=MailRuleMatchType(d["match_type"]),
+            match_target=d["match_target"],
+            status=ContactRuleStatus(d.get("status", "active")),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+        )

--- a/sdk/python/inkbox/mail/types.py
+++ b/sdk/python/inkbox/mail/types.py
@@ -44,8 +44,8 @@ class ThreadFolder(StrEnum):
     """
     Logical folder a thread lives in.
 
-    ``BLOCKED`` is server-assigned by the contact-rule engine at ingest;
-    clients cannot move a thread into ``BLOCKED``.
+    ``BLOCKED`` is server-assigned; clients cannot move a thread into
+    ``BLOCKED``.
     """
 
     INBOX = "inbox"
@@ -92,7 +92,7 @@ class FilterModeChangeNotice:
             :class:`MailRuleAction` / :class:`PhoneRuleAction` values.
         redundant_rule_count: Count of active rules whose action equals
             ``redundant_rule_action``. ``0`` is a clean flip. Paused and
-            soft-deleted rules are not counted.
+            deleted rules are not counted.
     """
 
     new_filter_mode: FilterMode

--- a/sdk/python/inkbox/notes/__init__.py
+++ b/sdk/python/inkbox/notes/__init__.py
@@ -1,0 +1,3 @@
+"""
+inkbox/notes — org-scoped notes with per-identity access grants.
+"""

--- a/sdk/python/inkbox/notes/resources/__init__.py
+++ b/sdk/python/inkbox/notes/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Resource modules for the notes subsystem."""

--- a/sdk/python/inkbox/notes/resources/note_access.py
+++ b/sdk/python/inkbox/notes/resources/note_access.py
@@ -1,0 +1,43 @@
+"""
+inkbox/notes/resources/note_access.py
+
+Per-note access grant management. No wildcards.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from inkbox.notes.types import NoteAccess
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/notes"
+
+
+class NoteAccessResource:
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def list(self, note_id: UUID | str) -> list[NoteAccess]:
+        data = self._http.get(f"{_BASE}/{note_id}/access")
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [NoteAccess._from_dict(a) for a in items]
+
+    def grant(self, note_id: UUID | str, *, identity_id: UUID | str) -> NoteAccess:
+        """Grant access on a note. Admin + JWT only."""
+        data = self._http.post(
+            f"{_BASE}/{note_id}/access",
+            json={"identity_id": str(identity_id)},
+        )
+        return NoteAccess._from_dict(data)
+
+    def revoke(self, note_id: UUID | str, identity_id: UUID | str) -> None:
+        """Revoke a specific identity's access on a note.
+
+        Claimed-agent keys may only revoke their own grant.
+        """
+        self._http.delete(f"{_BASE}/{note_id}/access/{identity_id}")

--- a/sdk/python/inkbox/notes/resources/notes.py
+++ b/sdk/python/inkbox/notes/resources/notes.py
@@ -1,0 +1,104 @@
+"""
+inkbox/notes/resources/notes.py
+
+Notes CRUD + per-note access subresource.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import UUID
+
+from inkbox.notes.resources.note_access import NoteAccessResource
+from inkbox.notes.types import Note
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/notes"
+_UNSET = object()
+
+
+class NotesResource:
+    """Org-scoped notes with per-identity access grants."""
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+        self._access = NoteAccessResource(http)
+
+    @property
+    def access(self) -> NoteAccessResource:
+        return self._access
+
+    def list(
+        self,
+        *,
+        q: str | None = None,
+        identity_id: UUID | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        order: Literal["recent", "created"] | str | None = None,
+    ) -> list[Note]:
+        """List accessible notes.
+
+        Args:
+            q: Substring search (≤200 chars).
+            identity_id: Filter to notes visible to a specific identity.
+            limit: 1–200 (server default 50).
+            offset: Offset for paging.
+            order: ``"recent"`` (default) or ``"created"``.
+        """
+        params: dict[str, Any] = {}
+        if q is not None:
+            params["q"] = q
+        if identity_id is not None:
+            params["identity_id"] = str(identity_id)
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        if order is not None:
+            params["order"] = order
+        data = self._http.get(_BASE, params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [Note._from_dict(n) for n in items]
+
+    def get(self, note_id: UUID | str) -> Note:
+        data = self._http.get(f"{_BASE}/{note_id}")
+        return Note._from_dict(data)
+
+    def create(self, *, body: str, title: str | None = None) -> Note:
+        """Create a note.
+
+        Agent-created notes auto-grant the creator. Human-created notes start
+        with zero grants and are invisible to all agents until granted.
+        """
+        payload: dict[str, Any] = {"body": body}
+        if title is not None:
+            payload["title"] = title
+        data = self._http.post(_BASE, json=payload)
+        return Note._from_dict(data)
+
+    def update(
+        self,
+        note_id: UUID | str,
+        *,
+        title: str | None = _UNSET,  # type: ignore[assignment]
+        body: str = _UNSET,  # type: ignore[assignment]
+    ) -> Note:
+        """JSON-merge-patch update.
+
+        ``title=None`` clears the title column (200 OK). ``body=None`` is
+        **not** a legal operation — the body column is required; the server
+        returns 422 if you try.
+        """
+        payload: dict[str, Any] = {}
+        if title is not _UNSET:
+            payload["title"] = title
+        if body is not _UNSET:
+            payload["body"] = body
+        data = self._http.patch(f"{_BASE}/{note_id}", json=payload)
+        return Note._from_dict(data)
+
+    def delete(self, note_id: UUID | str) -> None:
+        self._http.delete(f"{_BASE}/{note_id}")

--- a/sdk/python/inkbox/notes/types.py
+++ b/sdk/python/inkbox/notes/types.py
@@ -1,0 +1,60 @@
+"""
+inkbox/notes/types.py
+
+Dataclasses for the Notes API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+
+@dataclass
+class NoteAccess:
+    """A single grant on a note. No wildcard for notes — every grant is explicit."""
+
+    id: UUID
+    note_id: UUID
+    identity_id: UUID
+    created_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> NoteAccess:
+        return cls(
+            id=UUID(d["id"]),
+            note_id=UUID(d["note_id"]),
+            identity_id=UUID(d["identity_id"]),
+            created_at=datetime.fromisoformat(d["created_at"]),
+        )
+
+
+@dataclass
+class Note:
+    """An org-scoped note (free-form markdown body)."""
+
+    id: UUID
+    organization_id: str
+    created_by: str
+    title: str | None
+    body: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    access: list[NoteAccess] = field(default_factory=list)
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> Note:
+        return cls(
+            id=UUID(d["id"]),
+            organization_id=str(d["organization_id"]),
+            created_by=str(d["created_by"]),
+            title=d.get("title"),
+            body=d["body"],
+            status=str(d["status"]),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+            access=[NoteAccess._from_dict(a) for a in d.get("access") or []],
+        )

--- a/sdk/python/inkbox/phone/resources/contact_rules.py
+++ b/sdk/python/inkbox/phone/resources/contact_rules.py
@@ -111,7 +111,7 @@ class PhoneContactRulesResource:
         return PhoneContactRule._from_dict(data)
 
     def delete(self, phone_number_id: UUID | str, rule_id: UUID | str) -> None:
-        """Soft-delete a rule (admin-only)."""
+        """Delete a rule (admin-only)."""
         self._http.delete(_rule_path(phone_number_id, rule_id))
 
     def list_all(

--- a/sdk/python/inkbox/phone/resources/contact_rules.py
+++ b/sdk/python/inkbox/phone/resources/contact_rules.py
@@ -70,9 +70,9 @@ class PhoneContactRulesResource:
         action: PhoneRuleAction | str,
         match_target: str,
         match_type: PhoneRuleMatchType | str = PhoneRuleMatchType.EXACT_NUMBER,
-        status: ContactRuleStatus | str | None = None,
     ) -> PhoneContactRule:
-        """Create a rule.
+        """Create a rule. New rules are always ``active``; use
+        :meth:`update` to pause one after creation.
 
         Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
         rule with the same ``(match_type, match_target)`` already exists.
@@ -84,8 +84,6 @@ class PhoneContactRulesResource:
             ),
             "match_target": match_target,
         }
-        if status is not None:
-            body["status"] = status.value if isinstance(status, ContactRuleStatus) else status
         data = self._http.post(_rule_path(phone_number_id), json=body)
         return PhoneContactRule._from_dict(data)
 

--- a/sdk/python/inkbox/phone/resources/contact_rules.py
+++ b/sdk/python/inkbox/phone/resources/contact_rules.py
@@ -1,0 +1,148 @@
+"""
+inkbox/phone/resources/contact_rules.py
+
+Phone contact rules (per-number allow/block rules + org-wide list).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from inkbox.mail.types import ContactRuleStatus
+from inkbox.phone.types import (
+    PhoneContactRule,
+    PhoneRuleAction,
+    PhoneRuleMatchType,
+)
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+_BASE = "/numbers"
+_ORG_BASE = "/contact-rules"
+_UNSET = object()
+
+
+def _rule_path(phone_number_id: UUID | str, rule_id: UUID | str | None = None) -> str:
+    base = f"{_BASE}/{phone_number_id}/contact-rules"
+    return base if rule_id is None else f"{base}/{rule_id}"
+
+
+class PhoneContactRulesResource:
+    """Allow/block rules scoped to phone numbers (voice + SMS)."""
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def list(
+        self,
+        phone_number_id: UUID | str,
+        *,
+        action: PhoneRuleAction | str | None = None,
+        match_type: PhoneRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[PhoneContactRule]:
+        params: dict[str, Any] = {}
+        if action is not None:
+            params["action"] = action.value if isinstance(action, PhoneRuleAction) else action
+        if match_type is not None:
+            params["match_type"] = (
+                match_type.value if isinstance(match_type, PhoneRuleMatchType) else match_type
+            )
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        data = self._http.get(_rule_path(phone_number_id), params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [PhoneContactRule._from_dict(r) for r in items]
+
+    def get(self, phone_number_id: UUID | str, rule_id: UUID | str) -> PhoneContactRule:
+        data = self._http.get(_rule_path(phone_number_id, rule_id))
+        return PhoneContactRule._from_dict(data)
+
+    def create(
+        self,
+        phone_number_id: UUID | str,
+        *,
+        action: PhoneRuleAction | str,
+        match_target: str,
+        match_type: PhoneRuleMatchType | str = PhoneRuleMatchType.EXACT_NUMBER,
+        status: ContactRuleStatus | str | None = None,
+    ) -> PhoneContactRule:
+        """Create a rule.
+
+        Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
+        rule with the same ``(match_type, match_target)`` already exists.
+        """
+        body: dict[str, Any] = {
+            "action": action.value if isinstance(action, PhoneRuleAction) else action,
+            "match_type": (
+                match_type.value if isinstance(match_type, PhoneRuleMatchType) else match_type
+            ),
+            "match_target": match_target,
+        }
+        if status is not None:
+            body["status"] = status.value if isinstance(status, ContactRuleStatus) else status
+        data = self._http.post(_rule_path(phone_number_id), json=body)
+        return PhoneContactRule._from_dict(data)
+
+    def update(
+        self,
+        phone_number_id: UUID | str,
+        rule_id: UUID | str,
+        *,
+        action: PhoneRuleAction | str = _UNSET,  # type: ignore[assignment]
+        status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
+    ) -> PhoneContactRule:
+        """Update ``action`` or ``status`` (admin-only)."""
+        body: dict[str, Any] = {}
+        if action is not _UNSET:
+            body["action"] = (
+                action.value if isinstance(action, PhoneRuleAction) else action
+            )
+        if status is not _UNSET:
+            body["status"] = (
+                status.value if isinstance(status, ContactRuleStatus) else status
+            )
+        data = self._http.patch(_rule_path(phone_number_id, rule_id), json=body)
+        return PhoneContactRule._from_dict(data)
+
+    def delete(self, phone_number_id: UUID | str, rule_id: UUID | str) -> None:
+        """Soft-delete a rule (admin-only)."""
+        self._http.delete(_rule_path(phone_number_id, rule_id))
+
+    def list_all(
+        self,
+        *,
+        phone_number_id: UUID | str | None = None,
+        action: PhoneRuleAction | str | None = None,
+        match_type: PhoneRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[PhoneContactRule]:
+        """Org-wide list of phone contact rules (admin-only).
+
+        Args:
+            phone_number_id: Narrow to a single phone number by id.
+            action: Filter by ``allow`` or ``block``.
+            match_type: Filter by ``exact_number``.
+        """
+        params: dict[str, Any] = {}
+        if phone_number_id is not None:
+            params["phone_number_id"] = str(phone_number_id)
+        if action is not None:
+            params["action"] = action.value if isinstance(action, PhoneRuleAction) else action
+        if match_type is not None:
+            params["match_type"] = (
+                match_type.value if isinstance(match_type, PhoneRuleMatchType) else match_type
+            )
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        data = self._http.get(_ORG_BASE, params=params)
+        items = data["items"] if isinstance(data, dict) and "items" in data else data
+        return [PhoneContactRule._from_dict(r) for r in items]

--- a/sdk/python/inkbox/phone/resources/numbers.py
+++ b/sdk/python/inkbox/phone/resources/numbers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from inkbox.mail.types import FilterMode
 from inkbox.phone.types import PhoneNumber, PhoneTranscript
 
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ class PhoneNumbersResource:
         client_websocket_url: str | None = _UNSET,  # type: ignore[assignment]
         incoming_call_webhook_url: str | None = _UNSET,  # type: ignore[assignment]
         incoming_text_webhook_url: str | None = _UNSET,  # type: ignore[assignment]
+        filter_mode: FilterMode | str = _UNSET,  # type: ignore[assignment]
     ) -> PhoneNumber:
         """Update phone number settings.
 
@@ -53,6 +55,14 @@ class PhoneNumbersResource:
             client_websocket_url: WebSocket URL (wss://) for audio bridging.
             incoming_call_webhook_url: Webhook URL called for incoming calls when action is ``"webhook"``.
             incoming_text_webhook_url: Webhook URL called for incoming text messages.
+            filter_mode: ``"whitelist"`` or ``"blacklist"``. Admin-only on
+                the server; agent-scoped keys receive 403. A single value
+                governs both inbound voice and SMS.
+
+        Returns:
+            The updated phone number. When ``filter_mode`` was supplied and
+            the value actually changed, ``number.filter_mode_change_notice``
+            is populated with counts of now-redundant rules.
         """
         body: dict[str, Any] = {}
         if incoming_call_action is not _UNSET:
@@ -63,6 +73,10 @@ class PhoneNumbersResource:
             body["incoming_call_webhook_url"] = incoming_call_webhook_url
         if incoming_text_webhook_url is not _UNSET:
             body["incoming_text_webhook_url"] = incoming_text_webhook_url
+        if filter_mode is not _UNSET:
+            body["filter_mode"] = (
+                filter_mode.value if isinstance(filter_mode, FilterMode) else filter_mode
+            )
         data = self._http.patch(f"{_BASE}/{phone_number_id}", json=body)
         return PhoneNumber._from_dict(data)
 

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -117,7 +117,7 @@ class PhoneCall:
 
 @dataclass
 class RateLimitInfo:
-    """Rolling 24-hour rate limit snapshot for an organisation."""
+    """Rate limit snapshot for an organisation."""
 
     calls_used: int
     calls_remaining: int

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -34,7 +34,12 @@ def _dt(value: str | None) -> datetime | None:
 
 @dataclass
 class PhoneNumber:
-    """A phone number owned by your organisation."""
+    """A phone number owned by your organisation.
+
+    ``agent_identity_id`` is the UUID of the owning agent identity, or
+    ``None`` if the phone number is standalone (not tied to any agent).
+    Always populated on every phone-number response.
+    """
 
     id: UUID
     number: str
@@ -47,11 +52,13 @@ class PhoneNumber:
     filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    agent_identity_id: UUID | None = None
     filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> PhoneNumber:
         notice = d.get("filter_mode_change_notice")
+        agent_identity_id = d.get("agent_identity_id")
         return cls(
             id=UUID(d["id"]),
             number=d["number"],
@@ -64,6 +71,7 @@ class PhoneNumber:
             filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            agent_identity_id=UUID(agent_identity_id) if agent_identity_id else None,
             filter_mode_change_notice=(
                 FilterModeChangeNotice._from_dict(notice) if notice else None
             ),

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -8,8 +8,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 from uuid import UUID
+
+from inkbox.mail.types import ContactRuleStatus, FilterMode, FilterModeChangeNotice
+
+
+class PhoneRuleAction(StrEnum):
+    """Whether a matching phone number is allowed through or blocked."""
+
+    ALLOW = "allow"
+    BLOCK = "block"
+
+
+class PhoneRuleMatchType(StrEnum):
+    """What a phone contact rule matches on."""
+
+    EXACT_NUMBER = "exact_number"
 
 
 def _dt(value: str | None) -> datetime | None:
@@ -28,11 +44,14 @@ class PhoneNumber:
     client_websocket_url: str | None
     incoming_call_webhook_url: str | None
     incoming_text_webhook_url: str | None
+    filter_mode: FilterMode
     created_at: datetime
     updated_at: datetime
+    filter_mode_change_notice: FilterModeChangeNotice | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> PhoneNumber:
+        notice = d.get("filter_mode_change_notice")
         return cls(
             id=UUID(d["id"]),
             number=d["number"],
@@ -42,8 +61,12 @@ class PhoneNumber:
             client_websocket_url=d.get("client_websocket_url"),
             incoming_call_webhook_url=d.get("incoming_call_webhook_url"),
             incoming_text_webhook_url=d.get("incoming_text_webhook_url"),
+            filter_mode=FilterMode(d.get("filter_mode", "blacklist")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            filter_mode_change_notice=(
+                FilterModeChangeNotice._from_dict(notice) if notice else None
+            ),
         )
 
 
@@ -225,3 +248,28 @@ class PhoneTranscript:
         )
 
 
+@dataclass
+class PhoneContactRule:
+    """An inbound/outbound allow/block rule scoped to a phone number."""
+
+    id: UUID
+    phone_number_id: UUID
+    action: PhoneRuleAction
+    match_type: PhoneRuleMatchType
+    match_target: str
+    status: ContactRuleStatus
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> PhoneContactRule:
+        return cls(
+            id=UUID(d["id"]),
+            phone_number_id=UUID(d["phone_number_id"]),
+            action=PhoneRuleAction(d["action"]),
+            match_type=PhoneRuleMatchType(d["match_type"]),
+            match_target=d["match_target"],
+            status=ContactRuleStatus(d.get("status", "active")),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+        )

--- a/sdk/python/inkbox/whoami/types.py
+++ b/sdk/python/inkbox/whoami/types.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+# Named constants for the ``auth_subtype`` values returned on API-key responses.
+# The field itself is typed as a free-form ``str`` because the server may add
+# more variants over time; these constants are the current set.
+AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED = "api_key.admin_scoped"
+AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED = "api_key.agent_scoped.claimed"
+AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED = "api_key.agent_scoped.unclaimed"
+
 
 @dataclass
 class WhoamiApiKeyResponse:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.2.10"
+version = "0.2.11"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/sample_data.py
+++ b/sdk/python/tests/sample_data.py
@@ -9,6 +9,7 @@ PHONE_NUMBER_DICT = {
     "client_websocket_url": None,
     "incoming_call_webhook_url": None,
     "incoming_text_webhook_url": None,
+    "agent_identity_id": "eeee5555-0000-0000-0000-000000000001",
     "created_at": "2026-03-09T00:00:00Z",
     "updated_at": "2026-03-09T00:00:00Z",
 }

--- a/sdk/python/tests/sample_data_identities.py
+++ b/sdk/python/tests/sample_data_identities.py
@@ -12,6 +12,7 @@ IDENTITY_MAILBOX_DICT = {
     "id": "aaaa1111-0000-0000-0000-000000000001",
     "email_address": "sales-agent@inkbox.ai",
     "display_name": "Sales Agent",
+    "agent_identity_id": "eeee5555-0000-0000-0000-000000000001",
     "created_at": "2026-03-09T00:00:00Z",
     "updated_at": "2026-03-09T00:00:00Z",
 }
@@ -24,6 +25,7 @@ IDENTITY_PHONE_DICT = {
     "incoming_call_action": "auto_reject",
     "client_websocket_url": None,
     "incoming_text_webhook_url": None,
+    "agent_identity_id": "eeee5555-0000-0000-0000-000000000001",
     "created_at": "2026-03-09T00:00:00Z",
     "updated_at": "2026-03-09T00:00:00Z",
 }

--- a/sdk/python/tests/sample_data_mail.py
+++ b/sdk/python/tests/sample_data_mail.py
@@ -4,6 +4,7 @@ MAILBOX_DICT = {
     "id": "aaaa1111-0000-0000-0000-000000000001",
     "email_address": "agent01@inkbox.ai",
     "display_name": "Agent 01",
+    "agent_identity_id": "eeee5555-0000-0000-0000-000000000001",
     "created_at": "2026-03-09T00:00:00Z",
     "updated_at": "2026-03-09T00:00:00Z",
 }

--- a/sdk/python/tests/test_contact_rules.py
+++ b/sdk/python/tests/test_contact_rules.py
@@ -1,0 +1,182 @@
+"""
+sdk/python/tests/test_contact_rules.py
+
+Tests for MailContactRulesResource / PhoneContactRulesResource.
+"""
+
+from uuid import UUID
+from unittest.mock import MagicMock
+
+import pytest
+
+from inkbox.mail.resources.contact_rules import MailContactRulesResource
+from inkbox.mail.types import MailRuleAction, MailRuleMatchType
+from inkbox.phone.resources.contact_rules import PhoneContactRulesResource
+from inkbox.phone.types import PhoneRuleAction
+
+
+MAIL_RULE_DICT = {
+    "id": "aaaa1111-0000-0000-0000-000000000011",
+    "mailbox_id": "bbbb2222-0000-0000-0000-000000000001",
+    "action": "block",
+    "match_type": "domain",
+    "match_target": "spam.example",
+    "status": "active",
+    "created_at": "2026-04-20T00:00:00Z",
+    "updated_at": "2026-04-20T00:00:00Z",
+}
+
+PHONE_RULE_DICT = {
+    "id": "aaaa1111-0000-0000-0000-000000000012",
+    "phone_number_id": "cccc3333-0000-0000-0000-000000000001",
+    "action": "block",
+    "match_type": "exact_number",
+    "match_target": "+15551234567",
+    "status": "active",
+    "created_at": "2026-04-20T00:00:00Z",
+    "updated_at": "2026-04-20T00:00:00Z",
+}
+
+
+@pytest.fixture
+def transport():
+    t = MagicMock()
+    t.get = MagicMock()
+    t.post = MagicMock()
+    t.patch = MagicMock()
+    t.delete = MagicMock()
+    return t
+
+
+class TestMailContactRules:
+    def test_list_with_filters(self, transport):
+        transport.get.return_value = [MAIL_RULE_DICT]
+        resource = MailContactRulesResource(transport)
+
+        rows = resource.list(
+            "box@inkbox.ai",
+            action=MailRuleAction.BLOCK,
+            match_type=MailRuleMatchType.DOMAIN,
+            limit=10,
+        )
+
+        transport.get.assert_called_once_with(
+            "/mailboxes/box@inkbox.ai/contact-rules",
+            params={"action": "block", "match_type": "domain", "limit": 10},
+        )
+        assert rows[0].action == MailRuleAction.BLOCK
+        assert rows[0].match_type == MailRuleMatchType.DOMAIN
+
+    def test_create_sends_enum_values(self, transport):
+        transport.post.return_value = MAIL_RULE_DICT
+        resource = MailContactRulesResource(transport)
+
+        rule = resource.create(
+            "box@inkbox.ai",
+            action=MailRuleAction.BLOCK,
+            match_type=MailRuleMatchType.DOMAIN,
+            match_target="spam.example",
+        )
+
+        transport.post.assert_called_once_with(
+            "/mailboxes/box@inkbox.ai/contact-rules",
+            json={
+                "action": "block",
+                "match_type": "domain",
+                "match_target": "spam.example",
+            },
+        )
+        assert isinstance(rule.id, UUID)
+
+    def test_update_only_sends_supplied_fields(self, transport):
+        transport.patch.return_value = {**MAIL_RULE_DICT, "status": "paused"}
+        resource = MailContactRulesResource(transport)
+
+        rid = "aaaa1111-0000-0000-0000-000000000011"
+        resource.update("box@inkbox.ai", rid, status="paused")
+
+        transport.patch.assert_called_once_with(
+            f"/mailboxes/box@inkbox.ai/contact-rules/{rid}",
+            json={"status": "paused"},
+        )
+
+    def test_list_all_org_wide(self, transport):
+        transport.get.return_value = [MAIL_RULE_DICT]
+        resource = MailContactRulesResource(transport)
+
+        rows = resource.list_all(mailbox_id="bbbb2222-0000-0000-0000-000000000001")
+
+        transport.get.assert_called_once_with(
+            "/contact-rules",
+            params={"mailbox_id": "bbbb2222-0000-0000-0000-000000000001"},
+        )
+        assert len(rows) == 1
+
+    def test_list_all_with_action_and_match_type(self, transport):
+        transport.get.return_value = [MAIL_RULE_DICT]
+        resource = MailContactRulesResource(transport)
+
+        resource.list_all(
+            action=MailRuleAction.BLOCK,
+            match_type=MailRuleMatchType.DOMAIN,
+        )
+
+        transport.get.assert_called_once_with(
+            "/contact-rules",
+            params={"action": "block", "match_type": "domain"},
+        )
+
+
+class TestPhoneContactRules:
+    def test_create_defaults_match_type(self, transport):
+        transport.post.return_value = PHONE_RULE_DICT
+        resource = PhoneContactRulesResource(transport)
+
+        pid = "cccc3333-0000-0000-0000-000000000001"
+        resource.create(
+            pid,
+            action=PhoneRuleAction.BLOCK,
+            match_target="+15551234567",
+        )
+
+        transport.post.assert_called_once_with(
+            f"/numbers/{pid}/contact-rules",
+            json={
+                "action": "block",
+                "match_type": "exact_number",
+                "match_target": "+15551234567",
+            },
+        )
+
+    def test_delete_hits_rule_path(self, transport):
+        resource = PhoneContactRulesResource(transport)
+        pid = "cccc3333-0000-0000-0000-000000000001"
+        rid = "aaaa1111-0000-0000-0000-000000000012"
+
+        resource.delete(pid, rid)
+
+        transport.delete.assert_called_once_with(
+            f"/numbers/{pid}/contact-rules/{rid}",
+        )
+
+    def test_list_all_with_phone_number_id(self, transport):
+        transport.get.return_value = [PHONE_RULE_DICT]
+        resource = PhoneContactRulesResource(transport)
+
+        resource.list_all(phone_number_id="cccc3333-0000-0000-0000-000000000001")
+
+        transport.get.assert_called_once_with(
+            "/contact-rules",
+            params={"phone_number_id": "cccc3333-0000-0000-0000-000000000001"},
+        )
+
+    def test_list_all_with_action_filter(self, transport):
+        transport.get.return_value = [PHONE_RULE_DICT]
+        resource = PhoneContactRulesResource(transport)
+
+        resource.list_all(action=PhoneRuleAction.BLOCK)
+
+        transport.get.assert_called_once_with(
+            "/contact-rules",
+            params={"action": "block"},
+        )

--- a/sdk/python/tests/test_contacts_notes.py
+++ b/sdk/python/tests/test_contacts_notes.py
@@ -1,0 +1,407 @@
+"""
+sdk/python/tests/test_contacts_notes.py
+
+Unit tests for the Contacts and Notes SDK resources.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from inkbox.contacts.resources.contact_access import ContactAccessResource
+from inkbox.contacts.resources.contacts import ContactsResource
+from inkbox.contacts.resources.vcards import VCardsResource
+from inkbox.contacts.types import (
+    Contact,
+    ContactEmail,
+    ContactImportResult,
+    ContactPhone,
+)
+from inkbox.notes.resources.notes import NotesResource
+from inkbox.notes.types import Note
+
+
+CONTACT_DICT = {
+    "id": "aaaa1111-0000-0000-0000-000000000001",
+    "organization_id": "org_test",
+    "preferred_name": "Alex",
+    "name_prefix": None,
+    "given_name": "Alex",
+    "middle_name": None,
+    "family_name": "Waugh",
+    "name_suffix": None,
+    "company_name": None,
+    "job_title": None,
+    "birthday": "1990-01-01",
+    "notes": None,
+    "emails": [{"label": "work", "value": "alex@example.com", "is_primary": True}],
+    "phones": [{"value": "+15551234567"}],
+    "websites": [],
+    "dates": [{"label": "anniversary", "value": "2020-06-15"}],
+    "addresses": [],
+    "custom_fields": [],
+    "access": [
+        {
+            "id": "bbbb2222-0000-0000-0000-000000000001",
+            "contact_id": "aaaa1111-0000-0000-0000-000000000001",
+            "identity_id": None,
+            "created_at": "2026-04-20T00:00:00Z",
+        },
+    ],
+    "status": "active",
+    "created_at": "2026-04-20T00:00:00Z",
+    "updated_at": "2026-04-20T00:00:00Z",
+}
+
+NOTE_DICT = {
+    "id": "cccc3333-0000-0000-0000-000000000001",
+    "organization_id": "org_test",
+    "created_by": "user_test",
+    "title": "Design doc",
+    "body": "Some body text",
+    "status": "active",
+    "access": [],
+    "created_at": "2026-04-20T00:00:00Z",
+    "updated_at": "2026-04-20T00:00:00Z",
+}
+
+
+@pytest.fixture
+def transport():
+    t = MagicMock()
+    t.get = MagicMock()
+    t.post = MagicMock()
+    t.patch = MagicMock()
+    t.delete = MagicMock()
+    t.post_bytes = MagicMock()
+    t.get_bytes = MagicMock()
+    return t
+
+
+class TestContactsParse:
+    def test_contact_inlines_access(self):
+        c = Contact._from_dict(CONTACT_DICT)
+        assert len(c.access) == 1
+        assert c.access[0].identity_id is None  # wildcard
+
+    def test_contact_email_round_trips(self):
+        c = Contact._from_dict(CONTACT_DICT)
+        assert c.emails[0].is_primary is True
+
+    def test_empty_access_is_zero_grants_not_unloaded(self):
+        c = Contact._from_dict({**CONTACT_DICT, "access": []})
+        assert c.access == []
+
+    def test_all_name_fields_and_birthday_present(self):
+        from datetime import date
+
+        d = {
+            **CONTACT_DICT,
+            "name_prefix": "Dr.",
+            "middle_name": "Quincy",
+            "name_suffix": "Jr.",
+        }
+        c = Contact._from_dict(d)
+        assert c.name_prefix == "Dr."
+        assert c.middle_name == "Quincy"
+        assert c.name_suffix == "Jr."
+        assert c.birthday == date(1990, 1, 1)
+        assert c.organization_id == "org_test"
+        assert c.status == "active"
+
+    def test_birthday_null_parses_to_none(self):
+        c = Contact._from_dict({**CONTACT_DICT, "birthday": None})
+        assert c.birthday is None
+
+
+class TestContactsListAndLookup:
+    def test_list_with_q_and_order(self, transport):
+        transport.get.return_value = {"items": [CONTACT_DICT]}
+        resource = ContactsResource(transport)
+
+        rows = resource.list(q="al", order="name", limit=25, offset=0)
+
+        transport.get.assert_called_once_with(
+            "/contacts",
+            params={"q": "al", "order": "name", "limit": 25, "offset": 0},
+        )
+        assert len(rows) == 1
+
+    def test_lookup_requires_exactly_one_filter(self, transport):
+        resource = ContactsResource(transport)
+        with pytest.raises(ValueError):
+            resource.lookup()
+        with pytest.raises(ValueError):
+            resource.lookup(email="a@b.com", phone="+15551234567")
+
+    def test_lookup_single_filter_passes_through(self, transport):
+        transport.get.return_value = [CONTACT_DICT]
+        resource = ContactsResource(transport)
+
+        resource.lookup(email_domain="example.com")
+
+        transport.get.assert_called_once_with(
+            "/contacts/lookup",
+            params={"email_domain": "example.com"},
+        )
+
+
+class TestContactsCreate:
+    def test_wildcard_default_omits_access_ids(self, transport):
+        transport.post.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.create(
+            preferred_name="Alex",
+            emails=[ContactEmail(label="work", value="a@b.com", is_primary=True)],
+            phones=[ContactPhone(label=None, value="+15551234567")],
+        )
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"]["preferred_name"] == "Alex"
+        assert kwargs["json"]["emails"] == [
+            {"value": "a@b.com", "label": "work", "is_primary": True},
+        ]
+        assert "access_identity_ids" not in kwargs["json"]
+
+    def test_explicit_empty_list_sends_empty_grants(self, transport):
+        transport.post.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.create(access_identity_ids=[])
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"]["access_identity_ids"] == []
+
+    def test_none_explicit_forces_null(self, transport):
+        transport.post.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.create(access_identity_ids=None)
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"]["access_identity_ids"] is None
+
+    def test_all_name_fields_and_birthday_serialize(self, transport):
+        from datetime import date
+
+        transport.post.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.create(
+            preferred_name="Alex",
+            name_prefix="Dr.",
+            given_name="Alex",
+            middle_name="Q",
+            family_name="Waugh",
+            name_suffix="Jr.",
+            birthday=date(1990, 1, 1),
+        )
+
+        _, kwargs = transport.post.call_args
+        body = kwargs["json"]
+        assert body["name_prefix"] == "Dr."
+        assert body["middle_name"] == "Q"
+        assert body["name_suffix"] == "Jr."
+        assert body["birthday"] == "1990-01-01"
+
+    def test_birthday_accepts_iso_string(self, transport):
+        transport.post.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.create(preferred_name="Alex", birthday="1990-01-01")
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"]["birthday"] == "1990-01-01"
+
+
+class TestContactsUpdate:
+    def test_merge_patch_only_sends_supplied_fields(self, transport):
+        transport.patch.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.update("aaaa1111-0000-0000-0000-000000000001", notes="updated")
+
+        _, kwargs = transport.patch.call_args
+        assert kwargs["json"] == {"notes": "updated"}
+
+    def test_null_list_clears_column(self, transport):
+        transport.patch.return_value = CONTACT_DICT
+        resource = ContactsResource(transport)
+
+        resource.update("aaaa1111-0000-0000-0000-000000000001", emails=None)
+
+        _, kwargs = transport.patch.call_args
+        assert kwargs["json"]["emails"] is None
+
+
+class TestContactAccess:
+    def test_grant_wildcard(self, transport):
+        transport.post.return_value = {
+            "id": "bbbb2222-0000-0000-0000-000000000010",
+            "contact_id": "aaaa1111-0000-0000-0000-000000000001",
+            "identity_id": None,
+            "created_at": "2026-04-20T00:00:00Z",
+        }
+        access = ContactAccessResource(transport)
+
+        access.grant("aaaa1111-0000-0000-0000-000000000001", wildcard=True)
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"] == {"identity_id": None}
+
+    def test_grant_per_identity(self, transport):
+        transport.post.return_value = {
+            "id": "bbbb2222-0000-0000-0000-000000000011",
+            "contact_id": "aaaa1111-0000-0000-0000-000000000001",
+            "identity_id": "dddd4444-0000-0000-0000-000000000001",
+            "created_at": "2026-04-20T00:00:00Z",
+        }
+        access = ContactAccessResource(transport)
+
+        access.grant(
+            "aaaa1111-0000-0000-0000-000000000001",
+            identity_id="dddd4444-0000-0000-0000-000000000001",
+        )
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"] == {
+            "identity_id": "dddd4444-0000-0000-0000-000000000001",
+        }
+
+    def test_wildcard_plus_identity_rejects(self, transport):
+        access = ContactAccessResource(transport)
+        with pytest.raises(ValueError):
+            access.grant(
+                "aaaa1111-0000-0000-0000-000000000001",
+                identity_id="dddd4444-0000-0000-0000-000000000001",
+                wildcard=True,
+            )
+
+
+class TestVCards:
+    def test_import_posts_bytes(self, transport):
+        transport.post_bytes.return_value = {
+            "created_count": 1,
+            "error_count": 1,
+            "results": [
+                {"index": 0, "status": "created", "contact": CONTACT_DICT, "error": None},
+                {"index": 1, "status": "error", "contact": None, "error": "bad FN"},
+            ],
+        }
+        resource = VCardsResource(transport)
+
+        result = resource.import_vcards("BEGIN:VCARD\r\nEND:VCARD\r\n")
+
+        transport.post_bytes.assert_called_once()
+        args, kwargs = transport.post_bytes.call_args
+        assert args == ("/contacts/import",)
+        assert kwargs["content_type"] == "text/vcard"
+        assert isinstance(kwargs["content"], bytes)
+        assert isinstance(result, ContactImportResult)
+        assert result.created_count == 1
+        assert result.error_count == 1
+        assert len(result.results) == 2
+        assert result.results[0].status == "created"
+        assert result.results[0].contact is not None
+        assert result.results[1].status == "error"
+        assert result.results[1].error == "bad FN"
+        # Convenience properties
+        assert len(result.created_ids) == 1
+        assert len(result.errors) == 1
+        assert result.errors[0].index == 1
+
+    def test_export_returns_text(self, transport):
+        transport.get_bytes.return_value = b"BEGIN:VCARD\r\nEND:VCARD\r\n"
+        resource = VCardsResource(transport)
+
+        text = resource.export_vcard("aaaa1111-0000-0000-0000-000000000001")
+
+        transport.get_bytes.assert_called_once_with(
+            "/contacts/aaaa1111-0000-0000-0000-000000000001.vcf",
+            accept="text/vcard",
+        )
+        assert "BEGIN:VCARD" in text
+
+    def test_import_then_export_round_trip(self, transport):
+        # Import returns one successful card, then export that card: the
+        # two resource calls should be wired to separate transport methods
+        # and compose into a single logical round-trip.
+        transport.post_bytes.return_value = {
+            "created_count": 1,
+            "error_count": 0,
+            "results": [
+                {"index": 0, "status": "created", "contact": CONTACT_DICT, "error": None},
+            ],
+        }
+        transport.get_bytes.return_value = b"BEGIN:VCARD\r\nFN:Alex\r\nEND:VCARD\r\n"
+        resource = VCardsResource(transport)
+
+        result = resource.import_vcards("BEGIN:VCARD\r\nFN:Alex\r\nEND:VCARD\r\n")
+        assert len(result.created_ids) == 1
+        created = result.results[0].contact
+        assert created is not None
+
+        vcf = resource.export_vcard(created.id)
+        assert "BEGIN:VCARD" in vcf
+        assert transport.post_bytes.call_count == 1
+        assert transport.get_bytes.call_count == 1
+
+
+class TestNotes:
+    def test_list_includes_identity_filter(self, transport):
+        transport.get.return_value = {"items": [NOTE_DICT]}
+        resource = NotesResource(transport)
+
+        resource.list(
+            q="design",
+            identity_id="dddd4444-0000-0000-0000-000000000001",
+            limit=50,
+            order="recent",
+        )
+
+        transport.get.assert_called_once_with(
+            "/notes",
+            params={
+                "q": "design",
+                "identity_id": "dddd4444-0000-0000-0000-000000000001",
+                "limit": 50,
+                "order": "recent",
+            },
+        )
+
+    def test_create_sends_body_only_when_no_title(self, transport):
+        transport.post.return_value = NOTE_DICT
+        resource = NotesResource(transport)
+
+        resource.create(body="some text")
+
+        _, kwargs = transport.post.call_args
+        assert kwargs["json"] == {"body": "some text"}
+
+    def test_update_title_null_is_valid(self, transport):
+        transport.patch.return_value = {**NOTE_DICT, "title": None}
+        resource = NotesResource(transport)
+
+        resource.update("cccc3333-0000-0000-0000-000000000001", title=None)
+
+        _, kwargs = transport.patch.call_args
+        assert kwargs["json"] == {"title": None}
+
+    def test_note_parse(self):
+        n = Note._from_dict(NOTE_DICT)
+        assert n.title == "Design doc"
+        assert n.access == []
+        assert n.organization_id == "org_test"
+        assert n.created_by == "user_test"
+        assert n.status == "active"
+
+    def test_note_parse_missing_required_field_raises(self):
+        # Guards against silently dropping server fields — if the server
+        # response ever omits one of these required fields, we want to fail
+        # fast rather than dereference an undefined value later.
+        import pytest as _pytest
+
+        bad = {k: v for k, v in NOTE_DICT.items() if k != "organization_id"}
+        with _pytest.raises(KeyError):
+            Note._from_dict(bad)

--- a/sdk/python/tests/test_contacts_notes.py
+++ b/sdk/python/tests/test_contacts_notes.py
@@ -37,7 +37,7 @@ CONTACT_DICT = {
     "emails": [{"label": "work", "value": "alex@example.com", "is_primary": True}],
     "phones": [{"value_e164": "+15551234567"}],
     "websites": [],
-    "dates": [{"label": "anniversary", "value": "2020-06-15"}],
+    "dates": [{"label": "anniversary", "date": "2020-06-15"}],
     "addresses": [],
     "custom_fields": [],
     "access": [

--- a/sdk/python/tests/test_contacts_notes.py
+++ b/sdk/python/tests/test_contacts_notes.py
@@ -35,7 +35,7 @@ CONTACT_DICT = {
     "birthday": "1990-01-01",
     "notes": None,
     "emails": [{"label": "work", "value": "alex@example.com", "is_primary": True}],
-    "phones": [{"value": "+15551234567"}],
+    "phones": [{"value_e164": "+15551234567"}],
     "websites": [],
     "dates": [{"label": "anniversary", "value": "2020-06-15"}],
     "addresses": [],

--- a/sdk/python/tests/test_exceptions.py
+++ b/sdk/python/tests/test_exceptions.py
@@ -1,11 +1,27 @@
 """
 sdk/python/tests/test_exceptions.py
 
-Tests for SDK exception classes.
+Tests for SDK exception classes, including typed 409 subclasses and the
+widened ``InkboxAPIError.detail`` union.
 """
 
-from inkbox.phone.exceptions import InkboxAPIError as PhoneAPIError
+import httpx
+import pytest
+
+from inkbox._http import _raise_for_status
+from inkbox.exceptions import (
+    DuplicateContactRuleError,
+    InkboxAPIError,
+    RedundantContactAccessGrantError,
+)
 from inkbox.mail.exceptions import InkboxAPIError as MailAPIError
+from inkbox.phone.exceptions import InkboxAPIError as PhoneAPIError
+
+
+def _resp(status: int, body: dict | str) -> httpx.Response:
+    if isinstance(body, dict):
+        return httpx.Response(status_code=status, json=body)
+    return httpx.Response(status_code=status, text=body)
 
 
 class TestPhoneInkboxAPIError:
@@ -32,5 +48,76 @@ class TestMailInkboxAPIError:
         assert err.status_code == 403
         assert err.detail == "forbidden"
 
-    def test_is_exception(self):
-        assert issubclass(MailAPIError, Exception)
+
+class TestDetailUnion:
+    def test_string_detail_round_trips(self):
+        err = InkboxAPIError(400, "bad input")
+        assert err.detail == "bad input"
+        assert isinstance(err.detail, str)
+
+    def test_dict_detail_round_trips(self):
+        err = InkboxAPIError(409, {"error": "x", "detail": "y"})
+        assert isinstance(err.detail, dict)
+        assert err.detail["error"] == "x"
+
+
+class TestRaiseForStatusPlainString:
+    def test_plain_string_409_stays_base_class(self):
+        resp = _resp(409, {"detail": "Access already granted"})
+        with pytest.raises(InkboxAPIError) as info:
+            _raise_for_status(resp)
+        err = info.value
+        assert err.status_code == 409
+        assert err.detail == "Access already granted"
+        assert not isinstance(err, DuplicateContactRuleError)
+        assert not isinstance(err, RedundantContactAccessGrantError)
+
+
+class TestRaiseForStatusStructured:
+    def test_duplicate_contact_rule(self):
+        rule_id = "aaaa1111-0000-0000-0000-000000000009"
+        resp = _resp(
+            409,
+            {
+                "detail": {
+                    "existing_rule_id": rule_id,
+                    "message": "rule already exists",
+                },
+            },
+        )
+        with pytest.raises(DuplicateContactRuleError) as info:
+            _raise_for_status(resp)
+        err = info.value
+        assert str(err.existing_rule_id) == rule_id
+        assert err.status_code == 409
+        assert isinstance(err.detail, dict)
+
+    def test_redundant_contact_access_grant(self):
+        resp = _resp(
+            409,
+            {
+                "detail": {
+                    "error": "redundant_grant",
+                    "detail": "wildcard already implies this identity",
+                },
+            },
+        )
+        with pytest.raises(RedundantContactAccessGrantError) as info:
+            _raise_for_status(resp)
+        err = info.value
+        assert err.error == "redundant_grant"
+        assert "wildcard" in err.detail_message
+
+
+class TestRaiseForStatusOtherCodes:
+    def test_404_stays_base_class(self):
+        resp = _resp(404, {"detail": "not found"})
+        with pytest.raises(InkboxAPIError) as info:
+            _raise_for_status(resp)
+        assert type(info.value) is InkboxAPIError
+
+    def test_500_stays_base_class(self):
+        resp = _resp(500, "server error")
+        with pytest.raises(InkboxAPIError) as info:
+            _raise_for_status(resp)
+        assert info.value.status_code == 500

--- a/sdk/python/tests/test_filter_mode_and_threads.py
+++ b/sdk/python/tests/test_filter_mode_and_threads.py
@@ -1,0 +1,179 @@
+"""
+sdk/python/tests/test_filter_mode_and_threads.py
+
+Tests for FilterMode wiring on mailboxes/numbers and new thread methods.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from inkbox.mail.resources.mailboxes import MailboxesResource
+from inkbox.mail.resources.threads import ThreadsResource
+from inkbox.mail.types import (
+    FilterMode,
+    FilterModeChangeNotice,
+    Mailbox,
+    Thread,
+    ThreadFolder,
+)
+from inkbox.phone.resources.numbers import PhoneNumbersResource
+from inkbox.phone.types import PhoneNumber
+from sample_data import PHONE_NUMBER_DICT
+from sample_data_mail import MAILBOX_DICT, THREAD_DICT
+
+
+CHANGE_NOTICE = {
+    "new_filter_mode": "whitelist",
+    "redundant_rule_action": "block",
+    "redundant_rule_count": 3,
+}
+
+
+@pytest.fixture
+def transport():
+    t = MagicMock()
+    t.get = MagicMock()
+    t.post = MagicMock()
+    t.patch = MagicMock()
+    t.delete = MagicMock()
+    return t
+
+
+class TestMailboxFilterMode:
+    def test_parse_defaults_to_blacklist_when_missing(self):
+        mb = Mailbox._from_dict(MAILBOX_DICT)
+        assert mb.filter_mode == FilterMode.BLACKLIST
+        assert mb.filter_mode_change_notice is None
+
+    def test_parse_honors_server_value(self):
+        mb = Mailbox._from_dict({**MAILBOX_DICT, "filter_mode": "whitelist"})
+        assert mb.filter_mode == FilterMode.WHITELIST
+
+    def test_parse_change_notice(self):
+        mb = Mailbox._from_dict(
+            {
+                **MAILBOX_DICT,
+                "filter_mode": "whitelist",
+                "filter_mode_change_notice": CHANGE_NOTICE,
+            },
+        )
+        assert isinstance(mb.filter_mode_change_notice, FilterModeChangeNotice)
+        assert mb.filter_mode_change_notice.new_filter_mode == FilterMode.WHITELIST
+        assert mb.filter_mode_change_notice.redundant_rule_action == "block"
+        assert mb.filter_mode_change_notice.redundant_rule_count == 3
+
+    def test_update_sends_filter_mode_enum(self, transport):
+        transport.patch.return_value = {**MAILBOX_DICT, "filter_mode": "whitelist"}
+        resource = MailboxesResource(transport)
+
+        resource.update("box@inkbox.ai", filter_mode=FilterMode.WHITELIST)
+
+        transport.patch.assert_called_once_with(
+            "/mailboxes/box@inkbox.ai",
+            json={"filter_mode": "whitelist"},
+        )
+
+    def test_update_without_filter_mode_omits_field(self, transport):
+        transport.patch.return_value = MAILBOX_DICT
+        resource = MailboxesResource(transport)
+
+        resource.update("box@inkbox.ai", display_name="New")
+
+        _, kwargs = transport.patch.call_args
+        assert "filter_mode" not in kwargs["json"]
+
+
+class TestPhoneNumberFilterMode:
+    def test_parse_defaults_to_blacklist(self):
+        pn = PhoneNumber._from_dict(PHONE_NUMBER_DICT)
+        assert pn.filter_mode == FilterMode.BLACKLIST
+
+    def test_update_sends_filter_mode(self, transport):
+        transport.patch.return_value = {**PHONE_NUMBER_DICT, "filter_mode": "whitelist"}
+        resource = PhoneNumbersResource(transport)
+
+        pid = "aaaa1111-0000-0000-0000-000000000001"
+        resource.update(pid, filter_mode="whitelist")
+
+        transport.patch.assert_called_once_with(
+            f"/numbers/{pid}",
+            json={"filter_mode": "whitelist"},
+        )
+
+
+class TestThreadsList:
+    def test_list_without_folder_does_not_send_folder_param(self, transport):
+        transport.get.return_value = {
+            "items": [THREAD_DICT],
+            "next_cursor": None,
+            "has_more": False,
+        }
+        resource = ThreadsResource(transport)
+
+        list(resource.list("box@inkbox.ai"))
+
+        _, kwargs = transport.get.call_args
+        assert "folder" not in kwargs["params"]
+
+    def test_list_with_folder_enum(self, transport):
+        transport.get.return_value = {
+            "items": [],
+            "next_cursor": None,
+            "has_more": False,
+        }
+        resource = ThreadsResource(transport)
+
+        list(resource.list("box@inkbox.ai", folder=ThreadFolder.BLOCKED))
+
+        _, kwargs = transport.get.call_args
+        assert kwargs["params"]["folder"] == "blocked"
+
+
+class TestThreadsListFolders:
+    def test_list_folders_returns_folder_enum_list(self, transport):
+        transport.get.return_value = ["inbox", "spam", "blocked"]
+        resource = ThreadsResource(transport)
+
+        result = resource.list_folders("box@inkbox.ai")
+
+        transport.get.assert_called_once_with(
+            "/mailboxes/box@inkbox.ai/threads/folders",
+        )
+        assert result == [ThreadFolder.INBOX, ThreadFolder.SPAM, ThreadFolder.BLOCKED]
+
+    def test_list_folders_empty(self, transport):
+        transport.get.return_value = []
+        resource = ThreadsResource(transport)
+
+        assert resource.list_folders("box@inkbox.ai") == []
+
+
+class TestThreadsUpdate:
+    def test_update_folder_returns_bare_thread(self, transport):
+        # Server returns ThreadResponse (no `messages`), so update() must
+        # parse as `Thread`, not `ThreadDetail`.
+        transport.patch.return_value = {**THREAD_DICT, "folder": "archive"}
+        resource = ThreadsResource(transport)
+        tid = "eeee5555-0000-0000-0000-000000000001"
+
+        result = resource.update("box@inkbox.ai", tid, folder=ThreadFolder.ARCHIVE)
+
+        transport.patch.assert_called_once_with(
+            f"/mailboxes/box@inkbox.ai/threads/{tid}",
+            json={"folder": "archive"},
+        )
+        assert type(result) is Thread
+        assert result.folder == ThreadFolder.ARCHIVE
+        # Bare Thread has no `messages` attr — this guards against regression
+        # where the SDK falsely reports every update zeroing the thread.
+        assert not hasattr(result, "messages")
+
+    def test_update_blocked_rejects_client_side(self, transport):
+        resource = ThreadsResource(transport)
+        tid = "eeee5555-0000-0000-0000-000000000001"
+
+        with pytest.raises(ValueError):
+            resource.update("box@inkbox.ai", tid, folder=ThreadFolder.BLOCKED)
+
+        transport.patch.assert_not_called()

--- a/sdk/python/tests/test_identities_types.py
+++ b/sdk/python/tests/test_identities_types.py
@@ -57,6 +57,7 @@ class TestIdentityMailboxParsing:
         assert isinstance(m.id, UUID)
         assert m.email_address == "sales-agent@inkbox.ai"
         assert m.display_name == "Sales Agent"
+        assert m.agent_identity_id == UUID("eeee5555-0000-0000-0000-000000000001")
         assert isinstance(m.created_at, datetime)
         assert isinstance(m.updated_at, datetime)
 
@@ -72,6 +73,7 @@ class TestIdentityPhoneNumberParsing:
         assert p.incoming_call_action == "auto_reject"
         assert p.client_websocket_url is None
         assert p.incoming_text_webhook_url is None
+        assert p.agent_identity_id == UUID("eeee5555-0000-0000-0000-000000000001")
 
     def test_parses_incoming_text_webhook_url(self):
         p = IdentityPhoneNumber._from_dict(

--- a/sdk/python/tests/test_mail_types.py
+++ b/sdk/python/tests/test_mail_types.py
@@ -30,8 +30,19 @@ class TestMailboxParsing:
         assert isinstance(m.id, UUID)
         assert m.email_address == "agent01@inkbox.ai"
         assert m.display_name == "Agent 01"
+        assert m.agent_identity_id == UUID("eeee5555-0000-0000-0000-000000000001")
         assert isinstance(m.created_at, datetime)
         assert isinstance(m.updated_at, datetime)
+
+    def test_agent_identity_id_nullable(self):
+        m = Mailbox._from_dict({**MAILBOX_DICT, "agent_identity_id": None})
+        assert m.agent_identity_id is None
+
+    def test_agent_identity_id_missing(self):
+        d = {**MAILBOX_DICT}
+        del d["agent_identity_id"]
+        m = Mailbox._from_dict(d)
+        assert m.agent_identity_id is None
 
 
 class TestMessageParsing:

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -30,8 +30,13 @@ class TestPhoneNumberParsing:
         assert n.incoming_call_action == "auto_reject"
         assert n.client_websocket_url is None
         assert n.incoming_call_webhook_url is None
+        assert n.agent_identity_id == UUID("eeee5555-0000-0000-0000-000000000001")
         assert isinstance(n.created_at, datetime)
         assert isinstance(n.updated_at, datetime)
+
+    def test_agent_identity_id_nullable(self):
+        n = PhoneNumber._from_dict({**PHONE_NUMBER_DICT, "agent_identity_id": None})
+        assert n.agent_identity_id is None
 
 
 class TestPhoneCallParsing:

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -106,9 +106,9 @@ console.log(status.restrictions.maxSendsPerDay);    // 10 (unclaimed) or 500 (cl
 
 `request` for `signup()` requires `humanEmail` and `noteToHuman`. `displayName`, `agentHandle`, and `emailLocalPart` are optional. All methods accept an optional `options` object with `baseUrl` and `timeoutMs`.
 
-> **Note:** Unclaimed agents can only send to the `humanEmail` specified at signup (max 10/day). After verification or human approval in the console, full capabilities are unlocked.
+> **Note:** Unclaimed agents have a limited send quota and can only email the `humanEmail` specified at signup. After verification or human approval in the console, full capabilities are unlocked.
 
-> **Note:** The `organizationId` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. Always use the `organizationId` from the most recent response (`verifySignup` or `resendSignupVerification`) rather than caching the value from the initial `signup()` call.
+> **Note:** The `organizationId` returned at signup may change after verification or human approval. Always use the `organizationId` from the most recent response (`verifySignup` or `resendSignupVerification`) rather than caching the value from the initial `signup()` call.
 
 ---
 
@@ -274,7 +274,7 @@ const unread = await identity.listTexts({ isRead: false });
 // Get a single text
 const text = await identity.getText("text-uuid");
 console.log(text.type);  // "sms" or "mms"
-if (text.media) {         // MMS attachments (presigned S3 URLs, 1hr expiry)
+if (text.media) {         // MMS attachments (temporary signed URLs)
   for (const m of text.media) {
     console.log(m.contentType, m.size, m.url);
   }
@@ -470,7 +470,7 @@ await inkbox.messages.unstar("abc@inkboxmail.com", "message-uuid");
 // Delete a message
 await inkbox.messages.delete("abc@inkboxmail.com", "message-uuid");
 
-// Get an attachment presigned URL
+// Get a temporary signed URL for an attachment
 const attachment = await inkbox.messages.getAttachment("abc@inkboxmail.com", "message-uuid", "report.pdf");
 console.log(attachment.url);
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/_http.ts
+++ b/sdk/typescript/src/_http.ts
@@ -18,15 +18,64 @@ export class InkboxVaultKeyError extends InkboxError {
   }
 }
 
+export type InkboxAPIErrorDetail = string | Record<string, unknown>;
+
 export class InkboxAPIError extends InkboxError {
   readonly statusCode: number;
-  readonly detail: string;
+  readonly detail: InkboxAPIErrorDetail;
 
-  constructor(statusCode: number, detail: string) {
-    super(`HTTP ${statusCode}: ${detail}`);
+  constructor(statusCode: number, detail: InkboxAPIErrorDetail) {
+    super(`HTTP ${statusCode}: ${typeof detail === "string" ? detail : JSON.stringify(detail)}`);
     this.name = "InkboxAPIError";
     this.statusCode = statusCode;
     this.detail = detail;
+  }
+}
+
+export class DuplicateContactRuleError extends InkboxAPIError {
+  readonly existingRuleId: string;
+
+  constructor(statusCode: number, detail: Record<string, unknown>) {
+    super(statusCode, detail);
+    this.name = "DuplicateContactRuleError";
+    this.existingRuleId = String(detail["existing_rule_id"]);
+  }
+}
+
+export class RedundantContactAccessGrantError extends InkboxAPIError {
+  readonly error: string;
+  readonly detailMessage: string;
+
+  constructor(statusCode: number, detail: Record<string, unknown>) {
+    super(statusCode, detail);
+    this.name = "RedundantContactAccessGrantError";
+    this.error = String(detail["error"] ?? "redundant_grant");
+    this.detailMessage = String(detail["detail"] ?? "");
+  }
+}
+
+function raiseForErrorResponse(status: number, rawDetail: InkboxAPIErrorDetail): never {
+  if (status === 409 && typeof rawDetail === "object" && rawDetail !== null) {
+    if ("existing_rule_id" in rawDetail) {
+      throw new DuplicateContactRuleError(status, rawDetail);
+    }
+    if (rawDetail["error"] === "redundant_grant") {
+      throw new RedundantContactAccessGrantError(status, rawDetail);
+    }
+  }
+  throw new InkboxAPIError(status, rawDetail);
+}
+
+async function readErrorDetail(resp: Response): Promise<InkboxAPIErrorDetail> {
+  try {
+    const parsed = (await resp.json()) as { detail?: unknown };
+    const d = parsed?.detail;
+    if (d === undefined || d === null) return resp.statusText;
+    if (typeof d === "string") return d;
+    if (typeof d === "object") return d as Record<string, unknown>;
+    return String(d);
+  } catch {
+    return resp.statusText;
   }
 }
 
@@ -200,10 +249,39 @@ export class HttpTransport {
     await this.request<void>("DELETE", path);
   }
 
+  /**
+   * POST a raw body with a caller-supplied Content-Type. JSON response.
+   *
+   * Used for non-JSON payloads like vCard imports.
+   */
+  async postRaw<T>(
+    path: string,
+    body: string | Uint8Array,
+    contentType: string,
+  ): Promise<T> {
+    return this.request<T>("POST", path, { rawBody: body, contentType });
+  }
+
+  /**
+   * GET a non-JSON response as text.
+   *
+   * Used for vCard export and similar text endpoints.
+   */
+  async getText(path: string, accept: string, params?: Params): Promise<string> {
+    return this.request<string>("GET", path, { params, accept, rawResponse: "text" });
+  }
+
   private async request<T>(
     method: string,
     path: string,
-    opts: { params?: Params; body?: unknown } = {},
+    opts: {
+      params?: Params;
+      body?: unknown;
+      rawBody?: string | Uint8Array;
+      contentType?: string;
+      accept?: string;
+      rawResponse?: "text" | "bytes";
+    } = {},
   ): Promise<T> {
     let url = `${this.baseUrl}${path}`;
 
@@ -220,17 +298,20 @@ export class HttpTransport {
 
     const headers: Record<string, string> = {
       "X-API-Key": this.apiKey,
-      Accept: "application/json",
+      Accept: opts.accept ?? "application/json",
     };
     const cookieHeader = this.cookieJar.getHeaderValue(url);
     if (cookieHeader) {
       headers.Cookie = cookieHeader;
     }
 
-    let bodyStr: string | undefined;
-    if (opts.body !== undefined) {
+    let bodyPayload: string | Uint8Array | undefined;
+    if (opts.rawBody !== undefined) {
+      headers["Content-Type"] = opts.contentType ?? "application/octet-stream";
+      bodyPayload = opts.rawBody;
+    } else if (opts.body !== undefined) {
       headers["Content-Type"] = "application/json";
-      bodyStr = JSON.stringify(opts.body);
+      bodyPayload = JSON.stringify(opts.body);
     }
 
     const controller = new AbortController();
@@ -241,7 +322,7 @@ export class HttpTransport {
       resp = await fetch(url, {
         method,
         headers,
-        body: bodyStr,
+        body: bodyPayload as BodyInit | undefined,
         signal: controller.signal,
       });
     } finally {
@@ -251,18 +332,16 @@ export class HttpTransport {
     this.cookieJar.storeFromResponse(url, resp);
 
     if (!resp.ok) {
-      let detail: string;
-      try {
-        const err = (await resp.json()) as { detail?: string };
-        detail = err.detail ?? resp.statusText;
-      } catch {
-        detail = resp.statusText;
-      }
-      throw new InkboxAPIError(resp.status, detail);
+      const detail = await readErrorDetail(resp);
+      raiseForErrorResponse(resp.status, detail);
     }
 
     if (resp.status === 204) {
       return undefined as T;
+    }
+
+    if (opts.rawResponse === "text") {
+      return (await resp.text()) as unknown as T;
     }
 
     return resp.json() as Promise<T>;

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -213,8 +213,10 @@ export class AgentIdentity {
       id: mailbox.id,
       emailAddress: mailbox.emailAddress,
       displayName: mailbox.displayName,
+      filterMode: mailbox.filterMode,
       createdAt: mailbox.createdAt,
       updatedAt: mailbox.updatedAt,
+      filterModeChangeNotice: mailbox.filterModeChangeNotice,
     };
     this._mailbox = linked;
     this._data.emailAddress = mailbox.emailAddress;

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -214,6 +214,7 @@ export class AgentIdentity {
       emailAddress: mailbox.emailAddress,
       displayName: mailbox.displayName,
       filterMode: mailbox.filterMode,
+      agentIdentityId: mailbox.agentIdentityId,
       createdAt: mailbox.createdAt,
       updatedAt: mailbox.updatedAt,
       filterModeChangeNotice: mailbox.filterModeChangeNotice,

--- a/sdk/typescript/src/contacts/index.ts
+++ b/sdk/typescript/src/contacts/index.ts
@@ -1,0 +1,7 @@
+export * from "./types.js";
+export type {
+  CreateContactOptions,
+  ListContactsOptions,
+  LookupContactsOptions,
+  UpdateContactOptions,
+} from "./resources/contacts.js";

--- a/sdk/typescript/src/contacts/resources/contactAccess.ts
+++ b/sdk/typescript/src/contacts/resources/contactAccess.ts
@@ -1,0 +1,54 @@
+/**
+ * inkbox-contacts/resources/contactAccess.ts
+ *
+ * Per-contact access grant management.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import {
+  ContactAccess,
+  RawContactAccess,
+  parseContactAccess,
+} from "../types.js";
+
+const BASE = "/contacts";
+
+export interface GrantContactAccessOptions {
+  /** Identity UUID to grant. Mutually exclusive with `wildcard`. */
+  identityId?: string;
+  /** When true, reset to a wildcard grant (every active identity sees it). */
+  wildcard?: boolean;
+}
+
+export class ContactAccessResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async list(contactId: string): Promise<ContactAccess[]> {
+    const data = await this.http.get<
+      { items: RawContactAccess[] } | RawContactAccess[]
+    >(`${BASE}/${contactId}/access`);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseContactAccess);
+  }
+
+  async grant(
+    contactId: string,
+    options: GrantContactAccessOptions,
+  ): Promise<ContactAccess> {
+    if (options.wildcard && options.identityId !== undefined) {
+      throw new Error("Pass either identityId or wildcard: true, not both.");
+    }
+    const body: Record<string, unknown> = {
+      identity_id: options.wildcard ? null : options.identityId ?? null,
+    };
+    const data = await this.http.post<RawContactAccess>(
+      `${BASE}/${contactId}/access`,
+      body,
+    );
+    return parseContactAccess(data);
+  }
+
+  async revoke(contactId: string, identityId: string): Promise<void> {
+    await this.http.delete(`${BASE}/${contactId}/access/${identityId}`);
+  }
+}

--- a/sdk/typescript/src/contacts/resources/contacts.ts
+++ b/sdk/typescript/src/contacts/resources/contacts.ts
@@ -1,0 +1,216 @@
+/**
+ * inkbox-contacts/resources/contacts.ts
+ *
+ * Contacts CRUD + search + lookup.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import { ContactAccessResource } from "./contactAccess.js";
+import { VCardsResource } from "./vcards.js";
+import {
+  Contact,
+  ContactAddress,
+  ContactCustomField,
+  ContactDate,
+  ContactEmail,
+  ContactPhone,
+  ContactWebsite,
+  RawContact,
+  contactAddressToWire,
+  contactCustomFieldToWire,
+  contactDateToWire,
+  contactEmailToWire,
+  contactPhoneToWire,
+  contactWebsiteToWire,
+  parseContact,
+} from "../types.js";
+
+const BASE = "/contacts";
+
+export interface ListContactsOptions {
+  q?: string;
+  order?: "name" | "recent" | string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface LookupContactsOptions {
+  email?: string;
+  emailContains?: string;
+  emailDomain?: string;
+  phone?: string;
+  phoneContains?: string;
+}
+
+export interface CreateContactOptions {
+  preferredName?: string;
+  namePrefix?: string;
+  givenName?: string;
+  middleName?: string;
+  familyName?: string;
+  nameSuffix?: string;
+  companyName?: string;
+  jobTitle?: string;
+  /** ISO date (YYYY-MM-DD). */
+  birthday?: string;
+  notes?: string;
+  emails?: ContactEmail[];
+  phones?: ContactPhone[];
+  websites?: ContactWebsite[];
+  dates?: ContactDate[];
+  addresses?: ContactAddress[];
+  customFields?: ContactCustomField[];
+  /**
+   * Access control at create time.
+   *   - `undefined` (default) / `"wildcard"` — one wildcard row, every active
+   *     identity sees the contact.
+   *   - `[]` — zero grants (only admin + human callers see it).
+   *   - Explicit list of identity UUIDs — one per-identity grant each. Capped
+   *     at 500 entries server-side.
+   */
+  accessIdentityIds?: string[] | "wildcard" | null;
+}
+
+export interface UpdateContactOptions {
+  preferredName?: string | null;
+  namePrefix?: string | null;
+  givenName?: string | null;
+  middleName?: string | null;
+  familyName?: string | null;
+  nameSuffix?: string | null;
+  companyName?: string | null;
+  jobTitle?: string | null;
+  /** ISO date (YYYY-MM-DD) or null to clear. */
+  birthday?: string | null;
+  notes?: string | null;
+  emails?: ContactEmail[] | null;
+  phones?: ContactPhone[] | null;
+  websites?: ContactWebsite[] | null;
+  dates?: ContactDate[] | null;
+  addresses?: ContactAddress[] | null;
+  customFields?: ContactCustomField[] | null;
+}
+
+export class ContactsResource {
+  readonly access: ContactAccessResource;
+  readonly vcards: VCardsResource;
+
+  constructor(private readonly http: HttpTransport) {
+    this.access = new ContactAccessResource(http);
+    this.vcards = new VCardsResource(http);
+  }
+
+  async list(options: ListContactsOptions = {}): Promise<Contact[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.q !== undefined) params.q = options.q;
+    if (options.order !== undefined) params.order = options.order;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<{ items: RawContact[] } | RawContact[]>(
+      BASE,
+      params,
+    );
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseContact);
+  }
+
+  async lookup(options: LookupContactsOptions): Promise<Contact[]> {
+    const supplied: Record<string, string | undefined> = {
+      email: options.email,
+      email_contains: options.emailContains,
+      email_domain: options.emailDomain,
+      phone: options.phone,
+      phone_contains: options.phoneContains,
+    };
+    const nonNil = Object.entries(supplied).filter(([, v]) => v !== undefined);
+    if (nonNil.length !== 1) {
+      throw new Error(
+        "lookup() requires exactly one of: email, emailContains, emailDomain, phone, phoneContains.",
+      );
+    }
+    const params = Object.fromEntries(nonNil);
+    const data = await this.http.get<{ items: RawContact[] } | RawContact[]>(
+      `${BASE}/lookup`,
+      params,
+    );
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseContact);
+  }
+
+  async get(contactId: string): Promise<Contact> {
+    const data = await this.http.get<RawContact>(`${BASE}/${contactId}`);
+    return parseContact(data);
+  }
+
+  async create(options: CreateContactOptions = {}): Promise<Contact> {
+    const body: Record<string, unknown> = {};
+    if (options.preferredName !== undefined) body.preferred_name = options.preferredName;
+    if (options.namePrefix !== undefined) body.name_prefix = options.namePrefix;
+    if (options.givenName !== undefined) body.given_name = options.givenName;
+    if (options.middleName !== undefined) body.middle_name = options.middleName;
+    if (options.familyName !== undefined) body.family_name = options.familyName;
+    if (options.nameSuffix !== undefined) body.name_suffix = options.nameSuffix;
+    if (options.companyName !== undefined) body.company_name = options.companyName;
+    if (options.jobTitle !== undefined) body.job_title = options.jobTitle;
+    if (options.birthday !== undefined) body.birthday = options.birthday;
+    if (options.notes !== undefined) body.notes = options.notes;
+    if (options.emails !== undefined) body.emails = options.emails.map(contactEmailToWire);
+    if (options.phones !== undefined) body.phones = options.phones.map(contactPhoneToWire);
+    if (options.websites !== undefined) body.websites = options.websites.map(contactWebsiteToWire);
+    if (options.dates !== undefined) body.dates = options.dates.map(contactDateToWire);
+    if (options.addresses !== undefined) body.addresses = options.addresses.map(contactAddressToWire);
+    if (options.customFields !== undefined) body.custom_fields = options.customFields.map(contactCustomFieldToWire);
+    if (options.accessIdentityIds === undefined || options.accessIdentityIds === "wildcard") {
+      // omit — server wildcards by default
+    } else if (options.accessIdentityIds === null) {
+      body.access_identity_ids = null;
+    } else {
+      body.access_identity_ids = options.accessIdentityIds;
+    }
+    const data = await this.http.post<RawContact>(BASE, body);
+    return parseContact(data);
+  }
+
+  async update(contactId: string, options: UpdateContactOptions): Promise<Contact> {
+    const body: Record<string, unknown> = {};
+    for (const [key, wire] of [
+      ["preferredName", "preferred_name"],
+      ["namePrefix", "name_prefix"],
+      ["givenName", "given_name"],
+      ["middleName", "middle_name"],
+      ["familyName", "family_name"],
+      ["nameSuffix", "name_suffix"],
+      ["companyName", "company_name"],
+      ["jobTitle", "job_title"],
+      ["birthday", "birthday"],
+      ["notes", "notes"],
+    ] as const) {
+      if (key in options) body[wire] = (options as Record<string, unknown>)[key];
+    }
+    if ("emails" in options) {
+      body.emails = options.emails === null ? null : options.emails!.map(contactEmailToWire);
+    }
+    if ("phones" in options) {
+      body.phones = options.phones === null ? null : options.phones!.map(contactPhoneToWire);
+    }
+    if ("websites" in options) {
+      body.websites = options.websites === null ? null : options.websites!.map(contactWebsiteToWire);
+    }
+    if ("dates" in options) {
+      body.dates = options.dates === null ? null : options.dates!.map(contactDateToWire);
+    }
+    if ("addresses" in options) {
+      body.addresses = options.addresses === null ? null : options.addresses!.map(contactAddressToWire);
+    }
+    if ("customFields" in options) {
+      body.custom_fields =
+        options.customFields === null ? null : options.customFields!.map(contactCustomFieldToWire);
+    }
+    const data = await this.http.patch<RawContact>(`${BASE}/${contactId}`, body);
+    return parseContact(data);
+  }
+
+  async delete(contactId: string): Promise<void> {
+    await this.http.delete(`${BASE}/${contactId}`);
+  }
+}

--- a/sdk/typescript/src/contacts/resources/vcards.ts
+++ b/sdk/typescript/src/contacts/resources/vcards.ts
@@ -1,0 +1,44 @@
+/**
+ * inkbox-contacts/resources/vcards.ts
+ *
+ * vCard import / export.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import {
+  ContactImportResult,
+  RawContactImportResult,
+  parseContactImportResult,
+} from "../types.js";
+
+const BASE = "/contacts";
+const VCARD_CONTENT_TYPE = "text/vcard";
+
+export class VCardsResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  /**
+   * Bulk-import vCards.
+   *
+   * @param content - Raw vCard text. Server caps payload at 5 MiB and 1000 cards;
+   *   zero cards returns 422.
+   * @param contentType - MIME type. Defaults to `text/vcard`; `text/x-vcard`
+   *   is also accepted.
+   */
+  async import(
+    content: string | Uint8Array,
+    contentType: string = VCARD_CONTENT_TYPE,
+  ): Promise<ContactImportResult> {
+    const data = await this.http.postRaw<RawContactImportResult>(
+      `${BASE}/import`,
+      content,
+      contentType,
+    );
+    return parseContactImportResult(data);
+  }
+
+  /** Export a single contact as vCard 4.0 text. */
+  async export(contactId: string): Promise<string> {
+    return this.http.getText(`${BASE}/${contactId}.vcf`, VCARD_CONTENT_TYPE);
+  }
+}

--- a/sdk/typescript/src/contacts/types.ts
+++ b/sdk/typescript/src/contacts/types.ts
@@ -114,12 +114,12 @@ export interface RawContactPhone {
 
 export interface RawContactWebsite {
   label?: string | null;
-  value: string;
+  url: string;
 }
 
 export interface RawContactDate {
   label?: string | null;
-  value: string;
+  date: string;
 }
 
 export interface RawContactAddress {
@@ -127,7 +127,7 @@ export interface RawContactAddress {
   street?: string | null;
   city?: string | null;
   region?: string | null;
-  postal_code?: string | null;
+  postal?: string | null;
   country?: string | null;
 }
 
@@ -200,11 +200,11 @@ export function parseContactPhone(r: RawContactPhone): ContactPhone {
 }
 
 export function parseContactWebsite(r: RawContactWebsite): ContactWebsite {
-  return { label: r.label ?? null, value: r.value };
+  return { label: r.label ?? null, value: r.url };
 }
 
 export function parseContactDate(r: RawContactDate): ContactDate {
-  return { label: r.label ?? null, value: r.value };
+  return { label: r.label ?? null, value: r.date };
 }
 
 export function parseContactAddress(r: RawContactAddress): ContactAddress {
@@ -213,7 +213,7 @@ export function parseContactAddress(r: RawContactAddress): ContactAddress {
     street: r.street ?? null,
     city: r.city ?? null,
     region: r.region ?? null,
-    postalCode: r.postal_code ?? null,
+    postalCode: r.postal ?? null,
     country: r.country ?? null,
   };
 }
@@ -307,13 +307,13 @@ export function contactPhoneToWire(p: ContactPhone): RawContactPhone {
 }
 
 export function contactWebsiteToWire(w: ContactWebsite): RawContactWebsite {
-  const out: RawContactWebsite = { value: w.value };
+  const out: RawContactWebsite = { url: w.value };
   if (w.label !== null) out.label = w.label;
   return out;
 }
 
 export function contactDateToWire(d: ContactDate): RawContactDate {
-  const out: RawContactDate = { value: d.value };
+  const out: RawContactDate = { date: d.value };
   if (d.label !== null) out.label = d.label;
   return out;
 }
@@ -324,7 +324,7 @@ export function contactAddressToWire(a: ContactAddress): RawContactAddress {
   if (a.street !== null) out.street = a.street;
   if (a.city !== null) out.city = a.city;
   if (a.region !== null) out.region = a.region;
-  if (a.postalCode !== null) out.postal_code = a.postalCode;
+  if (a.postalCode !== null) out.postal = a.postalCode;
   if (a.country !== null) out.country = a.country;
   return out;
 }

--- a/sdk/typescript/src/contacts/types.ts
+++ b/sdk/typescript/src/contacts/types.ts
@@ -1,0 +1,323 @@
+/**
+ * inkbox-contacts TypeScript SDK — public types.
+ */
+
+export interface ContactEmail {
+  label: string | null;
+  value: string;
+  isPrimary: boolean;
+}
+
+export interface ContactPhone {
+  label: string | null;
+  value: string;
+  isPrimary: boolean;
+}
+
+export interface ContactWebsite {
+  label: string | null;
+  value: string;
+}
+
+export interface ContactDate {
+  label: string | null;
+  /** ISO date (YYYY-MM-DD). */
+  value: string;
+}
+
+export interface ContactAddress {
+  label: string | null;
+  street: string | null;
+  city: string | null;
+  region: string | null;
+  postalCode: string | null;
+  country: string | null;
+}
+
+export interface ContactCustomField {
+  label: string;
+  value: string;
+}
+
+export interface ContactAccess {
+  id: string;
+  contactId: string;
+  /** null = wildcard grant (every active identity sees the contact) */
+  identityId: string | null;
+  createdAt: Date;
+}
+
+export interface Contact {
+  id: string;
+  organizationId: string | null;
+  preferredName: string | null;
+  namePrefix: string | null;
+  givenName: string | null;
+  middleName: string | null;
+  familyName: string | null;
+  nameSuffix: string | null;
+  companyName: string | null;
+  jobTitle: string | null;
+  /** ISO date (YYYY-MM-DD), or null. */
+  birthday: string | null;
+  notes: string | null;
+  emails: ContactEmail[];
+  phones: ContactPhone[];
+  websites: ContactWebsite[];
+  dates: ContactDate[];
+  addresses: ContactAddress[];
+  customFields: ContactCustomField[];
+  access: ContactAccess[];
+  status: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * One card's result inside a bulk vCard import response.
+ *
+ * `contact` is populated when `status === "created"` (and `error` is null);
+ * `error` is populated when `status === "error"` (and `contact` is null).
+ */
+export interface ContactImportResultItem {
+  /** 0-based position within the uploaded vCard stream. */
+  index: number;
+  status: "created" | "error";
+  contact: Contact | null;
+  error: string | null;
+}
+
+export interface ContactImportResult {
+  createdCount: number;
+  errorCount: number;
+  /** Per-card outcome in submission order. */
+  results: ContactImportResultItem[];
+}
+
+// ---- wire types ----
+
+export interface RawContactEmail {
+  label?: string | null;
+  value: string;
+  is_primary?: boolean;
+}
+
+export interface RawContactPhone {
+  label?: string | null;
+  value: string;
+  is_primary?: boolean;
+}
+
+export interface RawContactWebsite {
+  label?: string | null;
+  value: string;
+}
+
+export interface RawContactDate {
+  label?: string | null;
+  value: string;
+}
+
+export interface RawContactAddress {
+  label?: string | null;
+  street?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
+}
+
+export interface RawContactCustomField {
+  label: string;
+  value: string;
+}
+
+export interface RawContactAccess {
+  id: string;
+  contact_id: string;
+  identity_id: string | null;
+  created_at: string;
+}
+
+export interface RawContact {
+  id: string;
+  organization_id?: string | null;
+  preferred_name: string | null;
+  name_prefix?: string | null;
+  given_name: string | null;
+  middle_name?: string | null;
+  family_name: string | null;
+  name_suffix?: string | null;
+  company_name: string | null;
+  job_title: string | null;
+  birthday?: string | null;
+  notes: string | null;
+  emails: RawContactEmail[] | null;
+  phones: RawContactPhone[] | null;
+  websites: RawContactWebsite[] | null;
+  dates: RawContactDate[] | null;
+  addresses: RawContactAddress[] | null;
+  custom_fields: RawContactCustomField[] | null;
+  access: RawContactAccess[] | null;
+  status?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RawContactImportResultItem {
+  index: number;
+  status: "created" | "error";
+  contact?: RawContact | null;
+  error?: string | null;
+}
+
+export interface RawContactImportResult {
+  created_count: number;
+  error_count: number;
+  results?: RawContactImportResultItem[] | null;
+}
+
+// ---- parsers ----
+
+export function parseContactEmail(r: RawContactEmail): ContactEmail {
+  return {
+    label: r.label ?? null,
+    value: r.value,
+    isPrimary: Boolean(r.is_primary),
+  };
+}
+
+export function parseContactPhone(r: RawContactPhone): ContactPhone {
+  return {
+    label: r.label ?? null,
+    value: r.value,
+    isPrimary: Boolean(r.is_primary),
+  };
+}
+
+export function parseContactWebsite(r: RawContactWebsite): ContactWebsite {
+  return { label: r.label ?? null, value: r.value };
+}
+
+export function parseContactDate(r: RawContactDate): ContactDate {
+  return { label: r.label ?? null, value: r.value };
+}
+
+export function parseContactAddress(r: RawContactAddress): ContactAddress {
+  return {
+    label: r.label ?? null,
+    street: r.street ?? null,
+    city: r.city ?? null,
+    region: r.region ?? null,
+    postalCode: r.postal_code ?? null,
+    country: r.country ?? null,
+  };
+}
+
+export function parseContactCustomField(
+  r: RawContactCustomField,
+): ContactCustomField {
+  return { label: r.label, value: r.value };
+}
+
+export function parseContactAccess(r: RawContactAccess): ContactAccess {
+  return {
+    id: r.id,
+    contactId: r.contact_id,
+    identityId: r.identity_id,
+    createdAt: new Date(r.created_at),
+  };
+}
+
+export function parseContact(r: RawContact): Contact {
+  return {
+    id: r.id,
+    organizationId: r.organization_id ?? null,
+    preferredName: r.preferred_name,
+    namePrefix: r.name_prefix ?? null,
+    givenName: r.given_name,
+    middleName: r.middle_name ?? null,
+    familyName: r.family_name,
+    nameSuffix: r.name_suffix ?? null,
+    companyName: r.company_name,
+    jobTitle: r.job_title,
+    birthday: r.birthday ?? null,
+    notes: r.notes,
+    emails: (r.emails ?? []).map(parseContactEmail),
+    phones: (r.phones ?? []).map(parseContactPhone),
+    websites: (r.websites ?? []).map(parseContactWebsite),
+    dates: (r.dates ?? []).map(parseContactDate),
+    addresses: (r.addresses ?? []).map(parseContactAddress),
+    customFields: (r.custom_fields ?? []).map(parseContactCustomField),
+    access: (r.access ?? []).map(parseContactAccess),
+    status: r.status ?? null,
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
+  };
+}
+
+export function parseContactImportResultItem(
+  r: RawContactImportResultItem,
+): ContactImportResultItem {
+  return {
+    index: r.index,
+    status: r.status,
+    contact: r.contact ? parseContact(r.contact) : null,
+    error: r.error ?? null,
+  };
+}
+
+export function parseContactImportResult(
+  r: RawContactImportResult,
+): ContactImportResult {
+  return {
+    createdCount: r.created_count,
+    errorCount: r.error_count,
+    results: (r.results ?? []).map(parseContactImportResultItem),
+  };
+}
+
+// ---- wire encoders ----
+
+export function contactEmailToWire(e: ContactEmail): RawContactEmail {
+  const out: RawContactEmail = { value: e.value };
+  if (e.label !== null) out.label = e.label;
+  if (e.isPrimary) out.is_primary = true;
+  return out;
+}
+
+export function contactPhoneToWire(p: ContactPhone): RawContactPhone {
+  const out: RawContactPhone = { value: p.value };
+  if (p.label !== null) out.label = p.label;
+  if (p.isPrimary) out.is_primary = true;
+  return out;
+}
+
+export function contactWebsiteToWire(w: ContactWebsite): RawContactWebsite {
+  const out: RawContactWebsite = { value: w.value };
+  if (w.label !== null) out.label = w.label;
+  return out;
+}
+
+export function contactDateToWire(d: ContactDate): RawContactDate {
+  const out: RawContactDate = { value: d.value };
+  if (d.label !== null) out.label = d.label;
+  return out;
+}
+
+export function contactAddressToWire(a: ContactAddress): RawContactAddress {
+  const out: RawContactAddress = {};
+  if (a.label !== null) out.label = a.label;
+  if (a.street !== null) out.street = a.street;
+  if (a.city !== null) out.city = a.city;
+  if (a.region !== null) out.region = a.region;
+  if (a.postalCode !== null) out.postal_code = a.postalCode;
+  if (a.country !== null) out.country = a.country;
+  return out;
+}
+
+export function contactCustomFieldToWire(
+  c: ContactCustomField,
+): RawContactCustomField {
+  return { label: c.label, value: c.value };
+}

--- a/sdk/typescript/src/contacts/types.ts
+++ b/sdk/typescript/src/contacts/types.ts
@@ -92,6 +92,10 @@ export interface ContactImportResult {
   errorCount: number;
   /** Per-card outcome in submission order. */
   results: ContactImportResultItem[];
+  /** Convenience: IDs of contacts that were created, in submission order. */
+  readonly createdIds: string[];
+  /** Convenience: per-card entries where `status === "error"`. */
+  readonly errors: ContactImportResultItem[];
 }
 
 // ---- wire types ----
@@ -104,7 +108,7 @@ export interface RawContactEmail {
 
 export interface RawContactPhone {
   label?: string | null;
-  value: string;
+  value_e164: string;
   is_primary?: boolean;
 }
 
@@ -190,7 +194,7 @@ export function parseContactEmail(r: RawContactEmail): ContactEmail {
 export function parseContactPhone(r: RawContactPhone): ContactPhone {
   return {
     label: r.label ?? null,
-    value: r.value,
+    value: r.value_e164,
     isPrimary: Boolean(r.is_primary),
   };
 }
@@ -270,10 +274,19 @@ export function parseContactImportResultItem(
 export function parseContactImportResult(
   r: RawContactImportResult,
 ): ContactImportResult {
+  const results = (r.results ?? []).map(parseContactImportResultItem);
   return {
     createdCount: r.created_count,
     errorCount: r.error_count,
-    results: (r.results ?? []).map(parseContactImportResultItem),
+    results,
+    get createdIds() {
+      return results
+        .filter((i) => i.status === "created" && i.contact !== null)
+        .map((i) => i.contact!.id);
+    },
+    get errors() {
+      return results.filter((i) => i.status === "error");
+    },
   };
 }
 
@@ -287,7 +300,7 @@ export function contactEmailToWire(e: ContactEmail): RawContactEmail {
 }
 
 export function contactPhoneToWire(p: ContactPhone): RawContactPhone {
-  const out: RawContactPhone = { value: p.value };
+  const out: RawContactPhone = { value_e164: p.value };
   if (p.label !== null) out.label = p.label;
   if (p.isPrimary) out.is_primary = true;
   return out;

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -2,6 +2,16 @@
  * inkbox-identities TypeScript SDK — public types.
  */
 
+import type {
+  FilterMode,
+  FilterModeChangeNotice,
+  RawFilterModeChangeNotice,
+} from "../mail/types.js";
+import {
+  FilterMode as FilterModeEnum,
+  parseFilterModeChangeNotice,
+} from "../mail/types.js";
+
 export interface IdentityMailboxCreateOptions {
   displayName?: string;
   emailLocalPart?: string;
@@ -28,8 +38,10 @@ export interface IdentityMailbox {
   id: string;
   emailAddress: string;
   displayName: string | null;
+  filterMode: FilterMode;
   createdAt: Date;
   updatedAt: Date;
+  filterModeChangeNotice: FilterModeChangeNotice | null;
 }
 
 export interface IdentityPhoneNumber {
@@ -43,8 +55,10 @@ export interface IdentityPhoneNumber {
   incomingCallAction: string;
   clientWebsocketUrl: string | null;
   incomingTextWebhookUrl: string | null;
+  filterMode: FilterMode;
   createdAt: Date;
   updatedAt: Date;
+  filterModeChangeNotice: FilterModeChangeNotice | null;
 }
 
 /** Lightweight identity returned by list and update endpoints. */
@@ -72,6 +86,8 @@ export interface RawIdentityMailbox {
   id: string;
   email_address: string;
   display_name: string | null;
+  filter_mode?: string;
+  filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
 }
@@ -84,6 +100,8 @@ export interface RawIdentityPhoneNumber {
   incoming_call_action: string;
   client_websocket_url: string | null;
   incoming_text_webhook_url: string | null;
+  filter_mode?: string;
+  filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
 }
@@ -109,8 +127,12 @@ export function parseIdentityMailbox(r: RawIdentityMailbox): IdentityMailbox {
     id: r.id,
     emailAddress: r.email_address,
     displayName: r.display_name,
+    filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
+    filterModeChangeNotice: r.filter_mode_change_notice
+      ? parseFilterModeChangeNotice(r.filter_mode_change_notice)
+      : null,
   };
 }
 
@@ -123,8 +145,12 @@ export function parseIdentityPhoneNumber(r: RawIdentityPhoneNumber): IdentityPho
     incomingCallAction: r.incoming_call_action,
     clientWebsocketUrl: r.client_websocket_url,
     incomingTextWebhookUrl: r.incoming_text_webhook_url ?? null,
+    filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
+    filterModeChangeNotice: r.filter_mode_change_notice
+      ? parseFilterModeChangeNotice(r.filter_mode_change_notice)
+      : null,
   };
 }
 

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -39,6 +39,11 @@ export interface IdentityMailbox {
   emailAddress: string;
   displayName: string | null;
   filterMode: FilterMode;
+  /**
+   * UUID of the owning agent identity, or `null` if standalone. On the
+   * embedded variant this always equals the owning identity's ID.
+   */
+  agentIdentityId: string | null;
   createdAt: Date;
   updatedAt: Date;
   filterModeChangeNotice: FilterModeChangeNotice | null;
@@ -56,6 +61,11 @@ export interface IdentityPhoneNumber {
   clientWebsocketUrl: string | null;
   incomingTextWebhookUrl: string | null;
   filterMode: FilterMode;
+  /**
+   * UUID of the owning agent identity, or `null` if standalone. On the
+   * embedded variant this always equals the owning identity's ID.
+   */
+  agentIdentityId: string | null;
   createdAt: Date;
   updatedAt: Date;
   filterModeChangeNotice: FilterModeChangeNotice | null;
@@ -87,6 +97,7 @@ export interface RawIdentityMailbox {
   email_address: string;
   display_name: string | null;
   filter_mode?: string;
+  agent_identity_id?: string | null;
   filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
@@ -101,6 +112,7 @@ export interface RawIdentityPhoneNumber {
   client_websocket_url: string | null;
   incoming_text_webhook_url: string | null;
   filter_mode?: string;
+  agent_identity_id?: string | null;
   filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
@@ -128,6 +140,7 @@ export function parseIdentityMailbox(r: RawIdentityMailbox): IdentityMailbox {
     emailAddress: r.email_address,
     displayName: r.display_name,
     filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    agentIdentityId: r.agent_identity_id ?? null,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
     filterModeChangeNotice: r.filter_mode_change_notice
@@ -146,6 +159,7 @@ export function parseIdentityPhoneNumber(r: RawIdentityPhoneNumber): IdentityPho
     clientWebsocketUrl: r.client_websocket_url,
     incomingTextWebhookUrl: r.incoming_text_webhook_url ?? null,
     filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    agentIdentityId: r.agent_identity_id ?? null,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
     filterModeChangeNotice: r.filter_mode_change_notice

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -11,26 +11,49 @@ export type {
   SignupRestrictions,
   AgentSignupStatusResponse,
 } from "./agent_signup/types.js";
-export { InkboxError, InkboxAPIError, InkboxVaultKeyError } from "./_http.js";
+export {
+  DuplicateContactRuleError,
+  InkboxAPIError,
+  InkboxError,
+  InkboxVaultKeyError,
+  RedundantContactAccessGrantError,
+} from "./_http.js";
+export type { InkboxAPIErrorDetail } from "./_http.js";
 export type {
   WhoamiApiKeyResponse,
   WhoamiJwtResponse,
   WhoamiResponse,
 } from "./whoami/types.js";
+export {
+  AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED,
+  AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED,
+  AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED,
+} from "./whoami/types.js";
 export type { SigningKey } from "./signing_keys.js";
 export { verifyWebhook } from "./signing_keys.js";
-export { MessageDirection } from "./mail/types.js";
+export {
+  ContactRuleStatus,
+  FilterMode,
+  MailRuleAction,
+  MailRuleMatchType,
+  MessageDirection,
+  ThreadFolder,
+} from "./mail/types.js";
 export type {
+  FilterModeChangeNotice,
   Mailbox,
+  MailContactRule,
   Message,
   MessageDetail,
   Thread,
   ThreadDetail,
 } from "./mail/types.js";
+export { PhoneRuleAction, PhoneRuleMatchType } from "./phone/types.js";
 export type {
   PhoneNumber,
   PhoneCall,
   PhoneCallWithRateLimit,
+  PhoneContactRule,
   RateLimitInfo,
   PhoneTranscript,
   TextMediaItem,
@@ -45,6 +68,28 @@ export type {
   IdentityPhoneNumberCreateOptions,
   IdentityPhoneNumber,
 } from "./identities/types.js";
+export type {
+  Contact,
+  ContactAccess,
+  ContactAddress,
+  ContactCustomField,
+  ContactDate,
+  ContactEmail,
+  ContactImportResult,
+  ContactImportResultItem,
+  ContactPhone,
+  ContactWebsite,
+  CreateContactOptions,
+  ListContactsOptions,
+  LookupContactsOptions,
+  UpdateContactOptions,
+} from "./contacts/index.js";
+export type { Note, NoteAccess } from "./notes/types.js";
+export type {
+  CreateNoteOptions,
+  ListNotesOptions,
+  UpdateNoteOptions,
+} from "./notes/resources/notes.js";
 export type {
   AccessRule,
   VaultInfo,

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -10,14 +10,18 @@ import { parseWhoamiResponse } from "./whoami/types.js";
 import { MailboxesResource } from "./mail/resources/mailboxes.js";
 import { MessagesResource } from "./mail/resources/messages.js";
 import { ThreadsResource } from "./mail/resources/threads.js";
+import { MailContactRulesResource } from "./mail/resources/contactRules.js";
 import { SigningKeysResource } from "./signing_keys.js";
 import type { SigningKey } from "./signing_keys.js";
 import { PhoneNumbersResource } from "./phone/resources/numbers.js";
 import { CallsResource } from "./phone/resources/calls.js";
 import { TextsResource } from "./phone/resources/texts.js";
 import { TranscriptsResource } from "./phone/resources/transcripts.js";
+import { PhoneContactRulesResource } from "./phone/resources/contactRules.js";
 import { IdentitiesResource } from "./identities/resources/identities.js";
 import { VaultResource } from "./vault/resources/vault.js";
+import { ContactsResource } from "./contacts/resources/contacts.js";
+import { NotesResource } from "./notes/resources/notes.js";
 import { AgentIdentity } from "./agent_identity.js";
 import type { AgentIdentitySummary, CreateIdentityOptions } from "./identities/types.js";
 import type {
@@ -105,13 +109,17 @@ export class Inkbox {
   readonly _mailboxes: MailboxesResource;
   readonly _messages: MessagesResource;
   readonly _threads: ThreadsResource;
+  readonly _mailContactRules: MailContactRulesResource;
   readonly _signingKeys: SigningKeysResource;
   readonly _numbers: PhoneNumbersResource;
   readonly _calls: CallsResource;
   readonly _texts: TextsResource;
   readonly _transcripts: TranscriptsResource;
+  readonly _phoneContactRules: PhoneContactRulesResource;
   readonly _idsResource: IdentitiesResource;
   readonly _vaultResource: VaultResource;
+  readonly _contacts: ContactsResource;
+  readonly _notes: NotesResource;
   readonly _rootApiHttp: HttpTransport;
   /** @internal */
   _vaultUnlockPromise: Promise<unknown> | null = null;
@@ -139,17 +147,22 @@ export class Inkbox {
     const rootApiHttp  = new HttpTransport(options.apiKey, `${baseUrl.replace(/\/$/, "")}/api`, ms, cookieJar);
     const apiHttp      = new HttpTransport(options.apiKey, apiRoot, ms, cookieJar);
 
-    this._mailboxes   = new MailboxesResource(mailHttp);
-    this._messages    = new MessagesResource(mailHttp);
-    this._threads     = new ThreadsResource(mailHttp);
-    this._signingKeys = new SigningKeysResource(apiHttp);
+    this._mailboxes        = new MailboxesResource(mailHttp);
+    this._messages         = new MessagesResource(mailHttp);
+    this._threads          = new ThreadsResource(mailHttp);
+    this._mailContactRules = new MailContactRulesResource(mailHttp);
+    this._signingKeys      = new SigningKeysResource(apiHttp);
 
-    this._numbers     = new PhoneNumbersResource(phoneHttp);
-    this._calls       = new CallsResource(phoneHttp);
-    this._texts       = new TextsResource(phoneHttp);
-    this._transcripts = new TranscriptsResource(phoneHttp);
+    this._numbers          = new PhoneNumbersResource(phoneHttp);
+    this._calls            = new CallsResource(phoneHttp);
+    this._texts            = new TextsResource(phoneHttp);
+    this._transcripts      = new TranscriptsResource(phoneHttp);
+    this._phoneContactRules = new PhoneContactRulesResource(phoneHttp);
 
     this._idsResource = new IdentitiesResource(idsHttp);
+
+    this._contacts = new ContactsResource(apiHttp);
+    this._notes = new NotesResource(apiHttp);
 
     this._rootApiHttp = rootApiHttp;
     this._vaultResource = new VaultResource(vaultHttp, rootApiHttp);
@@ -207,6 +220,18 @@ export class Inkbox {
 
   /** Encrypted vault (info, unlock, secrets). */
   get vault(): VaultResource { return this._vaultResource; }
+
+  /** Org-wide contacts (list, get, create, update, delete, lookup, access, vCards). */
+  get contacts(): ContactsResource { return this._contacts; }
+
+  /** Org-scoped notes with per-identity access grants. */
+  get notes(): NotesResource { return this._notes; }
+
+  /** Mail per-mailbox allow/block rules (+ org-wide list). */
+  get mailContactRules(): MailContactRulesResource { return this._mailContactRules; }
+
+  /** Phone per-number allow/block rules (+ org-wide list). */
+  get phoneContactRules(): PhoneContactRulesResource { return this._phoneContactRules; }
 
   // ------------------------------------------------------------------
   // Org-level operations

--- a/sdk/typescript/src/mail/resources/contactRules.ts
+++ b/sdk/typescript/src/mail/resources/contactRules.ts
@@ -1,0 +1,129 @@
+/**
+ * inkbox-mail/resources/contactRules.ts
+ *
+ * Per-mailbox mail contact rules (allow/block) + org-wide list.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import {
+  ContactRuleStatus,
+  MailContactRule,
+  MailRuleAction,
+  MailRuleMatchType,
+  RawMailContactRule,
+  parseMailContactRule,
+} from "../types.js";
+
+const ORG_BASE = "/contact-rules";
+const MAILBOXES_BASE = "/mailboxes";
+
+function rulePath(emailAddress: string, ruleId?: string): string {
+  const base = `${MAILBOXES_BASE}/${emailAddress}/contact-rules`;
+  return ruleId ? `${base}/${ruleId}` : base;
+}
+
+export interface ListMailContactRulesOptions {
+  action?: MailRuleAction;
+  matchType?: MailRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateMailContactRuleOptions {
+  action: MailRuleAction;
+  matchType: MailRuleMatchType;
+  matchTarget: string;
+  status?: ContactRuleStatus;
+}
+
+export interface UpdateMailContactRuleOptions {
+  action?: MailRuleAction;
+  status?: ContactRuleStatus;
+}
+
+export interface ListAllMailContactRulesOptions {
+  mailboxId?: string;
+  action?: MailRuleAction;
+  matchType?: MailRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export class MailContactRulesResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async list(
+    emailAddress: string,
+    options: ListMailContactRulesOptions = {},
+  ): Promise<MailContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawMailContactRule[] } | RawMailContactRule[]
+    >(rulePath(emailAddress), params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseMailContactRule);
+  }
+
+  async get(emailAddress: string, ruleId: string): Promise<MailContactRule> {
+    const data = await this.http.get<RawMailContactRule>(
+      rulePath(emailAddress, ruleId),
+    );
+    return parseMailContactRule(data);
+  }
+
+  async create(
+    emailAddress: string,
+    options: CreateMailContactRuleOptions,
+  ): Promise<MailContactRule> {
+    const body: Record<string, unknown> = {
+      action: options.action,
+      match_type: options.matchType,
+      match_target: options.matchTarget,
+    };
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.post<RawMailContactRule>(
+      rulePath(emailAddress),
+      body,
+    );
+    return parseMailContactRule(data);
+  }
+
+  async update(
+    emailAddress: string,
+    ruleId: string,
+    options: UpdateMailContactRuleOptions,
+  ): Promise<MailContactRule> {
+    const body: Record<string, unknown> = {};
+    if (options.action !== undefined) body.action = options.action;
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.patch<RawMailContactRule>(
+      rulePath(emailAddress, ruleId),
+      body,
+    );
+    return parseMailContactRule(data);
+  }
+
+  async delete(emailAddress: string, ruleId: string): Promise<void> {
+    await this.http.delete(rulePath(emailAddress, ruleId));
+  }
+
+  async listAll(
+    options: ListAllMailContactRulesOptions = {},
+  ): Promise<MailContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.mailboxId !== undefined) params.mailbox_id = options.mailboxId;
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawMailContactRule[] } | RawMailContactRule[]
+    >(ORG_BASE, params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseMailContactRule);
+  }
+}

--- a/sdk/typescript/src/mail/resources/contactRules.ts
+++ b/sdk/typescript/src/mail/resources/contactRules.ts
@@ -33,7 +33,6 @@ export interface CreateMailContactRuleOptions {
   action: MailRuleAction;
   matchType: MailRuleMatchType;
   matchTarget: string;
-  status?: ContactRuleStatus;
 }
 
 export interface UpdateMailContactRuleOptions {
@@ -84,7 +83,6 @@ export class MailContactRulesResource {
       match_type: options.matchType,
       match_target: options.matchTarget,
     };
-    if (options.status !== undefined) body.status = options.status;
     const data = await this.http.post<RawMailContactRule>(
       rulePath(emailAddress),
       body,

--- a/sdk/typescript/src/mail/resources/mailboxes.ts
+++ b/sdk/typescript/src/mail/resources/mailboxes.ts
@@ -6,6 +6,7 @@
 
 import { HttpTransport } from "../../_http.js";
 import {
+  FilterMode,
   Mailbox,
   Message,
   RawCursorPage,
@@ -68,7 +69,11 @@ export class MailboxesResource {
    */
   async update(
     emailAddress: string,
-    options: { displayName?: string; webhookUrl?: string | null },
+    options: {
+      displayName?: string;
+      webhookUrl?: string | null;
+      filterMode?: FilterMode;
+    },
   ): Promise<Mailbox> {
     const body: Record<string, unknown> = {};
     if (options.displayName !== undefined) {
@@ -76,6 +81,9 @@ export class MailboxesResource {
     }
     if ("webhookUrl" in options) {
       body["webhook_url"] = options.webhookUrl;
+    }
+    if (options.filterMode !== undefined) {
+      body["filter_mode"] = options.filterMode;
     }
     const data = await this.http.patch<RawMailbox>(`${BASE}/${emailAddress}`, body);
     return parseMailbox(data);

--- a/sdk/typescript/src/mail/resources/messages.ts
+++ b/sdk/typescript/src/mail/resources/messages.ts
@@ -175,7 +175,7 @@ export class MessagesResource {
   }
 
   /**
-   * Get a presigned URL for a message attachment.
+   * Get a temporary signed URL for a message attachment.
    *
    * @param emailAddress - Full email address of the owning mailbox.
    * @param messageId - UUID of the message.

--- a/sdk/typescript/src/mail/resources/threads.ts
+++ b/sdk/typescript/src/mail/resources/threads.ts
@@ -1,7 +1,8 @@
 /**
  * inkbox-mail/resources/threads.ts
  *
- * Thread operations: list (auto-paginated), get with messages, delete.
+ * Thread operations: list (auto-paginated), get with messages, folder
+ * listing, per-thread update, and delete.
  */
 
 import { HttpTransport } from "../../_http.js";
@@ -10,6 +11,7 @@ import {
   RawThread,
   Thread,
   ThreadDetail,
+  ThreadFolder,
   parseThread,
   parseThreadDetail,
 } from "../types.js";
@@ -20,28 +22,39 @@ export class ThreadsResource {
   constructor(private readonly http: HttpTransport) {}
 
   /**
-   * Async iterator over all threads in a mailbox, most recent activity first.
+   * Async iterator over threads in a mailbox, most recent activity first.
    *
    * Pagination is handled automatically — just iterate.
    *
+   * @param options.folder - Optional folder filter. When omitted, the server
+   *   returns all visible folders for the caller.
+   * @param options.pageSize - Number of threads fetched per API call (1–100).
+   *
    * @example
    * ```ts
-   * for await (const thread of client.threads.list(emailAddress)) {
-   *   console.log(thread.subject, thread.messageCount);
+   * for await (const thread of client.threads.list(emailAddress, { folder: ThreadFolder.BLOCKED })) {
+   *   console.log(thread.subject, thread.folder);
    * }
    * ```
    */
   async *list(
     emailAddress: string,
-    options?: { pageSize?: number },
+    options?: { folder?: ThreadFolder; pageSize?: number },
   ): AsyncGenerator<Thread> {
     const limit = options?.pageSize ?? DEFAULT_PAGE_SIZE;
     let cursor: string | undefined;
 
     while (true) {
+      const params: Record<string, string | number | undefined> = {
+        limit,
+        cursor,
+      };
+      if (options?.folder !== undefined) {
+        params.folder = options.folder;
+      }
       const page = await this.http.get<RawCursorPage<RawThread>>(
         `/mailboxes/${emailAddress}/threads`,
-        { limit, cursor },
+        params,
       );
       for (const item of page.items) {
         yield parseThread(item);
@@ -49,6 +62,20 @@ export class ThreadsResource {
       if (!page.has_more) break;
       cursor = page.next_cursor ?? undefined;
     }
+  }
+
+  /**
+   * Return the distinct folders that have at least one thread in this
+   * mailbox.
+   *
+   * @returns Sorted list of {@link ThreadFolder} values that currently hold
+   *   at least one non-deleted thread.
+   */
+  async listFolders(emailAddress: string): Promise<ThreadFolder[]> {
+    const data = await this.http.get<string[]>(
+      `/mailboxes/${emailAddress}/threads/folders`,
+    );
+    return data.map((f) => f as ThreadFolder);
   }
 
   /**
@@ -62,6 +89,38 @@ export class ThreadsResource {
       `/mailboxes/${emailAddress}/threads/${threadId}`,
     );
     return parseThreadDetail(data);
+  }
+
+  /**
+   * Update mutable thread fields.
+   *
+   * Returns a bare {@link Thread} (no inlined messages). Use {@link get} to
+   * refetch the thread with messages attached.
+   *
+   * @param options.folder - New folder. `ThreadFolder.BLOCKED` is
+   *   server-assigned by the contact-rule engine and cannot be set by
+   *   clients; passing it throws synchronously without making an HTTP call.
+   */
+  async update(
+    emailAddress: string,
+    threadId: string,
+    options: { folder?: ThreadFolder } = {},
+  ): Promise<Thread> {
+    const body: Record<string, unknown> = {};
+    if (options.folder !== undefined) {
+      if (options.folder === ThreadFolder.BLOCKED) {
+        throw new Error(
+          "folder='blocked' is server-assigned and cannot be set by clients " +
+            "— the server will reject this PATCH.",
+        );
+      }
+      body["folder"] = options.folder;
+    }
+    const data = await this.http.patch<RawThread>(
+      `/mailboxes/${emailAddress}/threads/${threadId}`,
+      body,
+    );
+    return parseThread(data);
   }
 
   /** Delete a thread. */

--- a/sdk/typescript/src/mail/resources/threads.ts
+++ b/sdk/typescript/src/mail/resources/threads.ts
@@ -98,8 +98,8 @@ export class ThreadsResource {
    * refetch the thread with messages attached.
    *
    * @param options.folder - New folder. `ThreadFolder.BLOCKED` is
-   *   server-assigned by the contact-rule engine and cannot be set by
-   *   clients; passing it throws synchronously without making an HTTP call.
+   *   server-assigned and cannot be set by clients; passing it throws
+   *   synchronously without making an HTTP call.
    */
   async update(
     emailAddress: string,

--- a/sdk/typescript/src/mail/types.ts
+++ b/sdk/typescript/src/mail/types.ts
@@ -10,13 +10,74 @@ export enum MessageDirection {
   OUTBOUND = "outbound",
 }
 
+/**
+ * Contact-rule filter mode on a mailbox or phone number.
+ *
+ * `WHITELIST` — only addresses that match an `allow` rule are delivered.
+ * `BLACKLIST` — everything is delivered except matches against a
+ *   `block` rule. This is the default.
+ */
+export enum FilterMode {
+  WHITELIST = "whitelist",
+  BLACKLIST = "blacklist",
+}
+
+/**
+ * Logical folder a thread lives in.
+ *
+ * `BLOCKED` is server-assigned at ingest by the contact-rule engine and
+ * is not client-settable — PATCH will reject it.
+ */
+export enum ThreadFolder {
+  INBOX = "inbox",
+  SPAM = "spam",
+  BLOCKED = "blocked",
+  ARCHIVE = "archive",
+}
+
+/** Whether a matching address is allowed through or blocked. */
+export enum MailRuleAction {
+  ALLOW = "allow",
+  BLOCK = "block",
+}
+
+/** What a mail contact rule matches on. */
+export enum MailRuleMatchType {
+  EXACT_EMAIL = "exact_email",
+  DOMAIN = "domain",
+}
+
+/** Whether a contact rule is currently enforced. */
+export enum ContactRuleStatus {
+  ACTIVE = "active",
+  PAUSED = "paused",
+}
+
+export interface FilterModeChangeNotice {
+  /** The mode the resource was just flipped to. */
+  newFilterMode: FilterMode;
+  /**
+   * Action whose rules are now redundant under `newFilterMode` —
+   * `"block"` under whitelist, `"allow"` under blacklist. Typed as a
+   * free-form string to tolerate new server values.
+   */
+  redundantRuleAction: string;
+  /**
+   * Count of active rules whose `action` equals `redundantRuleAction`.
+   * `0` is a clean flip. Paused / soft-deleted rules are not counted.
+   */
+  redundantRuleCount: number;
+}
+
 export interface Mailbox {
   id: string;
   emailAddress: string;
   displayName: string | null;
   webhookUrl: string | null;
+  filterMode: FilterMode;
   createdAt: Date;
   updatedAt: Date;
+  filterModeChangeNotice: FilterModeChangeNotice | null;
 }
 
 export interface Message {
@@ -56,6 +117,7 @@ export interface Thread {
   id: string;
   mailboxId: string;
   subject: string | null;
+  folder: ThreadFolder;
   messageCount: number;
   lastMessageAt: Date;
   createdAt: Date;
@@ -66,13 +128,32 @@ export interface ThreadDetail extends Thread {
   messages: Message[];
 }
 
+export interface MailContactRule {
+  id: string;
+  mailboxId: string;
+  action: MailRuleAction;
+  matchType: MailRuleMatchType;
+  matchTarget: string;
+  status: ContactRuleStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 // ---- internal raw API shapes (snake_case from JSON) ----
+
+export interface RawFilterModeChangeNotice {
+  new_filter_mode: string;
+  redundant_rule_action: string;
+  redundant_rule_count: number;
+}
 
 export interface RawMailbox {
   id: string;
   email_address: string;
   display_name: string | null;
   webhook_url: string | null;
+  filter_mode?: string;
+  filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
 }
@@ -108,10 +189,22 @@ export interface RawThread {
   id: string;
   mailbox_id: string;
   subject: string | null;
+  folder?: string;
   message_count: number;
   last_message_at: string;
   created_at: string;
   messages?: RawMessage[];
+}
+
+export interface RawMailContactRule {
+  id: string;
+  mailbox_id: string;
+  action: string;
+  match_type: string;
+  match_target: string;
+  status?: string;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface RawCursorPage<T> {
@@ -122,14 +215,28 @@ export interface RawCursorPage<T> {
 
 // ---- parsers ----
 
+export function parseFilterModeChangeNotice(
+  r: RawFilterModeChangeNotice,
+): FilterModeChangeNotice {
+  return {
+    newFilterMode: r.new_filter_mode as FilterMode,
+    redundantRuleAction: r.redundant_rule_action,
+    redundantRuleCount: r.redundant_rule_count,
+  };
+}
+
 export function parseMailbox(r: RawMailbox): Mailbox {
   return {
     id: r.id,
     emailAddress: r.email_address,
     displayName: r.display_name,
     webhookUrl: r.webhook_url,
+    filterMode: (r.filter_mode as FilterMode) ?? FilterMode.BLACKLIST,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
+    filterModeChangeNotice: r.filter_mode_change_notice
+      ? parseFilterModeChangeNotice(r.filter_mode_change_notice)
+      : null,
   };
 }
 
@@ -172,6 +279,7 @@ export function parseThread(r: RawThread): Thread {
     id: r.id,
     mailboxId: r.mailbox_id,
     subject: r.subject,
+    folder: (r.folder as ThreadFolder) ?? ThreadFolder.INBOX,
     messageCount: r.message_count,
     lastMessageAt: new Date(r.last_message_at),
     createdAt: new Date(r.created_at),
@@ -182,5 +290,18 @@ export function parseThreadDetail(r: RawThread): ThreadDetail {
   return {
     ...parseThread(r),
     messages: (r.messages ?? []).map(parseMessage),
+  };
+}
+
+export function parseMailContactRule(r: RawMailContactRule): MailContactRule {
+  return {
+    id: r.id,
+    mailboxId: r.mailbox_id,
+    action: r.action as MailRuleAction,
+    matchType: r.match_type as MailRuleMatchType,
+    matchTarget: r.match_target,
+    status: (r.status as ContactRuleStatus) ?? ContactRuleStatus.ACTIVE,
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
   };
 }

--- a/sdk/typescript/src/mail/types.ts
+++ b/sdk/typescript/src/mail/types.ts
@@ -75,6 +75,12 @@ export interface Mailbox {
   displayName: string | null;
   webhookUrl: string | null;
   filterMode: FilterMode;
+  /**
+   * UUID of the owning agent identity, or `null` if the mailbox is
+   * standalone (not tied to any agent). Always present on every mailbox
+   * response shape.
+   */
+  agentIdentityId: string | null;
   createdAt: Date;
   updatedAt: Date;
   filterModeChangeNotice: FilterModeChangeNotice | null;
@@ -153,6 +159,7 @@ export interface RawMailbox {
   display_name: string | null;
   webhook_url: string | null;
   filter_mode?: string;
+  agent_identity_id?: string | null;
   filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
@@ -232,6 +239,7 @@ export function parseMailbox(r: RawMailbox): Mailbox {
     displayName: r.display_name,
     webhookUrl: r.webhook_url,
     filterMode: (r.filter_mode as FilterMode) ?? FilterMode.BLACKLIST,
+    agentIdentityId: r.agent_identity_id ?? null,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
     filterModeChangeNotice: r.filter_mode_change_notice

--- a/sdk/typescript/src/mail/types.ts
+++ b/sdk/typescript/src/mail/types.ts
@@ -25,8 +25,8 @@ export enum FilterMode {
 /**
  * Logical folder a thread lives in.
  *
- * `BLOCKED` is server-assigned at ingest by the contact-rule engine and
- * is not client-settable — PATCH will reject it.
+ * `BLOCKED` is server-assigned and is not client-settable — PATCH will
+ * reject it.
  */
 export enum ThreadFolder {
   INBOX = "inbox",
@@ -64,7 +64,7 @@ export interface FilterModeChangeNotice {
   redundantRuleAction: string;
   /**
    * Count of active rules whose `action` equals `redundantRuleAction`.
-   * `0` is a clean flip. Paused / soft-deleted rules are not counted.
+   * `0` is a clean flip. Paused / deleted rules are not counted.
    */
   redundantRuleCount: number;
 }

--- a/sdk/typescript/src/notes/resources/noteAccess.ts
+++ b/sdk/typescript/src/notes/resources/noteAccess.ts
@@ -1,0 +1,34 @@
+/**
+ * inkbox-notes/resources/noteAccess.ts
+ *
+ * Per-note access grant management. No wildcards.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import { NoteAccess, RawNoteAccess, parseNoteAccess } from "../types.js";
+
+const BASE = "/notes";
+
+export class NoteAccessResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async list(noteId: string): Promise<NoteAccess[]> {
+    const data = await this.http.get<
+      { items: RawNoteAccess[] } | RawNoteAccess[]
+    >(`${BASE}/${noteId}/access`);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseNoteAccess);
+  }
+
+  async grant(noteId: string, identityId: string): Promise<NoteAccess> {
+    const data = await this.http.post<RawNoteAccess>(
+      `${BASE}/${noteId}/access`,
+      { identity_id: identityId },
+    );
+    return parseNoteAccess(data);
+  }
+
+  async revoke(noteId: string, identityId: string): Promise<void> {
+    await this.http.delete(`${BASE}/${noteId}/access/${identityId}`);
+  }
+}

--- a/sdk/typescript/src/notes/resources/notes.ts
+++ b/sdk/typescript/src/notes/resources/notes.ts
@@ -1,0 +1,82 @@
+/**
+ * inkbox-notes/resources/notes.ts
+ *
+ * Notes CRUD + per-note access subresource.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import { NoteAccessResource } from "./noteAccess.js";
+import { Note, RawNote, parseNote } from "../types.js";
+
+const BASE = "/notes";
+
+export interface ListNotesOptions {
+  q?: string;
+  identityId?: string;
+  limit?: number;
+  offset?: number;
+  order?: "recent" | "created" | string;
+}
+
+export interface CreateNoteOptions {
+  body: string;
+  title?: string;
+}
+
+export interface UpdateNoteOptions {
+  title?: string | null;
+  body?: string;
+}
+
+export class NotesResource {
+  readonly access: NoteAccessResource;
+
+  constructor(private readonly http: HttpTransport) {
+    this.access = new NoteAccessResource(http);
+  }
+
+  async list(options: ListNotesOptions = {}): Promise<Note[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.q !== undefined) params.q = options.q;
+    if (options.identityId !== undefined) params.identity_id = options.identityId;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    if (options.order !== undefined) params.order = options.order;
+    const data = await this.http.get<{ items: RawNote[] } | RawNote[]>(
+      BASE,
+      params,
+    );
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseNote);
+  }
+
+  async get(noteId: string): Promise<Note> {
+    const data = await this.http.get<RawNote>(`${BASE}/${noteId}`);
+    return parseNote(data);
+  }
+
+  async create(options: CreateNoteOptions): Promise<Note> {
+    const body: Record<string, unknown> = { body: options.body };
+    if (options.title !== undefined) body.title = options.title;
+    const data = await this.http.post<RawNote>(BASE, body);
+    return parseNote(data);
+  }
+
+  /**
+   * JSON-merge-patch update.
+   *
+   * `title: null` clears the title (server returns 200). Setting `body`
+   * to null is **not** a legal operation — the server rejects with 422.
+   */
+  async update(noteId: string, options: UpdateNoteOptions): Promise<Note> {
+    const body: Record<string, unknown> = {};
+    if ("title" in options) body.title = options.title;
+    if (options.body !== undefined) body.body = options.body;
+    const data = await this.http.patch<RawNote>(`${BASE}/${noteId}`, body);
+    return parseNote(data);
+  }
+
+  async delete(noteId: string): Promise<void> {
+    await this.http.delete(`${BASE}/${noteId}`);
+  }
+}

--- a/sdk/typescript/src/notes/types.ts
+++ b/sdk/typescript/src/notes/types.ts
@@ -1,0 +1,68 @@
+/**
+ * inkbox-notes TypeScript SDK — public types.
+ */
+
+export interface NoteAccess {
+  id: string;
+  noteId: string;
+  identityId: string;
+  createdAt: Date;
+}
+
+export interface Note {
+  id: string;
+  organizationId: string;
+  createdBy: string;
+  title: string | null;
+  body: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  access: NoteAccess[];
+}
+
+// ---- raw wire shapes ----
+
+export interface RawNoteAccess {
+  id: string;
+  note_id: string;
+  identity_id: string;
+  created_at: string;
+}
+
+export interface RawNote {
+  id: string;
+  organization_id: string;
+  created_by: string;
+  title: string | null;
+  body: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  access?: RawNoteAccess[] | null;
+}
+
+// ---- parsers ----
+
+export function parseNoteAccess(r: RawNoteAccess): NoteAccess {
+  return {
+    id: r.id,
+    noteId: r.note_id,
+    identityId: r.identity_id,
+    createdAt: new Date(r.created_at),
+  };
+}
+
+export function parseNote(r: RawNote): Note {
+  return {
+    id: r.id,
+    organizationId: r.organization_id,
+    createdBy: r.created_by,
+    title: r.title,
+    body: r.body,
+    status: r.status,
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
+    access: (r.access ?? []).map(parseNoteAccess),
+  };
+}

--- a/sdk/typescript/src/phone/resources/contactRules.ts
+++ b/sdk/typescript/src/phone/resources/contactRules.ts
@@ -33,7 +33,6 @@ export interface CreatePhoneContactRuleOptions {
   action: PhoneRuleAction;
   matchTarget: string;
   matchType?: PhoneRuleMatchType;
-  status?: ContactRuleStatus;
 }
 
 export interface UpdatePhoneContactRuleOptions {
@@ -84,7 +83,6 @@ export class PhoneContactRulesResource {
       match_type: options.matchType ?? PhoneRuleMatchType.EXACT_NUMBER,
       match_target: options.matchTarget,
     };
-    if (options.status !== undefined) body.status = options.status;
     const data = await this.http.post<RawPhoneContactRule>(
       rulePath(phoneNumberId),
       body,

--- a/sdk/typescript/src/phone/resources/contactRules.ts
+++ b/sdk/typescript/src/phone/resources/contactRules.ts
@@ -1,0 +1,129 @@
+/**
+ * inkbox-phone/resources/contactRules.ts
+ *
+ * Per-number phone contact rules (allow/block) + org-wide list.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import { ContactRuleStatus } from "../../mail/types.js";
+import {
+  PhoneContactRule,
+  PhoneRuleAction,
+  PhoneRuleMatchType,
+  RawPhoneContactRule,
+  parsePhoneContactRule,
+} from "../types.js";
+
+const ORG_BASE = "/contact-rules";
+const NUMBERS_BASE = "/numbers";
+
+function rulePath(phoneNumberId: string, ruleId?: string): string {
+  const base = `${NUMBERS_BASE}/${phoneNumberId}/contact-rules`;
+  return ruleId ? `${base}/${ruleId}` : base;
+}
+
+export interface ListPhoneContactRulesOptions {
+  action?: PhoneRuleAction;
+  matchType?: PhoneRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreatePhoneContactRuleOptions {
+  action: PhoneRuleAction;
+  matchTarget: string;
+  matchType?: PhoneRuleMatchType;
+  status?: ContactRuleStatus;
+}
+
+export interface UpdatePhoneContactRuleOptions {
+  action?: PhoneRuleAction;
+  status?: ContactRuleStatus;
+}
+
+export interface ListAllPhoneContactRulesOptions {
+  phoneNumberId?: string;
+  action?: PhoneRuleAction;
+  matchType?: PhoneRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export class PhoneContactRulesResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async list(
+    phoneNumberId: string,
+    options: ListPhoneContactRulesOptions = {},
+  ): Promise<PhoneContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawPhoneContactRule[] } | RawPhoneContactRule[]
+    >(rulePath(phoneNumberId), params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parsePhoneContactRule);
+  }
+
+  async get(phoneNumberId: string, ruleId: string): Promise<PhoneContactRule> {
+    const data = await this.http.get<RawPhoneContactRule>(
+      rulePath(phoneNumberId, ruleId),
+    );
+    return parsePhoneContactRule(data);
+  }
+
+  async create(
+    phoneNumberId: string,
+    options: CreatePhoneContactRuleOptions,
+  ): Promise<PhoneContactRule> {
+    const body: Record<string, unknown> = {
+      action: options.action,
+      match_type: options.matchType ?? PhoneRuleMatchType.EXACT_NUMBER,
+      match_target: options.matchTarget,
+    };
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.post<RawPhoneContactRule>(
+      rulePath(phoneNumberId),
+      body,
+    );
+    return parsePhoneContactRule(data);
+  }
+
+  async update(
+    phoneNumberId: string,
+    ruleId: string,
+    options: UpdatePhoneContactRuleOptions,
+  ): Promise<PhoneContactRule> {
+    const body: Record<string, unknown> = {};
+    if (options.action !== undefined) body.action = options.action;
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.patch<RawPhoneContactRule>(
+      rulePath(phoneNumberId, ruleId),
+      body,
+    );
+    return parsePhoneContactRule(data);
+  }
+
+  async delete(phoneNumberId: string, ruleId: string): Promise<void> {
+    await this.http.delete(rulePath(phoneNumberId, ruleId));
+  }
+
+  async listAll(
+    options: ListAllPhoneContactRulesOptions = {},
+  ): Promise<PhoneContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.phoneNumberId !== undefined) params.phone_number_id = options.phoneNumberId;
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawPhoneContactRule[] } | RawPhoneContactRule[]
+    >(ORG_BASE, params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parsePhoneContactRule);
+  }
+}

--- a/sdk/typescript/src/phone/resources/numbers.ts
+++ b/sdk/typescript/src/phone/resources/numbers.ts
@@ -5,6 +5,7 @@
  */
 
 import { HttpTransport } from "../../_http.js";
+import { FilterMode } from "../../mail/types.js";
 import {
   PhoneNumber,
   PhoneTranscript,
@@ -49,6 +50,7 @@ export class PhoneNumbersResource {
       clientWebsocketUrl?: string | null;
       incomingCallWebhookUrl?: string | null;
       incomingTextWebhookUrl?: string | null;
+      filterMode?: FilterMode;
     },
   ): Promise<PhoneNumber> {
     const body: Record<string, unknown> = {};
@@ -63,6 +65,9 @@ export class PhoneNumbersResource {
     }
     if ("incomingTextWebhookUrl" in options) {
       body["incoming_text_webhook_url"] = options.incomingTextWebhookUrl;
+    }
+    if (options.filterMode !== undefined) {
+      body["filter_mode"] = options.filterMode;
     }
     const data = await this.http.patch<RawPhoneNumber>(
       `${BASE}/${phoneNumberId}`,

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -2,6 +2,28 @@
  * inkbox-phone TypeScript SDK — public types.
  */
 
+import type {
+  ContactRuleStatus,
+  FilterMode,
+  FilterModeChangeNotice,
+  RawFilterModeChangeNotice,
+} from "../mail/types.js";
+import {
+  FilterMode as FilterModeEnum,
+  parseFilterModeChangeNotice,
+} from "../mail/types.js";
+
+/** Whether a matching phone number is allowed through or blocked. */
+export enum PhoneRuleAction {
+  ALLOW = "allow",
+  BLOCK = "block",
+}
+
+/** What a phone contact rule matches on. */
+export enum PhoneRuleMatchType {
+  EXACT_NUMBER = "exact_number",
+}
+
 export interface PhoneNumber {
   id: string;
   number: string;
@@ -14,6 +36,19 @@ export interface PhoneNumber {
   clientWebsocketUrl: string | null;
   incomingCallWebhookUrl: string | null;
   incomingTextWebhookUrl: string | null;
+  filterMode: FilterMode;
+  createdAt: Date;
+  updatedAt: Date;
+  filterModeChangeNotice: FilterModeChangeNotice | null;
+}
+
+export interface PhoneContactRule {
+  id: string;
+  phoneNumberId: string;
+  action: PhoneRuleAction;
+  matchType: PhoneRuleMatchType;
+  matchTarget: string;
+  status: ContactRuleStatus;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -103,6 +138,19 @@ export interface RawPhoneNumber {
   client_websocket_url: string | null;
   incoming_call_webhook_url: string | null;
   incoming_text_webhook_url: string | null;
+  filter_mode?: string;
+  filter_mode_change_notice?: RawFilterModeChangeNotice | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RawPhoneContactRule {
+  id: string;
+  phone_number_id: string;
+  action: string;
+  match_type: string;
+  match_target: string;
+  status?: string;
   created_at: string;
   updated_at: string;
 }
@@ -187,6 +235,23 @@ export function parsePhoneNumber(r: RawPhoneNumber): PhoneNumber {
     clientWebsocketUrl: r.client_websocket_url,
     incomingCallWebhookUrl: r.incoming_call_webhook_url,
     incomingTextWebhookUrl: r.incoming_text_webhook_url,
+    filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
+    filterModeChangeNotice: r.filter_mode_change_notice
+      ? parseFilterModeChangeNotice(r.filter_mode_change_notice)
+      : null,
+  };
+}
+
+export function parsePhoneContactRule(r: RawPhoneContactRule): PhoneContactRule {
+  return {
+    id: r.id,
+    phoneNumberId: r.phone_number_id,
+    action: r.action as PhoneRuleAction,
+    matchType: r.match_type as PhoneRuleMatchType,
+    matchTarget: r.match_target,
+    status: (r.status as ContactRuleStatus) ?? ("active" as ContactRuleStatus),
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
   };

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -37,6 +37,12 @@ export interface PhoneNumber {
   incomingCallWebhookUrl: string | null;
   incomingTextWebhookUrl: string | null;
   filterMode: FilterMode;
+  /**
+   * UUID of the owning agent identity, or `null` if the phone number is
+   * standalone (not tied to any agent). Always present on every
+   * phone-number response shape.
+   */
+  agentIdentityId: string | null;
   createdAt: Date;
   updatedAt: Date;
   filterModeChangeNotice: FilterModeChangeNotice | null;
@@ -139,6 +145,7 @@ export interface RawPhoneNumber {
   incoming_call_webhook_url: string | null;
   incoming_text_webhook_url: string | null;
   filter_mode?: string;
+  agent_identity_id?: string | null;
   filter_mode_change_notice?: RawFilterModeChangeNotice | null;
   created_at: string;
   updated_at: string;
@@ -236,6 +243,7 @@ export function parsePhoneNumber(r: RawPhoneNumber): PhoneNumber {
     incomingCallWebhookUrl: r.incoming_call_webhook_url,
     incomingTextWebhookUrl: r.incoming_text_webhook_url,
     filterMode: (r.filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    agentIdentityId: r.agent_identity_id ?? null,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
     filterModeChangeNotice: r.filter_mode_change_notice

--- a/sdk/typescript/src/whoami/types.ts
+++ b/sdk/typescript/src/whoami/types.ts
@@ -4,6 +4,16 @@
  * Types for the ``GET /api/whoami`` endpoint.
  */
 
+/**
+ * Named constants for the `authSubtype` values returned on API-key responses.
+ *
+ * The field itself is typed as `string | null` because the server may add
+ * more variants over time; these constants are the current set.
+ */
+export const AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED = "api_key.admin_scoped";
+export const AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED = "api_key.agent_scoped.claimed";
+export const AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED = "api_key.agent_scoped.unclaimed";
+
 // ---- public interfaces (camelCase) ----
 
 export interface WhoamiApiKeyResponse {

--- a/sdk/typescript/tests/contactRules.test.ts
+++ b/sdk/typescript/tests/contactRules.test.ts
@@ -1,0 +1,148 @@
+// sdk/typescript/tests/contactRules.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpTransport } from "../src/_http.js";
+import { MailContactRulesResource } from "../src/mail/resources/contactRules.js";
+import { PhoneContactRulesResource } from "../src/phone/resources/contactRules.js";
+import {
+  ContactRuleStatus,
+  MailRuleAction,
+  MailRuleMatchType,
+} from "../src/mail/types.js";
+import {
+  PhoneRuleAction,
+  PhoneRuleMatchType,
+} from "../src/phone/types.js";
+
+const BASE = "https://inkbox.ai/api/v1";
+
+const MAIL_RULE_DICT = {
+  id: "aaaa1111-0000-0000-0000-000000000011",
+  mailbox_id: "bbbb2222-0000-0000-0000-000000000001",
+  action: "block",
+  match_type: "domain",
+  match_target: "spam.example",
+  status: "active",
+  created_at: "2026-04-20T00:00:00Z",
+  updated_at: "2026-04-20T00:00:00Z",
+};
+
+const PHONE_RULE_DICT = {
+  id: "aaaa1111-0000-0000-0000-000000000012",
+  phone_number_id: "cccc3333-0000-0000-0000-000000000001",
+  action: "block",
+  match_type: "exact_number",
+  match_target: "+15551234567",
+  status: "active",
+  created_at: "2026-04-20T00:00:00Z",
+  updated_at: "2026-04-20T00:00:00Z",
+};
+
+function ok(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get() { return null; },
+      getSetCookie() { return []; },
+    } as unknown as Headers,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("MailContactRulesResource", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("create sends enum values as strings", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok(MAIL_RULE_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailContactRulesResource(http);
+
+    await resource.create("box@inkbox.ai", {
+      action: MailRuleAction.BLOCK,
+      matchType: MailRuleMatchType.DOMAIN,
+      matchTarget: "spam.example",
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({
+      action: "block",
+      match_type: "domain",
+      match_target: "spam.example",
+    });
+  });
+
+  it("update only sends supplied fields", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ ...MAIL_RULE_DICT, status: "paused" }));
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailContactRulesResource(http);
+
+    await resource.update("box@inkbox.ai", "aaaa1111-0000-0000-0000-000000000011", {
+      status: ContactRuleStatus.PAUSED,
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({ status: "paused" });
+  });
+
+  it("listAll hits /contact-rules with mailboxId param", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok([MAIL_RULE_DICT]));
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailContactRulesResource(http);
+
+    await resource.listAll({ mailboxId: "bbbb2222-0000-0000-0000-000000000001" });
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain("/contact-rules");
+    expect(url).toContain("mailbox_id=bbbb2222");
+  });
+
+  it("listAll forwards action + match_type filters", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok([MAIL_RULE_DICT]));
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailContactRulesResource(http);
+
+    await resource.listAll({
+      action: MailRuleAction.BLOCK,
+      matchType: MailRuleMatchType.DOMAIN,
+    });
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain("action=block");
+    expect(url).toContain("match_type=domain");
+  });
+});
+
+describe("PhoneContactRulesResource", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("create defaults matchType to exact_number", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok(PHONE_RULE_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new PhoneContactRulesResource(http);
+
+    await resource.create("cccc3333-0000-0000-0000-000000000001", {
+      action: PhoneRuleAction.BLOCK,
+      matchTarget: "+15551234567",
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.match_type).toBe("exact_number");
+    expect(body.action).toBe("block");
+  });
+});

--- a/sdk/typescript/tests/contacts.test.ts
+++ b/sdk/typescript/tests/contacts.test.ts
@@ -1,0 +1,279 @@
+// sdk/typescript/tests/contacts.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpTransport } from "../src/_http.js";
+import { ContactsResource } from "../src/contacts/resources/contacts.js";
+import { VCardsResource } from "../src/contacts/resources/vcards.js";
+
+const BASE = "https://inkbox.ai/api/v1";
+const CONTACT_DICT = {
+  id: "aaaa1111-0000-0000-0000-000000000001",
+  organization_id: "org_test",
+  preferred_name: "Alex",
+  name_prefix: null,
+  given_name: "Alex",
+  middle_name: null,
+  family_name: "Waugh",
+  name_suffix: null,
+  company_name: null,
+  job_title: null,
+  birthday: "1990-01-01",
+  notes: null,
+  emails: [{ value: "a@b.com", label: "work", is_primary: true }],
+  phones: [{ value: "+15551234567" }],
+  websites: [],
+  dates: [],
+  addresses: [],
+  custom_fields: [],
+  access: [
+    {
+      id: "bbbb2222-0000-0000-0000-000000000001",
+      contact_id: "aaaa1111-0000-0000-0000-000000000001",
+      identity_id: null,
+      created_at: "2026-04-20T00:00:00Z",
+    },
+  ],
+  status: "active",
+  created_at: "2026-04-20T00:00:00Z",
+  updated_at: "2026-04-20T00:00:00Z",
+};
+
+function makeOkResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get() { return null; },
+      getSetCookie() { return []; },
+    } as unknown as Headers,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe("ContactsResource", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("list with q + order builds query string", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse({ items: [CONTACT_DICT] }));
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    const rows = await resource.list({ q: "al", order: "name", limit: 10 });
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].preferredName).toBe("Alex");
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain("q=al");
+    expect(url).toContain("order=name");
+    expect(url).toContain("limit=10");
+  });
+
+  it("lookup with zero filters throws before HTTP", async () => {
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await expect(resource.lookup({})).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("lookup with two filters throws before HTTP", async () => {
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await expect(resource.lookup({ email: "a@b.com", phone: "+1234" })).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("create with wildcard default omits access_identity_ids", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse(CONTACT_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await resource.create({ preferredName: "Alex" });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.preferred_name).toBe("Alex");
+    expect("access_identity_ids" in body).toBe(false);
+  });
+
+  it("create with empty-list access_identity_ids sends []", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse(CONTACT_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await resource.create({ accessIdentityIds: [] });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.access_identity_ids).toEqual([]);
+  });
+
+  it("create serializes full name fields and birthday", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse(CONTACT_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await resource.create({
+      preferredName: "Alex",
+      namePrefix: "Dr.",
+      givenName: "Alex",
+      middleName: "Q",
+      familyName: "Waugh",
+      nameSuffix: "Jr.",
+      birthday: "1990-01-01",
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.name_prefix).toBe("Dr.");
+    expect(body.middle_name).toBe("Q");
+    expect(body.name_suffix).toBe("Jr.");
+    expect(body.birthday).toBe("1990-01-01");
+  });
+
+  it("update null clears name fields", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse(CONTACT_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await resource.update("aaaa1111-0000-0000-0000-000000000001", {
+      middleName: null,
+      birthday: null,
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.middle_name).toBeNull();
+    expect(body.birthday).toBeNull();
+  });
+
+  it("parsed contact exposes all new name fields", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({
+        ...CONTACT_DICT,
+        name_prefix: "Dr.",
+        middle_name: "Q",
+        name_suffix: "Jr.",
+      }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    const c = await resource.get("aaaa1111-0000-0000-0000-000000000001");
+    expect(c.namePrefix).toBe("Dr.");
+    expect(c.middleName).toBe("Q");
+    expect(c.nameSuffix).toBe("Jr.");
+    expect(c.birthday).toBe("1990-01-01");
+    expect(c.organizationId).toBe("org_test");
+    expect(c.status).toBe("active");
+  });
+
+  it("grant with both identity and wildcard throws", async () => {
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await expect(
+      resource.access.grant("abc", { identityId: "x", wildcard: true }),
+    ).rejects.toThrow();
+  });
+
+  it("grant wildcard sends identity_id: null", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({
+        id: "b1",
+        contact_id: "c1",
+        identity_id: null,
+        created_at: "2026-04-20T00:00:00Z",
+      }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new ContactsResource(http);
+
+    await resource.access.grant("c1", { wildcard: true });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({ identity_id: null });
+  });
+});
+
+describe("VCardsResource", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("import sends raw body with text/vcard and parses results", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({
+        created_count: 1,
+        error_count: 1,
+        results: [
+          { index: 0, status: "created", contact: CONTACT_DICT, error: null },
+          { index: 1, status: "error", contact: null, error: "bad FN" },
+        ],
+      }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new VCardsResource(http);
+
+    const result = await resource.import("BEGIN:VCARD\r\nEND:VCARD\r\n");
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = call.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("text/vcard");
+    expect(typeof call.body).toBe("string");
+    expect(result.createdCount).toBe(1);
+    expect(result.errorCount).toBe(1);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].status).toBe("created");
+    expect(result.results[0].contact?.id).toBe(CONTACT_DICT.id);
+    expect(result.results[1].status).toBe("error");
+    expect(result.results[1].error).toBe("bad FN");
+  });
+
+  it("import then export is a coherent round-trip", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        makeOkResponse({
+          created_count: 1,
+          error_count: 0,
+          results: [{ index: 0, status: "created", contact: CONTACT_DICT, error: null }],
+        }),
+      )
+      .mockResolvedValueOnce(makeOkResponse("BEGIN:VCARD\r\nFN:Alex\r\nEND:VCARD\r\n"));
+    const http = new HttpTransport("k", BASE);
+    const resource = new VCardsResource(http);
+
+    const imported = await resource.import("BEGIN:VCARD\r\nFN:Alex\r\nEND:VCARD\r\n");
+    const created = imported.results[0].contact!;
+    const exported = await resource.export(created.id);
+
+    expect(exported).toContain("BEGIN:VCARD");
+    expect(vi.mocked(fetch).mock.calls).toHaveLength(2);
+  });
+
+  it("export returns raw text and sends Accept: text/vcard", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse("BEGIN:VCARD\r\nEND:VCARD\r\n"));
+    const http = new HttpTransport("k", BASE);
+    const resource = new VCardsResource(http);
+
+    const text = await resource.export("aaaa1111-0000-0000-0000-000000000001");
+
+    expect(text).toContain("BEGIN:VCARD");
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const headers = call.headers as Record<string, string>;
+    expect(headers.Accept).toBe("text/vcard");
+  });
+});

--- a/sdk/typescript/tests/contacts.test.ts
+++ b/sdk/typescript/tests/contacts.test.ts
@@ -19,7 +19,7 @@ const CONTACT_DICT = {
   birthday: "1990-01-01",
   notes: null,
   emails: [{ value: "a@b.com", label: "work", is_primary: true }],
-  phones: [{ value: "+15551234567" }],
+  phones: [{ value_e164: "+15551234567" }],
   websites: [],
   dates: [],
   addresses: [],

--- a/sdk/typescript/tests/errors.test.ts
+++ b/sdk/typescript/tests/errors.test.ts
@@ -1,6 +1,33 @@
 // sdk/typescript/tests/errors.test.ts
-import { describe, it, expect } from "vitest";
-import { InkboxError, InkboxAPIError, InkboxVaultKeyError } from "../src/_http.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  DuplicateContactRuleError,
+  HttpTransport,
+  InkboxAPIError,
+  InkboxError,
+  InkboxVaultKeyError,
+  RedundantContactAccessGrantError,
+} from "../src/_http.js";
+
+const BASE = "https://inkbox.ai/api/v1";
+const API_KEY = "test-key";
+
+function makeHeaders() {
+  return {
+    get() { return null; },
+    getSetCookie() { return []; },
+  } as unknown as Headers;
+}
+
+function makeErrorResponse(status: number, body: unknown) {
+  return {
+    ok: false,
+    status,
+    statusText: "Error",
+    headers: makeHeaders(),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
 
 describe("InkboxError", () => {
   it("sets message and name", () => {
@@ -15,20 +42,22 @@ describe("InkboxError", () => {
 });
 
 describe("InkboxAPIError", () => {
-  it("formats the message correctly", () => {
+  it("formats string detail into message", () => {
     const err = new InkboxAPIError(404, "not found");
     expect(err.message).toBe("HTTP 404: not found");
   });
 
-  it("exposes statusCode and detail", () => {
+  it("exposes statusCode and string detail", () => {
     const err = new InkboxAPIError(422, "validation error");
     expect(err.statusCode).toBe(422);
     expect(err.detail).toBe("validation error");
   });
 
-  it("sets name to InkboxAPIError", () => {
-    const err = new InkboxAPIError(500, "server error");
-    expect(err.name).toBe("InkboxAPIError");
+  it("accepts and round-trips object detail", () => {
+    const err = new InkboxAPIError(409, { error: "redundant_grant", detail: "why" });
+    expect(err.statusCode).toBe(409);
+    expect(typeof err.detail).toBe("object");
+    expect(err.message).toContain("redundant_grant");
   });
 
   it("is an instance of InkboxError", () => {
@@ -44,5 +73,82 @@ describe("InkboxVaultKeyError", () => {
     expect(err).toBeInstanceOf(InkboxError);
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("InkboxVaultKeyError");
+  });
+});
+
+describe("HttpTransport 409 routing", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes duplicate-rule 409 to DuplicateContactRuleError", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeErrorResponse(409, {
+        detail: {
+          existing_rule_id: "aaaa1111-0000-0000-0000-000000000009",
+          message: "exists",
+        },
+      }),
+    );
+    const http = new HttpTransport(API_KEY, BASE);
+    await expect(http.get("/mailboxes/x/contact-rules")).rejects.toMatchObject({
+      name: "DuplicateContactRuleError",
+      existingRuleId: "aaaa1111-0000-0000-0000-000000000009",
+      statusCode: 409,
+    });
+  });
+
+  it("routes redundant_grant 409 to RedundantContactAccessGrantError", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeErrorResponse(409, {
+        detail: {
+          error: "redundant_grant",
+          detail: "wildcard already implies this identity",
+        },
+      }),
+    );
+    const http = new HttpTransport(API_KEY, BASE);
+    await expect(http.post("/contacts/x/access")).rejects.toMatchObject({
+      name: "RedundantContactAccessGrantError",
+      error: "redundant_grant",
+      detailMessage: "wildcard already implies this identity",
+      statusCode: 409,
+    });
+  });
+
+  it("plain-string 409 stays on InkboxAPIError with string detail", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeErrorResponse(409, { detail: "Access already granted" }),
+    );
+    const http = new HttpTransport(API_KEY, BASE);
+    try {
+      await http.post("/contacts/x/access");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InkboxAPIError);
+      expect(err).not.toBeInstanceOf(DuplicateContactRuleError);
+      expect(err).not.toBeInstanceOf(RedundantContactAccessGrantError);
+      expect((err as InkboxAPIError).detail).toBe("Access already granted");
+    }
+  });
+
+  it("preserves dict detail shape on generic 409", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeErrorResponse(409, { detail: { misc: "field" } }),
+    );
+    const http = new HttpTransport(API_KEY, BASE);
+    try {
+      await http.post("/x");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InkboxAPIError);
+      const detail = (err as InkboxAPIError).detail;
+      expect(typeof detail).toBe("object");
+      expect((detail as Record<string, unknown>).misc).toBe("field");
+    }
   });
 });

--- a/sdk/typescript/tests/filterMode.test.ts
+++ b/sdk/typescript/tests/filterMode.test.ts
@@ -1,0 +1,181 @@
+// sdk/typescript/tests/filterMode.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpTransport } from "../src/_http.js";
+import { MailboxesResource } from "../src/mail/resources/mailboxes.js";
+import { ThreadsResource } from "../src/mail/resources/threads.js";
+import {
+  FilterMode,
+  ThreadFolder,
+  parseMailbox,
+} from "../src/mail/types.js";
+
+const BASE = "https://inkbox.ai/api/v1";
+
+const MAILBOX_DICT = {
+  id: "aaaa1111-0000-0000-0000-000000000001",
+  email_address: "box@inkbox.ai",
+  display_name: "Agent",
+  webhook_url: null,
+  created_at: "2026-04-20T00:00:00Z",
+  updated_at: "2026-04-20T00:00:00Z",
+};
+
+const THREAD_DICT = {
+  id: "eeee5555-0000-0000-0000-000000000001",
+  mailbox_id: "aaaa1111-0000-0000-0000-000000000001",
+  subject: "Hello",
+  message_count: 1,
+  last_message_at: "2026-04-20T00:00:00Z",
+  created_at: "2026-04-20T00:00:00Z",
+};
+
+function makeOkResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get() { return null; },
+      getSetCookie() { return []; },
+    } as unknown as Headers,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("Mailbox filterMode", () => {
+  it("parseMailbox defaults filterMode to blacklist", () => {
+    const mb = parseMailbox(MAILBOX_DICT as unknown as any);
+    expect(mb.filterMode).toBe(FilterMode.BLACKLIST);
+    expect(mb.filterModeChangeNotice).toBeNull();
+  });
+
+  it("parseMailbox parses change notice when present", () => {
+    const mb = parseMailbox({
+      ...MAILBOX_DICT,
+      filter_mode: "whitelist",
+      filter_mode_change_notice: {
+        new_filter_mode: "whitelist",
+        redundant_rule_action: "block",
+        redundant_rule_count: 2,
+      },
+    } as unknown as any);
+    expect(mb.filterMode).toBe(FilterMode.WHITELIST);
+    expect(mb.filterModeChangeNotice?.newFilterMode).toBe(FilterMode.WHITELIST);
+    expect(mb.filterModeChangeNotice?.redundantRuleAction).toBe("block");
+    expect(mb.filterModeChangeNotice?.redundantRuleCount).toBe(2);
+  });
+});
+
+describe("MailboxesResource.update filter_mode wiring", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("threads filterMode through to body", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({ ...MAILBOX_DICT, filter_mode: "whitelist" }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailboxesResource(http);
+
+    await resource.update("box@inkbox.ai", { filterMode: FilterMode.WHITELIST });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body.filter_mode).toBe("whitelist");
+  });
+
+  it("omits filter_mode when not supplied", async () => {
+    vi.mocked(fetch).mockResolvedValue(makeOkResponse(MAILBOX_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new MailboxesResource(http);
+
+    await resource.update("box@inkbox.ai", { displayName: "New" });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect("filter_mode" in body).toBe(false);
+  });
+});
+
+describe("ThreadsResource new methods", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("list(folder) threads param through", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({ items: [], next_cursor: null, has_more: false }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new ThreadsResource(http);
+
+    const iterator = resource.list("box@inkbox.ai", { folder: ThreadFolder.BLOCKED });
+    for await (const _ of iterator) {
+      // drain
+    }
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain("folder=blocked");
+  });
+
+  it("listFolders returns an array of ThreadFolder values", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse(["inbox", "spam", "blocked"]),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new ThreadsResource(http);
+
+    const folders = await resource.listFolders("box@inkbox.ai");
+
+    expect(folders).toEqual([
+      ThreadFolder.INBOX,
+      ThreadFolder.SPAM,
+      ThreadFolder.BLOCKED,
+    ]);
+  });
+
+  it("update(folder=BLOCKED) rejects client-side without HTTP", async () => {
+    const http = new HttpTransport("k", BASE);
+    const resource = new ThreadsResource(http);
+
+    await expect(
+      resource.update("box@inkbox.ai", "eeee5555-0000-0000-0000-000000000001", {
+        folder: ThreadFolder.BLOCKED,
+      }),
+    ).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("update returns bare Thread (no messages) and sends folder", async () => {
+    // Server returns ThreadResponse on PATCH (no `messages` field). The SDK
+    // must parse this as Thread, not ThreadDetail — otherwise every update
+    // falsely reports the thread's messages wiped out.
+    vi.mocked(fetch).mockResolvedValue(
+      makeOkResponse({ ...THREAD_DICT, folder: "archive" }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new ThreadsResource(http);
+
+    const result = await resource.update(
+      "box@inkbox.ai",
+      "eeee5555-0000-0000-0000-000000000001",
+      { folder: ThreadFolder.ARCHIVE },
+    );
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({ folder: "archive" });
+    expect(result.folder).toBe(ThreadFolder.ARCHIVE);
+    // Parsed as Thread, so no `messages` field on the returned object
+    expect((result as unknown as { messages?: unknown }).messages).toBeUndefined();
+  });
+});

--- a/sdk/typescript/tests/filterMode.test.ts
+++ b/sdk/typescript/tests/filterMode.test.ts
@@ -16,6 +16,7 @@ const MAILBOX_DICT = {
   email_address: "box@inkbox.ai",
   display_name: "Agent",
   webhook_url: null,
+  agent_identity_id: "eeee5555-0000-0000-0000-000000000001",
   created_at: "2026-04-20T00:00:00Z",
   updated_at: "2026-04-20T00:00:00Z",
 };
@@ -47,6 +48,19 @@ describe("Mailbox filterMode", () => {
     const mb = parseMailbox(MAILBOX_DICT as unknown as any);
     expect(mb.filterMode).toBe(FilterMode.BLACKLIST);
     expect(mb.filterModeChangeNotice).toBeNull();
+  });
+
+  it("parseMailbox surfaces agentIdentityId", () => {
+    const mb = parseMailbox(MAILBOX_DICT as unknown as any);
+    expect(mb.agentIdentityId).toBe("eeee5555-0000-0000-0000-000000000001");
+  });
+
+  it("parseMailbox null agentIdentityId for standalone mailbox", () => {
+    const mb = parseMailbox({
+      ...MAILBOX_DICT,
+      agent_identity_id: null,
+    } as unknown as any);
+    expect(mb.agentIdentityId).toBeNull();
   });
 
   it("parseMailbox parses change notice when present", () => {

--- a/sdk/typescript/tests/identities/types.test.ts
+++ b/sdk/typescript/tests/identities/types.test.ts
@@ -48,6 +48,7 @@ describe("parseIdentityMailbox", () => {
     expect(m.id).toBe(RAW_IDENTITY_MAILBOX.id);
     expect(m.emailAddress).toBe("sales-agent@inkbox.ai");
     expect(m.displayName).toBe("Sales Agent");
+    expect(m.agentIdentityId).toBe("eeee5555-0000-0000-0000-000000000001");
     expect(m.createdAt).toBeInstanceOf(Date);
     expect(m.updatedAt).toBeInstanceOf(Date);
   });
@@ -62,6 +63,7 @@ describe("parseIdentityPhoneNumber", () => {
     expect(p.incomingCallAction).toBe("auto_reject");
     expect(p.clientWebsocketUrl).toBeNull();
     expect(p.incomingTextWebhookUrl).toBeNull();
+    expect(p.agentIdentityId).toBe("eeee5555-0000-0000-0000-000000000001");
     expect(p.createdAt).toBeInstanceOf(Date);
   });
 

--- a/sdk/typescript/tests/notes.test.ts
+++ b/sdk/typescript/tests/notes.test.ts
@@ -1,0 +1,153 @@
+// sdk/typescript/tests/notes.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpTransport } from "../src/_http.js";
+import { NotesResource } from "../src/notes/resources/notes.js";
+import { parseNote } from "../src/notes/types.js";
+
+const BASE = "https://inkbox.ai/api/v1";
+
+const NOTE_DICT = {
+  id: "cccc3333-0000-0000-0000-000000000001",
+  organization_id: "org_test",
+  created_by: "user_test",
+  title: "Design doc",
+  body: "Some body text",
+  status: "active",
+  access: [
+    {
+      id: "gggg7777-0000-0000-0000-000000000001",
+      note_id: "cccc3333-0000-0000-0000-000000000001",
+      identity_id: "dddd4444-0000-0000-0000-000000000001",
+      created_at: "2026-04-20T00:00:00Z",
+    },
+  ],
+  created_at: "2026-04-20T00:00:00Z",
+  updated_at: "2026-04-20T00:00:00Z",
+};
+
+function ok(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get() { return null; },
+      getSetCookie() { return []; },
+    } as unknown as Headers,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("parseNote", () => {
+  it("inlines access grants", () => {
+    const note = parseNote(NOTE_DICT);
+    expect(note.access.length).toBe(1);
+    expect(note.access[0].identityId).toBe("dddd4444-0000-0000-0000-000000000001");
+  });
+
+  it("title: null parses to null", () => {
+    const note = parseNote({ ...NOTE_DICT, title: null });
+    expect(note.title).toBeNull();
+  });
+
+  it("round-trips organizationId, createdBy, and status", () => {
+    const note = parseNote(NOTE_DICT);
+    expect(note.organizationId).toBe("org_test");
+    expect(note.createdBy).toBe("user_test");
+    expect(note.status).toBe("active");
+  });
+});
+
+describe("NotesResource", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("list threads q/identity/order through the query string", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ items: [NOTE_DICT] }));
+    const http = new HttpTransport("k", BASE);
+    const resource = new NotesResource(http);
+
+    await resource.list({
+      q: "design",
+      identityId: "dddd4444-0000-0000-0000-000000000001",
+      order: "recent",
+      limit: 25,
+    });
+
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain("q=design");
+    expect(url).toContain("identity_id=dddd4444");
+    expect(url).toContain("order=recent");
+    expect(url).toContain("limit=25");
+  });
+
+  it("create sends body and title", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok(NOTE_DICT));
+    const http = new HttpTransport("k", BASE);
+    const resource = new NotesResource(http);
+
+    await resource.create({ body: "text", title: "Draft" });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({ body: "text", title: "Draft" });
+  });
+
+  it("update title: null is a valid clear", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ ...NOTE_DICT, title: null }));
+    const http = new HttpTransport("k", BASE);
+    const resource = new NotesResource(http);
+
+    await resource.update("cccc3333-0000-0000-0000-000000000001", { title: null });
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({ title: null });
+  });
+
+  it("access.grant posts identity_id", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      ok({
+        id: "gggg7777-0000-0000-0000-000000000002",
+        note_id: "cccc3333-0000-0000-0000-000000000001",
+        identity_id: "dddd4444-0000-0000-0000-000000000002",
+        created_at: "2026-04-20T00:00:00Z",
+      }),
+    );
+    const http = new HttpTransport("k", BASE);
+    const resource = new NotesResource(http);
+
+    await resource.access.grant(
+      "cccc3333-0000-0000-0000-000000000001",
+      "dddd4444-0000-0000-0000-000000000002",
+    );
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(call.body as string);
+    expect(body).toEqual({
+      identity_id: "dddd4444-0000-0000-0000-000000000002",
+    });
+  });
+
+  it("delete hits /notes/<id>", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      headers: { get() { return null; }, getSetCookie() { return []; } } as unknown as Headers,
+      json: () => Promise.resolve(undefined),
+    } as Response);
+    const http = new HttpTransport("k", BASE);
+    const resource = new NotesResource(http);
+
+    await resource.delete("cccc3333-0000-0000-0000-000000000001");
+
+    const call = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(call.method).toBe("DELETE");
+  });
+});

--- a/sdk/typescript/tests/phone/types.test.ts
+++ b/sdk/typescript/tests/phone/types.test.ts
@@ -24,8 +24,14 @@ describe("parsePhoneNumber", () => {
     expect(n.status).toBe("active");
     expect(n.incomingCallAction).toBe("auto_reject");
     expect(n.clientWebsocketUrl).toBeNull();
+    expect(n.agentIdentityId).toBe("eeee5555-0000-0000-0000-000000000001");
     expect(n.createdAt).toBeInstanceOf(Date);
     expect(n.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("null agentIdentityId for standalone number", () => {
+    const n = parsePhoneNumber({ ...RAW_PHONE_NUMBER, agent_identity_id: null });
+    expect(n.agentIdentityId).toBeNull();
   });
 });
 

--- a/sdk/typescript/tests/sampleData.ts
+++ b/sdk/typescript/tests/sampleData.ts
@@ -6,6 +6,7 @@ export const RAW_MAILBOX = {
   id: "aaaa1111-0000-0000-0000-000000000001",
   email_address: "agent01@inkbox.ai",
   display_name: "Agent 01",
+  agent_identity_id: "eeee5555-0000-0000-0000-000000000001",
   created_at: "2026-03-09T00:00:00Z",
   updated_at: "2026-03-09T00:00:00Z",
 };
@@ -82,6 +83,7 @@ export const RAW_PHONE_NUMBER = {
   incoming_call_action: "auto_reject",
   client_websocket_url: null,
   incoming_text_webhook_url: null,
+  agent_identity_id: "eeee5555-0000-0000-0000-000000000001",
   created_at: "2026-03-09T00:00:00Z",
   updated_at: "2026-03-09T00:00:00Z",
 };
@@ -176,6 +178,7 @@ export const RAW_IDENTITY_MAILBOX = {
   id: "aaaa1111-0000-0000-0000-000000000001",
   email_address: "sales-agent@inkbox.ai",
   display_name: "Sales Agent",
+  agent_identity_id: "eeee5555-0000-0000-0000-000000000001",
   created_at: "2026-03-09T00:00:00Z",
   updated_at: "2026-03-09T00:00:00Z",
 };
@@ -188,6 +191,7 @@ export const RAW_IDENTITY_PHONE = {
   incoming_call_action: "auto_reject",
   client_websocket_url: null,
   incoming_text_webhook_url: null,
+  agent_identity_id: "eeee5555-0000-0000-0000-000000000001",
   created_at: "2026-03-09T00:00:00Z",
   updated_at: "2026-03-09T00:00:00Z",
 };

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,10 +40,10 @@ Once the skills are installed, your coding agent will automatically know how to 
 
 | Skill | Language | Description |
 |-------|----------|-------------|
-| **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, webhooks using the `inkbox` Python SDK |
-| **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, webhooks using the `@inkbox/sdk` TypeScript SDK |
-| **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email and phone for your OpenClaw agent |
-| **inkbox-cli** | TypeScript / Node ≥ 18 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, vault, mailboxes, numbers, webhooks, and signing keys |
+| **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `inkbox` Python SDK |
+| **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `@inkbox/sdk` TypeScript SDK |
+| **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email, phone, text, contacts, notes, contact rules, and vault for your OpenClaw agent |
+| **inkbox-cli** | TypeScript / Node ≥ 18 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |
 | **inkbox-all** | Language-agnostic | Index of all Inkbox skills in this repository, including example skills and links for choosing the right one |
 | **agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
 

--- a/skills/agent-self-signup/SKILL.md
+++ b/skills/agent-self-signup/SKILL.md
@@ -161,7 +161,7 @@ Response:
 ```json
 {
   "email_address": "sales-agent-a1b2c3@inkboxmail.com",
-  "organization_id": "org_agent_...",
+  "organization_id": "org_...",
   "api_key": "ik_live_...",
   "agent_handle": "sales-agent-a1b2c3",
   "claim_status": "UNCLAIMED",
@@ -172,7 +172,7 @@ Response:
 
 Save the `api_key` — it is shown only once.
 
-> **Note:** The `organization_id` returned at signup is provisional (`org_agent_...`). It may change to a real organization ID after verification or human approval. The `/verify` and `/resend-verification` endpoints both return the current `organization_id` — always prefer the most recent value over the one from the initial signup.
+> **Note:** The `organization_id` returned at signup may change after verification or human approval. The `/verify` and `/resend-verification` endpoints both return the current `organization_id` — always prefer the most recent value over the one from the initial signup.
 
 ### Verify
 

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -32,11 +32,11 @@ This skill is just a directory of the other Inkbox skills in this repository. Us
 
 - `inkbox-python`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-python/SKILL.md
-  Python SDK reference for `inkbox`, including identities, email, phone, text/SMS, vault, and signing keys.
+  Python SDK reference for `inkbox`, including identities, email, phone, text/SMS, contacts, notes, contact rules, vault, and signing keys.
 
 - `inkbox-ts`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-ts/SKILL.md
-  TypeScript/JavaScript SDK reference for `@inkbox/sdk`, including identities, email, phone, text/SMS, vault, and signing keys.
+  TypeScript/JavaScript SDK reference for `@inkbox/sdk`, including identities, email, phone, text/SMS, contacts, notes, contact rules, vault, and signing keys.
 
 ## Example Skills
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-cli
-description: Use when running or writing shell commands with the Inkbox CLI (`inkbox` / `@inkbox/cli`) for identities, email, phone, text/SMS, vault, mailbox, phone number, webhook, or signup workflows.
+description: Use when running or writing shell commands with the Inkbox CLI (`inkbox` / `@inkbox/cli`) for identities, email, phone, text/SMS, contacts, notes, contact rules, vault, mailbox, phone number, webhook, or signup workflows.
 user-invocable: false
 ---
 
@@ -71,8 +71,12 @@ These commands can send real traffic or mutate real resources. Confirm with the 
 - `email delete-thread`
 - `vault delete`
 - `mailbox delete`
+- `mailbox update --filter-mode ...` (admin-only; flips allow/block semantics for that mailbox)
 - `number release`
+- `number update --filter-mode ...` (admin-only; same caveat as mailbox)
 - `signing-key create`
+
+Soft-deletes (`contacts delete`, `notes delete`, `mailbox rules delete`, `number rules delete`) are reversible on the server side but still affect downstream filtering — confirm intent before running.
 
 Also confirm before creating or rotating secrets if the values were not explicitly provided by the user.
 
@@ -223,27 +227,94 @@ Secret type flags:
 --data <json> [--notes <text>]
 ```
 
-## Org-Level Mailboxes
+## Admin-Only Mailboxes
 
 ```bash
 inkbox mailbox list
 inkbox mailbox get <email-address>
 inkbox mailbox create -i <handle> [--display-name <name>] [--local-part <part>]
-inkbox mailbox update <email-address> [--display-name <name>] [--webhook-url <url>]
+inkbox mailbox update <email-address> [--display-name <name>] [--webhook-url <url>] [--filter-mode whitelist|blacklist]
 inkbox mailbox delete <email-address>
 ```
 
-## Org-Level Phone Numbers
+`mailbox list` / `get` / `update` rows now include `filterMode` and `agentIdentityId`. `--filter-mode` is admin-only; when the value actually changes, a note is printed to **stderr** telling you how many existing rules are now redundant under the new mode.
+
+### Mailbox Contact Rules (`inkbox mailbox rules …`)
+
+Per-mailbox allow/block rules (combined with the mailbox's `filterMode`).
+
+```bash
+inkbox mailbox rules list --mailbox <email> [--action allow|block] [--match-type exact_email|domain] [--limit <n>] [--offset <n>]
+inkbox mailbox rules list --all-mailboxes [--mailbox-id <id>] [--action …] [--match-type …]    # admin-only
+inkbox mailbox rules get <rule-id> --mailbox <email>
+inkbox mailbox rules create --mailbox <email> --action allow|block --match-type exact_email|domain --match-target <value> [--status active|paused]
+inkbox mailbox rules update <rule-id> --mailbox <email> [--action allow|block] [--status active|paused]   # admin-only
+inkbox mailbox rules delete <rule-id> --mailbox <email>                                                    # admin-only
+```
+
+## Admin-Only Phone Numbers
 
 ```bash
 inkbox number list
 inkbox number get <id>
 inkbox number provision --handle <handle> [--type toll_free|local] [--state NY]
-inkbox number update <id> [--incoming-call-action auto_accept|auto_reject|webhook] ...
+inkbox number update <id> [--incoming-call-action auto_accept|auto_reject|webhook] [--filter-mode whitelist|blacklist] ...
 inkbox number release <number-id>
 ```
 
-Use `--state` only when provisioning a local number.
+Use `--state` only when provisioning a local number. Phone-number rows also carry `filterMode` / `agentIdentityId`; `--filter-mode` is admin-only and prints a stderr note when the value changes.
+
+### Number Contact Rules (`inkbox number rules …`)
+
+Per-number allow/block rules (combined with the number's `filterMode`).
+
+```bash
+inkbox number rules list --number <id> [--action allow|block] [--match-type exact_number] [--limit <n>] [--offset <n>]
+inkbox number rules list --all-numbers [--phone-number-id <id>] [--action …] [--match-type …]   # admin-only
+inkbox number rules get <rule-id> --number <id>
+inkbox number rules create --number <id> --action allow|block --match-target <e164> [--match-type exact_number] [--status active|paused]
+inkbox number rules update <rule-id> --number <id> [--action allow|block] [--status active|paused]   # admin-only
+inkbox number rules delete <rule-id> --number <id>                                                    # admin-only
+```
+
+## Contacts
+
+Admin-only address book. All commands hit the admin endpoints; agents see contacts they've been granted access to.
+
+```bash
+inkbox contacts list [--q <query>] [--order name|recent] [--limit <n>] [--offset <n>]
+inkbox contacts get <contact-id>
+inkbox contacts create --json <payload>            # JSON matching CreateContactOptions
+inkbox contacts update <contact-id> --json <patch>  # JSON-merge-patch
+inkbox contacts delete <contact-id>                # soft-delete
+inkbox contacts lookup (--email <email> | --email-contains <s> | --email-domain <d> | --phone <e164> | --phone-contains <s>)
+inkbox contacts import <file.vcf>                  # bulk vCard import (≤5 MiB, ≤1000 cards)
+inkbox contacts export <contact-id> [--out <file>] # vCard 4.0 to stdout or file
+
+# Per-contact access grants
+inkbox contacts access list <contact-id>
+inkbox contacts access grant <contact-id> (--identity <uuid> | --wildcard)   # admin + JWT only
+inkbox contacts access revoke <contact-id> <identity-id>
+```
+
+`contacts lookup` requires exactly one filter flag. For `create` / `update`, construct the payload carefully — fields include `preferredName`, `givenName`, `familyName`, `companyName`, `jobTitle`, `birthday`, `notes`, and lists `emails` / `phones` / `websites` / `dates` / `addresses` / `customFields` (each list item has `label` / `value`).
+
+## Notes
+
+Admin-only free-form notes with per-identity grants (no wildcard).
+
+```bash
+inkbox notes list [--q <query>] [--identity <uuid>] [--order recent|created] [--limit <n>] [--offset <n>]
+inkbox notes get <note-id>
+inkbox notes create --body <text> [--title <text>]
+inkbox notes update <note-id> [--title <text>] [--body <text>]   # pass --title "" to clear
+inkbox notes delete <note-id>
+
+# Per-note access grants
+inkbox notes access list <note-id>
+inkbox notes access grant <note-id> <identity-id>    # admin + JWT only
+inkbox notes access revoke <note-id> <identity-id>
+```
 
 ## Whoami, Signing Keys, Webhooks
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -76,7 +76,7 @@ These commands can send real traffic or mutate real resources. Confirm with the 
 - `number update --filter-mode ...` (admin-only; same caveat as mailbox)
 - `signing-key create`
 
-Soft-deletes (`contacts delete`, `notes delete`, `mailbox rules delete`, `number rules delete`) are reversible on the server side but still affect downstream filtering — confirm intent before running.
+`contacts delete`, `notes delete`, `mailbox rules delete`, `number rules delete` affect downstream filtering and access — confirm intent before running.
 
 Also confirm before creating or rotating secrets if the values were not explicitly provided by the user.
 
@@ -286,7 +286,7 @@ inkbox contacts list [--q <query>] [--order name|recent] [--limit <n>] [--offset
 inkbox contacts get <contact-id>
 inkbox contacts create --json <payload>            # JSON matching CreateContactOptions
 inkbox contacts update <contact-id> --json <patch>  # JSON-merge-patch
-inkbox contacts delete <contact-id>                # soft-delete
+inkbox contacts delete <contact-id>
 inkbox contacts lookup (--email <email> | --email-contains <s> | --email-domain <d> | --phone <e164> | --phone-contains <s>)
 inkbox contacts import <file.vcf>                  # bulk vCard import (≤5 MiB, ≤1000 cards)
 inkbox contacts export <contact-id> [--out <file>] # vCard 4.0 to stdout or file

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -187,7 +187,7 @@ for (const m of thread.messages) {
 
 ### Thread Folders
 
-Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set). `ThreadFolder` is exported from `@inkbox/sdk`.
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned, never client-set). `ThreadFolder` is exported from `@inkbox/sdk`.
 
 ### Search
 
@@ -210,7 +210,7 @@ const call = await identity.placeCall({
   clientWebsocketUrl: "wss://your-agent.example.com/ws",
 });
 console.log(call.status);
-console.log(call.rateLimit.callsRemaining);   // rolling 24h budget
+console.log(call.rateLimit.callsRemaining);
 
 // List calls (offset pagination)
 const calls = await identity.listCalls({ limit: 10, offset: 0 });
@@ -242,7 +242,7 @@ const unread = await identity.listTexts({ isRead: false });
 // Get a single text message
 const text = await identity.getText("text-uuid");
 console.log(text.type);   // "sms" or "mms"
-if (text.media) {          // MMS media attachments (presigned S3 URLs, 1hr expiry)
+if (text.media) {          // MMS media attachments (temporary signed URLs)
   for (const m of text.media) {
     console.log(m.contentType, m.size, m.url);
   }
@@ -503,7 +503,7 @@ Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChang
 
 ## Contact Rules
 
-Per-mailbox or per-phone-number allow/block lists, enforced at ingest. The active `filterMode` decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+Per-mailbox or per-phone-number allow/block lists, enforced server-side. The active `filterMode` decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
 
 ```js
 import {

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-openclaw
-description: Openclaw-distributed Inkbox skill — use when adding email, phone, text/SMS, encrypted vault, or agent identity features via the Inkbox TypeScript SDK (`@inkbox/sdk`) with openclaw environment and dependency provisioning.
+description: Openclaw-distributed Inkbox skill — use when adding email, phone, text/SMS, contacts, notes, contact rules, encrypted vault, or agent identity features via the Inkbox TypeScript SDK (`@inkbox/sdk`) with openclaw environment and dependency provisioning.
 metadata:
   openclaw:
     emoji: "📬"
@@ -58,16 +58,20 @@ Constructor options: `{ apiKey: string, baseUrl?: string, timeoutMs?: number }`
 ## Core Model
 
 ```
-Inkbox (org-level client)
-├── .createIdentity(handle) → Promise<AgentIdentity>
-├── .getIdentity(handle)    → Promise<AgentIdentity>
-├── .listIdentities()       → Promise<AgentIdentitySummary[]>
-├── .mailboxes              → MailboxesResource
-├── .phoneNumbers           → PhoneNumbersResource
-├── .texts                  → TextsResource
-├── .vault                  → VaultResource
-├── .whoami()               → Promise<WhoamiResponse>
-└── .createSigningKey()     → Promise<SigningKey>
+Inkbox (admin-only client)
+├── .createIdentity(handle)   → Promise<AgentIdentity>
+├── .getIdentity(handle)      → Promise<AgentIdentity>
+├── .listIdentities()         → Promise<AgentIdentitySummary[]>
+├── .mailboxes                → MailboxesResource
+├── .phoneNumbers             → PhoneNumbersResource
+├── .texts                    → TextsResource
+├── .mailContactRules         → MailContactRulesResource
+├── .phoneContactRules        → PhoneContactRulesResource
+├── .contacts                 → ContactsResource   (.access, .vcards)
+├── .notes                    → NotesResource      (.access)
+├── .vault                    → VaultResource
+├── .whoami()                 → Promise<WhoamiResponse>
+└── .createSigningKey()       → Promise<SigningKey>
 
 AgentIdentity (identity-scoped helper)
 ├── .mailbox                → IdentityMailbox | null
@@ -181,10 +185,14 @@ for (const m of thread.messages) {
 }
 ```
 
+### Thread Folders
+
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set). `ThreadFolder` is exported from `@inkbox/sdk`.
+
 ### Search
 
 ```js
-// Org-level mailbox search
+// Admin-only mailbox search
 const results = await inkbox.mailboxes.search(identity.mailbox.emailAddress, {
   q: "invoice",
   limit: 20,
@@ -256,7 +264,7 @@ await identity.markTextRead("text-uuid");
 const readResult = await identity.markTextConversationRead("+15167251294");
 console.log(readResult.updatedCount);
 
-// Org-level: search and delete
+// Admin-only: search and delete
 const results = await inkbox.texts.search(phone.id, { q: "invoice", limit: 20 });
 await inkbox.texts.update(phone.id, "text-uuid", { status: "deleted" });
 ```
@@ -427,7 +435,7 @@ await identity.setTotp(secretId, "otpauth://totp/...?secret=...");
 await identity.removeTotp(secretId);
 ```
 
-#### From the unlocked vault (org-level)
+#### From the unlocked vault (admin-only)
 
 ```js
 const unlocked = await inkbox.vault.unlock("my-Vault-key-01!");
@@ -447,7 +455,7 @@ const code = await unlocked.getTotpCode(secretId);
 | `periodEnd` | `number` | Unix timestamp when the code expires |
 | `secondsRemaining` | `number` | Seconds until expiry |
 
-## Org-level Resources
+## Admin-only Resources
 
 ### Mailboxes (`inkbox.mailboxes`)
 
@@ -458,6 +466,13 @@ const mailbox   = await inkbox.mailboxes.get("abc@inkboxmail.com");
 await inkbox.mailboxes.update(mailbox.emailAddress, { displayName: "New Name" });
 await inkbox.mailboxes.update(mailbox.emailAddress, { webhookUrl: "https://example.com/hook" });
 await inkbox.mailboxes.update(mailbox.emailAddress, { webhookUrl: null });   // remove webhook
+
+// Admin-only: flip the contact-rule filter mode for this mailbox
+const updated = await inkbox.mailboxes.update(mailbox.emailAddress, { filterMode: "whitelist" });
+if (updated.filterModeChangeNotice) {
+  const n = updated.filterModeChangeNotice;
+  console.log(n.redundantRuleCount, n.redundantRuleAction, n.newFilterMode);
+}
 
 const results = await inkbox.mailboxes.search(mailbox.emailAddress, { q: "invoice", limit: 20 });
 await inkbox.mailboxes.delete(mailbox.emailAddress);
@@ -482,6 +497,87 @@ await inkbox.phoneNumbers.update(num.id, {
 
 const hits = await inkbox.phoneNumbers.searchTranscripts(num.id, { q: "refund", party: "remote", limit: 50 });
 await inkbox.phoneNumbers.release(num.id);
+```
+
+Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChangeNotice` fields as mailboxes; flipping `filterMode` is admin-only.
+
+## Contact Rules
+
+Per-mailbox or per-phone-number allow/block lists, enforced at ingest. The active `filterMode` decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+
+```js
+import {
+  MailRuleAction, MailRuleMatchType, PhoneRuleAction, PhoneRuleMatchType,
+  DuplicateContactRuleError,
+} from "@inkbox/sdk";
+
+// Mail — scoped to a single mailbox
+const rule = await inkbox.mailContactRules.create(mailbox.emailAddress, {
+  action: "allow",                  // or "block"
+  matchType: "domain",              // or "exact_email"
+  matchTarget: "example.com",
+});
+await inkbox.mailContactRules.list(mailbox.emailAddress);
+await inkbox.mailContactRules.update(mailbox.emailAddress, rule.id, { status: "paused" });  // admin-only
+await inkbox.mailContactRules.delete(mailbox.emailAddress, rule.id);                        // admin-only
+await inkbox.mailContactRules.listAll({ mailboxId: mailbox.id });                           // admin-only
+
+// Phone — only matchType: "exact_number"
+await inkbox.phoneContactRules.create(num.id, {
+  action: "block",
+  matchType: "exact_number",
+  matchTarget: "+15551234567",
+});
+```
+
+Duplicate `(matchType, matchTarget)` throws `DuplicateContactRuleError` with `.existingRuleId`.
+
+## Contacts
+
+Admin-only address book with per-identity access grants and vCard import/export.
+
+```js
+import { RedundantContactAccessGrantError } from "@inkbox/sdk";
+
+const contact = await inkbox.contacts.create({
+  givenName: "Ada",
+  familyName: "Lovelace",
+  emails: [{ label: "work", value: "ada@example.com" }],
+  phones: [{ label: "mobile", value: "+15551234567" }],
+  // accessIdentityIds defaults to "wildcard"
+});
+await inkbox.contacts.list({ q: "ada", order: "recent", limit: 50 });
+await inkbox.contacts.lookup({ email: "ada@example.com" });   // exactly one filter
+await inkbox.contacts.update(contact.id, { jobTitle: "Analyst" });
+await inkbox.contacts.delete(contact.id);
+
+// Access
+await inkbox.contacts.access.grant(contact.id, { identityId: "agent-uuid" });
+await inkbox.contacts.access.grant(contact.id, { wildcard: true });
+await inkbox.contacts.access.revoke(contact.id, "agent-uuid");
+
+// vCards
+const result = await inkbox.contacts.vcards.import(vcfText);
+const vcf = await inkbox.contacts.vcards.export(contact.id);
+```
+
+Redundant access grants throw `RedundantContactAccessGrantError`.
+
+Before creating or deleting contacts on a shared org, confirm with the user.
+
+## Notes
+
+Admin-only free-form notes with per-identity grants (no wildcard).
+
+```js
+const note = await inkbox.notes.create({ body: "Prefers email follow-up.", title: "Ada" });
+await inkbox.notes.list({ q: "email", identityId: "agent-uuid", order: "recent" });
+await inkbox.notes.update(note.id, { body: "Updated body" });
+await inkbox.notes.update(note.id, { title: null });   // clear title; body cannot be null
+await inkbox.notes.delete(note.id);
+
+await inkbox.notes.access.grant(note.id, "agent-uuid");
+await inkbox.notes.access.revoke(note.id, "agent-uuid");
 ```
 
 ## Whoami
@@ -523,17 +619,26 @@ Algorithm: HMAC-SHA256 over `"{requestId}.{timestamp}.{body}"`.
 ## Error Handling
 
 ```js
-import { InkboxAPIError } from "@inkbox/sdk";
+import {
+  InkboxAPIError,
+  DuplicateContactRuleError,
+  RedundantContactAccessGrantError,
+} from "@inkbox/sdk";
 
 try {
   const identity = await inkbox.getIdentity("unknown");
 } catch (e) {
   if (e instanceof InkboxAPIError) {
     console.log(e.statusCode);   // HTTP status (e.g. 404)
-    console.log(e.detail);       // message from API
+    console.log(e.detail);       // string for legacy errors, object for structured ones
   }
 }
 ```
+
+`InkboxAPIError.detail` may be a string or a structured object. Catch the narrower subclasses when you need parsed fields:
+
+- `DuplicateContactRuleError` — 409 creating a duplicate `(matchType, matchTarget)` on the same mailbox/number. Exposes `.existingRuleId`.
+- `RedundantContactAccessGrantError` — 409 when a contact-access grant is redundant (e.g. per-identity on top of an active wildcard). Exposes `.error` and `.detailMessage`.
 
 - If Inkbox returns `401 Unauthorized`, tell the user the API key was rejected and ask them to verify or rotate `INKBOX_API_KEY`
 - If `INKBOX_AGENT_HANDLE` is missing, ask the user which identity to use or create one first

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -140,7 +140,7 @@ for m in thread.messages:
 
 ### Thread Folders
 
-Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set).
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned, never client-set).
 
 ```python
 from inkbox import ThreadFolder
@@ -158,7 +158,7 @@ call = identity.place_call(
     client_websocket_url="wss://your-agent.example.com/ws",
 )
 print(call.status)
-print(call.rate_limit.calls_remaining)   # rolling 24h budget
+print(call.rate_limit.calls_remaining)
 
 # List calls (offset pagination)
 calls = identity.list_calls(limit=10, offset=0)
@@ -184,7 +184,7 @@ unread = identity.list_texts(is_read=False)
 # Get a single text message
 text = identity.get_text("text-uuid")
 print(text.type)   # "sms" or "mms"
-if text.media:     # MMS media attachments (presigned S3 URLs, 1hr expiry)
+if text.media:     # MMS media attachments (temporary signed URLs)
     for m in text.media:
         print(m.content_type, m.size, m.url)
 
@@ -439,7 +439,7 @@ Phone numbers carry the same `filter_mode` / `agent_identity_id` / `filter_mode_
 
 ## Contact Rules
 
-Per-mailbox or per-phone-number allow/block lists, enforced by the server at ingest. The active `filter_mode` on the owning resource controls whether the rules are interpreted as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+Per-mailbox or per-phone-number allow/block lists, enforced server-side. The active `filter_mode` on the owning resource controls whether the rules are interpreted as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
 
 ```python
 from inkbox import (
@@ -505,7 +505,7 @@ contact = inkbox.contacts.create(
 inkbox.contacts.get(str(contact.id))
 inkbox.contacts.list(q="ada", order="recent", limit=50, offset=0)
 inkbox.contacts.update(str(contact.id), job_title="Analyst")       # JSON-merge-patch via kwargs
-inkbox.contacts.delete(str(contact.id))                            # soft-delete
+inkbox.contacts.delete(str(contact.id))
 
 # Reverse-lookup — exactly one filter required (else ValueError before HTTP)
 inkbox.contacts.lookup(email="ada@example.com")

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-python
-description: Use when writing Python code that imports from `inkbox`, uses `pip install inkbox`, or when adding email, phone, text/SMS, vault, or agent identity features using the Inkbox Python SDK.
+description: Use when writing Python code that imports from `inkbox`, uses `pip install inkbox`, or when adding email, phone, text/SMS, contacts, notes, contact rules, vault, or agent identity features using the Inkbox Python SDK.
 user-invocable: false
 ---
 
@@ -28,16 +28,20 @@ Constructor: `Inkbox(api_key, base_url="https://inkbox.ai", timeout=30.0)`
 ## Core Model
 
 ```
-Inkbox (org-level client)
-├── .create_identity(handle) → AgentIdentity
-├── .get_identity(handle)    → AgentIdentity
-├── .list_identities()       → list[AgentIdentitySummary]
-├── .mailboxes               → MailboxesResource
-├── .phone_numbers           → PhoneNumbersResource
-├── .texts                   → TextsResource
-├── .vault                   → VaultResource
-├── .whoami()                → WhoamiResponse
-└── .create_signing_key()    → SigningKey
+Inkbox (admin-only client)
+├── .create_identity(handle)  → AgentIdentity
+├── .get_identity(handle)     → AgentIdentity
+├── .list_identities()        → list[AgentIdentitySummary]
+├── .mailboxes                → MailboxesResource
+├── .phone_numbers            → PhoneNumbersResource
+├── .texts                    → TextsResource
+├── .mail_contact_rules       → MailContactRulesResource
+├── .phone_contact_rules      → PhoneContactRulesResource
+├── .contacts                 → ContactsResource  (.access, .vcards)
+├── .notes                    → NotesResource     (.access)
+├── .vault                    → VaultResource
+├── .whoami()                 → WhoamiResponse
+└── .create_signing_key()     → SigningKey
 
 AgentIdentity (identity-scoped helper)
 ├── .mailbox                 → IdentityMailbox | None
@@ -134,6 +138,17 @@ for m in thread.messages:
     print(f"[{m.from_address}] {m.subject}")
 ```
 
+### Thread Folders
+
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set).
+
+```python
+from inkbox import ThreadFolder
+# Thread.folder / ThreadDetail.folder is always one of the four values above.
+```
+
+Low-level folder listing / per-thread updates (`list(folder=…)`, `list_folders(email)`, `update(..., folder=…)`) live on `ThreadsResource`. Passing `folder="blocked"` to `update` raises `ValueError` before the HTTP call.
+
 ## Phone
 
 ```python
@@ -188,7 +203,7 @@ identity.mark_text_read("text-uuid")
 result = identity.mark_text_conversation_read("+15167251294")
 print(result["updated_count"])
 
-# Org-level: search, update, delete
+# Admin-only: search, update, delete
 results = inkbox.texts.search(phone.id, q="invoice", limit=20)
 inkbox.texts.update(phone.id, "text-uuid", status="deleted")
 ```
@@ -350,7 +365,7 @@ identity.set_totp(secret_id, "otpauth://totp/...?secret=...")
 identity.remove_totp(secret_id)
 ```
 
-### From the unlocked vault (org-level)
+### From the unlocked vault (admin-only)
 
 ```python
 unlocked = inkbox.vault.unlock("my-Vault-key-01!")
@@ -370,7 +385,7 @@ code = unlocked.get_totp_code(secret_id)
 | `period_end` | `int` | Unix timestamp when the code expires |
 | `seconds_remaining` | `int` | Seconds until expiry |
 
-## Org-level Resources
+## Admin-only Resources
 
 ### Mailboxes (`inkbox.mailboxes`)
 
@@ -381,6 +396,17 @@ mailbox   = inkbox.mailboxes.get("abc@inkboxmail.com")
 inkbox.mailboxes.update(mailbox.email_address, display_name="New Name")
 inkbox.mailboxes.update(mailbox.email_address, webhook_url="https://example.com/hook")
 inkbox.mailboxes.update(mailbox.email_address, webhook_url=None)   # remove webhook
+
+# Switch contact-rule filter mode (admin-only — agent-scoped keys get 403)
+updated = inkbox.mailboxes.update(mailbox.email_address, filter_mode="whitelist")
+if updated.filter_mode_change_notice:
+    # Populated when filter_mode actually changed — tells you how many
+    # rules are now redundant under the new mode.
+    n = updated.filter_mode_change_notice
+    print(n.redundant_rule_count, n.redundant_rule_action, n.new_filter_mode)
+
+# Mailbox responses now also carry mailbox.agent_identity_id when the
+# mailbox is linked to an identity.
 
 results = inkbox.mailboxes.search(mailbox.email_address, q="invoice", limit=20)
 inkbox.mailboxes.delete(mailbox.email_address)
@@ -409,6 +435,124 @@ hits = inkbox.phone_numbers.search_transcripts(number.id, q="refund", party="rem
 inkbox.phone_numbers.release(number.id)
 ```
 
+Phone numbers carry the same `filter_mode` / `agent_identity_id` / `filter_mode_change_notice` fields as mailboxes; flipping `filter_mode` is admin-only and returns a change-notice when the value actually changed.
+
+## Contact Rules
+
+Per-mailbox or per-phone-number allow/block lists, enforced by the server at ingest. The active `filter_mode` on the owning resource controls whether the rules are interpreted as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+
+```python
+from inkbox import (
+    MailRuleAction, MailRuleMatchType, PhoneRuleAction, PhoneRuleMatchType,
+    ContactRuleStatus, DuplicateContactRuleError,
+)
+
+# Mail rules — scoped to a single mailbox
+rule = inkbox.mail_contact_rules.create(
+    mailbox.email_address,
+    action=MailRuleAction.ALLOW,         # or BLOCK
+    match_type=MailRuleMatchType.DOMAIN, # or EXACT_EMAIL
+    match_target="example.com",
+    status=ContactRuleStatus.ACTIVE,     # default; or PAUSED
+)
+inkbox.mail_contact_rules.list(mailbox.email_address)
+inkbox.mail_contact_rules.get(mailbox.email_address, rule.id)
+inkbox.mail_contact_rules.update(mailbox.email_address, rule.id, status="paused")  # admin-only
+inkbox.mail_contact_rules.delete(mailbox.email_address, rule.id)                   # admin-only
+
+# Admin-only list; optionally narrow to a single mailbox_id
+all_rules = inkbox.mail_contact_rules.list_all(mailbox_id=str(mailbox.id))
+
+# Duplicate (match_type, match_target) on the same mailbox raises 409:
+try:
+    inkbox.mail_contact_rules.create(
+        mailbox.email_address,
+        action="allow", match_type="domain", match_target="example.com",
+    )
+except DuplicateContactRuleError as e:
+    print(e.existing_rule_id)   # UUID of the rule that already matched
+
+# Phone rules — same shape, only match_type="exact_number" is supported.
+inkbox.phone_contact_rules.create(
+    number.id,
+    action=PhoneRuleAction.BLOCK,
+    match_type=PhoneRuleMatchType.EXACT_NUMBER,
+    match_target="+15551234567",
+)
+inkbox.phone_contact_rules.list(number.id)
+inkbox.phone_contact_rules.list_all(phone_number_id=str(number.id))
+```
+
+## Contacts
+
+Admin-only address book with per-identity access grants and vCard import/export.
+
+```python
+from inkbox import (
+    Contact, ContactEmail, ContactPhone, ContactAddress,
+    RedundantContactAccessGrantError,
+)
+
+# CRUD
+contact = inkbox.contacts.create(
+    given_name="Ada",
+    family_name="Lovelace",
+    emails=[ContactEmail(label="work", value="ada@example.com")],
+    phones=[ContactPhone(label="mobile", value="+15551234567")],
+    # access_identity_ids defaults to "wildcard" (every active identity);
+    # pass [] for admin-only, or a list of identity UUIDs for explicit grants.
+)
+inkbox.contacts.get(str(contact.id))
+inkbox.contacts.list(q="ada", order="recent", limit=50, offset=0)
+inkbox.contacts.update(str(contact.id), job_title="Analyst")       # JSON-merge-patch via kwargs
+inkbox.contacts.delete(str(contact.id))                            # soft-delete
+
+# Reverse-lookup — exactly one filter required (else ValueError before HTTP)
+inkbox.contacts.lookup(email="ada@example.com")
+inkbox.contacts.lookup(email_domain="example.com")
+inkbox.contacts.lookup(phone="+15551234567")
+inkbox.contacts.lookup(email_contains="ada")
+inkbox.contacts.lookup(phone_contains="555")
+
+# Access grants (admin + JWT only; agents can self-revoke)
+inkbox.contacts.access.list(str(contact.id))
+inkbox.contacts.access.grant(str(contact.id), identity_id="agent-uuid")
+inkbox.contacts.access.grant(str(contact.id), wildcard=True)       # every active identity
+inkbox.contacts.access.revoke(str(contact.id), "agent-uuid")
+
+# Redundant grants (e.g. per-identity on top of wildcard) raise 409
+try:
+    inkbox.contacts.access.grant(str(contact.id), identity_id="agent-uuid")
+except RedundantContactAccessGrantError as e:
+    print(e.error, e.detail_message)
+
+# vCards
+result = inkbox.contacts.vcards.import_vcards(vcf_text)   # bulk, ≤5 MiB, ≤1000 cards
+print(result.created_ids)     # list[UUID]
+for item in result.errors:    # list[ContactImportResultItem]
+    print(item.index, item.error)
+
+vcf = inkbox.contacts.vcards.export_vcard(str(contact.id))  # vCard 4.0 string
+```
+
+## Notes
+
+Admin-only free-form notes with per-identity access grants. Identities must be granted access explicitly — there is no wildcard for notes.
+
+```python
+note = inkbox.notes.create(body="Customer prefers email follow-up.", title="Ada")
+inkbox.notes.get(str(note.id))
+inkbox.notes.list(q="email", identity_id="agent-uuid", order="recent", limit=50)
+inkbox.notes.update(str(note.id), body="Updated body")
+inkbox.notes.update(str(note.id), title=None)   # clear title (body cannot be null)
+inkbox.notes.delete(str(note.id))
+
+# Access grants (admin + JWT only)
+inkbox.notes.access.list(str(note.id))
+inkbox.notes.access.grant(str(note.id), identity_id="agent-uuid")
+inkbox.notes.access.revoke(str(note.id), "agent-uuid")
+```
+
 ## Whoami
 
 ```python
@@ -418,7 +562,20 @@ print(info.auth_type)        # "api_key" or "jwt"
 print(info.organization_id)
 ```
 
-Returns `WhoamiApiKeyResponse` (with `key_id`, `label`, `creator_type`, etc.) or `WhoamiJwtResponse` (with `email`, `org_role`, etc.) based on `auth_type`.
+Returns `WhoamiApiKeyResponse` (with `key_id`, `label`, `creator_type`, `auth_subtype`, etc.) or `WhoamiJwtResponse` (with `email`, `org_role`, etc.) based on `auth_type`.
+
+For branching on API-key scope, compare against the exported constants:
+
+```python
+from inkbox import (
+    AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED,
+    AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED,
+    AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED,
+)
+
+if info.auth_type == "api_key" and info.auth_subtype == AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED:
+    ...   # admin-only operations (filter_mode flips, rule updates/deletes, etc.)
+```
 
 ## Webhooks & Signature Verification
 
@@ -443,14 +600,23 @@ Algorithm: HMAC-SHA256 over `"{request_id}.{timestamp}.{body}"`.
 ## Error Handling
 
 ```python
-from inkbox import InkboxAPIError
+from inkbox import (
+    InkboxAPIError,
+    DuplicateContactRuleError,
+    RedundantContactAccessGrantError,
+)
 
 try:
     identity = inkbox.get_identity("unknown")
 except InkboxAPIError as e:
     print(e.status_code)   # HTTP status (e.g. 404)
-    print(e.detail)        # message from API
+    print(e.detail)        # str for legacy errors, dict for structured ones
 ```
+
+`InkboxAPIError.detail` can now be a `dict` for structured responses (e.g. contact-rule / access conflicts). Catch the narrower subclasses when you need the parsed fields:
+
+- `DuplicateContactRuleError` — 409 when creating a contact rule with an already-taken `(match_type, match_target)` on the same resource. Exposes `.existing_rule_id: UUID`.
+- `RedundantContactAccessGrantError` — 409 when a contact-access grant is redundant (e.g. per-identity grant on top of an active wildcard). Exposes `.error` and `.detail_message`.
 
 ## Key Conventions
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -444,16 +444,16 @@ Per-mailbox or per-phone-number allow/block lists, enforced server-side. The act
 ```python
 from inkbox import (
     MailRuleAction, MailRuleMatchType, PhoneRuleAction, PhoneRuleMatchType,
-    ContactRuleStatus, DuplicateContactRuleError,
+    DuplicateContactRuleError,
 )
 
-# Mail rules — scoped to a single mailbox
+# Mail rules — scoped to a single mailbox. New rules always start active;
+# call `update(..., status="paused")` afterwards to pause one.
 rule = inkbox.mail_contact_rules.create(
     mailbox.email_address,
     action=MailRuleAction.ALLOW,         # or BLOCK
     match_type=MailRuleMatchType.DOMAIN, # or EXACT_EMAIL
     match_target="example.com",
-    status=ContactRuleStatus.ACTIVE,     # default; or PAUSED
 )
 inkbox.mail_contact_rules.list(mailbox.email_address)
 inkbox.mail_contact_rules.get(mailbox.email_address, rule.id)

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -464,15 +464,15 @@ Per-mailbox or per-phone-number allow/block lists, enforced server-side. The act
 ```typescript
 import {
   MailRuleAction, MailRuleMatchType, PhoneRuleAction, PhoneRuleMatchType,
-  ContactRuleStatus, DuplicateContactRuleError,
+  DuplicateContactRuleError,
 } from "@inkbox/sdk";
 
-// Mail rules — scoped to a single mailbox
+// Mail rules — scoped to a single mailbox. New rules always start active;
+// call `update(..., { status: "paused" })` afterwards to pause one.
 const rule = await inkbox.mailContactRules.create(mailbox.emailAddress, {
   action: MailRuleAction.ALLOW,          // or BLOCK
   matchType: MailRuleMatchType.DOMAIN,   // or EXACT_EMAIL
   matchTarget: "example.com",
-  status: ContactRuleStatus.ACTIVE,      // default; or PAUSED
 });
 await inkbox.mailContactRules.list(mailbox.emailAddress);
 await inkbox.mailContactRules.get(mailbox.emailAddress, rule.id);

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-ts
-description: Use when writing TypeScript or JavaScript code that imports from `@inkbox/sdk`, uses `npm install @inkbox/sdk`, or when adding email, phone, text/SMS, vault, or agent identity features using the Inkbox TypeScript SDK.
+description: Use when writing TypeScript or JavaScript code that imports from `@inkbox/sdk`, uses `npm install @inkbox/sdk`, or when adding email, phone, text/SMS, contacts, notes, contact rules, vault, or agent identity features using the Inkbox TypeScript SDK.
 user-invocable: false
 ---
 
@@ -27,16 +27,20 @@ Constructor options: `{ apiKey: string, baseUrl?: string, timeoutMs?: number }`
 ## Core Model
 
 ```
-Inkbox (org-level client)
-├── .createIdentity(handle) → Promise<AgentIdentity>
-├── .getIdentity(handle)    → Promise<AgentIdentity>
-├── .listIdentities()       → Promise<AgentIdentitySummary[]>
-├── .mailboxes              → MailboxesResource
-├── .phoneNumbers           → PhoneNumbersResource
-├── .texts                  → TextsResource
-├── .vault                  → VaultResource
-├── .whoami()               → Promise<WhoamiResponse>
-└── .createSigningKey()     → Promise<SigningKey>
+Inkbox (admin-only client)
+├── .createIdentity(handle)   → Promise<AgentIdentity>
+├── .getIdentity(handle)      → Promise<AgentIdentity>
+├── .listIdentities()         → Promise<AgentIdentitySummary[]>
+├── .mailboxes                → MailboxesResource
+├── .phoneNumbers             → PhoneNumbersResource
+├── .texts                    → TextsResource
+├── .mailContactRules         → MailContactRulesResource
+├── .phoneContactRules        → PhoneContactRulesResource
+├── .contacts                 → ContactsResource   (.access, .vcards)
+├── .notes                    → NotesResource      (.access)
+├── .vault                    → VaultResource
+├── .whoami()                 → Promise<WhoamiResponse>
+└── .createSigningKey()       → Promise<SigningKey>
 
 AgentIdentity (identity-scoped helper)
 ├── .mailbox                → IdentityMailbox | null
@@ -139,6 +143,17 @@ for (const m of thread.messages) {
 }
 ```
 
+### Thread Folders
+
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set).
+
+```typescript
+import { ThreadFolder } from "@inkbox/sdk";
+// thread.folder / threadDetail.folder is always one of the four values above.
+```
+
+Low-level folder listing / per-thread updates (`list({ folder })`, `listFolders(email)`, `update(..., { folder })`) live on `ThreadsResource`. Passing `folder: "blocked"` to `update` throws before the HTTP call.
+
 ## Phone
 
 ```typescript
@@ -200,7 +215,7 @@ await identity.markTextRead("text-uuid");
 const readResult = await identity.markTextConversationRead("+15167251294");
 console.log(readResult.updatedCount);
 
-// Org-level: search, update, delete
+// Admin-only: search, update, delete
 const results = await inkbox.texts.search(phone.id, { q: "invoice", limit: 20 });
 await inkbox.texts.update(phone.id, "text-uuid", { status: "deleted" });
 ```
@@ -371,7 +386,7 @@ await identity.setTotp(secretId, "otpauth://totp/...?secret=...");
 await identity.removeTotp(secretId);
 ```
 
-### From the unlocked vault (org-level)
+### From the unlocked vault (admin-only)
 
 ```typescript
 const unlocked = await inkbox.vault.unlock("my-Vault-key-01!");
@@ -391,7 +406,7 @@ const code = await unlocked.getTotpCode(secretId);
 | `periodEnd` | `number` | Unix timestamp when the code expires |
 | `secondsRemaining` | `number` | Seconds until expiry |
 
-## Org-level Resources
+## Admin-only Resources
 
 ### Mailboxes (`inkbox.mailboxes`)
 
@@ -402,6 +417,18 @@ const mailbox   = await inkbox.mailboxes.get("abc@inkboxmail.com");
 await inkbox.mailboxes.update(mailbox.emailAddress, { displayName: "New Name" });
 await inkbox.mailboxes.update(mailbox.emailAddress, { webhookUrl: "https://example.com/hook" });
 await inkbox.mailboxes.update(mailbox.emailAddress, { webhookUrl: null });   // remove webhook
+
+// Switch contact-rule filter mode (admin-only — agent-scoped keys get 403)
+const updated = await inkbox.mailboxes.update(mailbox.emailAddress, {
+  filterMode: "whitelist",   // or "blacklist" — see FilterMode enum
+});
+if (updated.filterModeChangeNotice) {
+  // Populated when filterMode actually changed.
+  const n = updated.filterModeChangeNotice;
+  console.log(n.redundantRuleCount, n.redundantRuleAction, n.newFilterMode);
+}
+
+// Mailbox responses now also carry mailbox.agentIdentityId when linked.
 
 const results = await inkbox.mailboxes.search(mailbox.emailAddress, { q: "invoice", limit: 20 });
 await inkbox.mailboxes.delete(mailbox.emailAddress);
@@ -428,6 +455,125 @@ const hits = await inkbox.phoneNumbers.searchTranscripts(num.id, { q: "refund", 
 await inkbox.phoneNumbers.release(num.id);
 ```
 
+Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChangeNotice` fields as mailboxes; flipping `filterMode` is admin-only and returns a change-notice when the value actually changed.
+
+## Contact Rules
+
+Per-mailbox or per-phone-number allow/block lists, enforced at ingest. The active `filterMode` on the owning resource decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+
+```typescript
+import {
+  MailRuleAction, MailRuleMatchType, PhoneRuleAction, PhoneRuleMatchType,
+  ContactRuleStatus, DuplicateContactRuleError,
+} from "@inkbox/sdk";
+
+// Mail rules — scoped to a single mailbox
+const rule = await inkbox.mailContactRules.create(mailbox.emailAddress, {
+  action: MailRuleAction.ALLOW,          // or BLOCK
+  matchType: MailRuleMatchType.DOMAIN,   // or EXACT_EMAIL
+  matchTarget: "example.com",
+  status: ContactRuleStatus.ACTIVE,      // default; or PAUSED
+});
+await inkbox.mailContactRules.list(mailbox.emailAddress);
+await inkbox.mailContactRules.get(mailbox.emailAddress, rule.id);
+await inkbox.mailContactRules.update(mailbox.emailAddress, rule.id, { status: "paused" });  // admin-only
+await inkbox.mailContactRules.delete(mailbox.emailAddress, rule.id);                        // admin-only
+
+// Admin-only list; optionally narrow to a single mailboxId
+const allRules = await inkbox.mailContactRules.listAll({ mailboxId: mailbox.id });
+
+// Duplicate (matchType, matchTarget) on the same mailbox throws 409:
+try {
+  await inkbox.mailContactRules.create(mailbox.emailAddress, {
+    action: "allow", matchType: "domain", matchTarget: "example.com",
+  });
+} catch (e) {
+  if (e instanceof DuplicateContactRuleError) {
+    console.log(e.existingRuleId);   // id of the rule that already matched
+  }
+}
+
+// Phone rules — same shape, only matchType: "exact_number" is supported.
+await inkbox.phoneContactRules.create(num.id, {
+  action: PhoneRuleAction.BLOCK,
+  matchType: PhoneRuleMatchType.EXACT_NUMBER,
+  matchTarget: "+15551234567",
+});
+await inkbox.phoneContactRules.list(num.id);
+await inkbox.phoneContactRules.listAll({ phoneNumberId: num.id });
+```
+
+## Contacts
+
+Admin-only address book with per-identity access grants and vCard import/export.
+
+```typescript
+import type { CreateContactOptions, ContactEmail, ContactPhone } from "@inkbox/sdk";
+import { RedundantContactAccessGrantError } from "@inkbox/sdk";
+
+// CRUD
+const contact = await inkbox.contacts.create({
+  givenName: "Ada",
+  familyName: "Lovelace",
+  emails: [{ label: "work", value: "ada@example.com" }],
+  phones: [{ label: "mobile", value: "+15551234567" }],
+  // accessIdentityIds defaults to "wildcard"; pass [] for admin-only, or
+  // a list of identity UUIDs for explicit grants.
+});
+await inkbox.contacts.get(contact.id);
+await inkbox.contacts.list({ q: "ada", order: "recent", limit: 50, offset: 0 });
+await inkbox.contacts.update(contact.id, { jobTitle: "Analyst" });   // JSON-merge-patch
+await inkbox.contacts.delete(contact.id);                            // soft-delete
+
+// Reverse-lookup — exactly one filter required (else thrown before HTTP)
+await inkbox.contacts.lookup({ email: "ada@example.com" });
+await inkbox.contacts.lookup({ emailDomain: "example.com" });
+await inkbox.contacts.lookup({ phone: "+15551234567" });
+await inkbox.contacts.lookup({ emailContains: "ada" });
+await inkbox.contacts.lookup({ phoneContains: "555" });
+
+// Access grants (admin + JWT only; agents can self-revoke)
+await inkbox.contacts.access.list(contact.id);
+await inkbox.contacts.access.grant(contact.id, { identityId: "agent-uuid" });
+await inkbox.contacts.access.grant(contact.id, { wildcard: true });   // every active identity
+await inkbox.contacts.access.revoke(contact.id, "agent-uuid");
+
+try {
+  await inkbox.contacts.access.grant(contact.id, { identityId: "agent-uuid" });
+} catch (e) {
+  if (e instanceof RedundantContactAccessGrantError) {
+    console.log(e.error, e.detailMessage);
+  }
+}
+
+// vCards
+const result = await inkbox.contacts.vcards.import(vcfText);  // bulk, ≤5 MiB, ≤1000 cards
+console.log(result.createdIds);
+for (const item of result.errors) {
+  console.log(item.index, item.error);
+}
+
+const vcf = await inkbox.contacts.vcards.export(contact.id);  // vCard 4.0 string
+```
+
+## Notes
+
+Admin-only free-form notes with per-identity access grants. There is no wildcard for notes — grant identities explicitly.
+
+```typescript
+const note = await inkbox.notes.create({ body: "Customer prefers email follow-up.", title: "Ada" });
+await inkbox.notes.get(note.id);
+await inkbox.notes.list({ q: "email", identityId: "agent-uuid", order: "recent", limit: 50 });
+await inkbox.notes.update(note.id, { body: "Updated body" });
+await inkbox.notes.update(note.id, { title: null });   // clear title; body cannot be null
+await inkbox.notes.delete(note.id);
+
+// Access grants (admin + JWT only)
+await inkbox.notes.access.list(note.id);
+await inkbox.notes.access.grant(note.id, "agent-uuid");
+await inkbox.notes.access.revoke(note.id, "agent-uuid");
+```
+
 ## Whoami
 
 ```typescript
@@ -441,7 +587,21 @@ if (info.authType === "api_key") {
 }
 ```
 
-Returns `WhoamiApiKeyResponse` (with `keyId`, `label`, `creatorType`, etc.) or `WhoamiJwtResponse` (with `email`, `orgRole`, etc.) — discriminated on `authType`.
+Returns `WhoamiApiKeyResponse` (with `keyId`, `label`, `creatorType`, `authSubtype`, etc.) or `WhoamiJwtResponse` (with `email`, `orgRole`, etc.) — discriminated on `authType`.
+
+For branching on API-key scope, compare against the exported constants:
+
+```typescript
+import {
+  AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED,
+  AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED,
+  AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED,
+} from "@inkbox/sdk";
+
+if (info.authType === "api_key" && info.authSubtype === AUTH_SUBTYPE_API_KEY_ADMIN_SCOPED) {
+  // admin-only operations (filter_mode flips, rule updates/deletes, etc.)
+}
+```
 
 ## Webhooks & Signature Verification
 
@@ -467,17 +627,26 @@ Algorithm: HMAC-SHA256 over `"{requestId}.{timestamp}.{body}"`.
 ## Error Handling
 
 ```typescript
-import { InkboxAPIError } from "@inkbox/sdk";
+import {
+  InkboxAPIError,
+  DuplicateContactRuleError,
+  RedundantContactAccessGrantError,
+} from "@inkbox/sdk";
 
 try {
   const identity = await inkbox.getIdentity("unknown");
 } catch (e) {
   if (e instanceof InkboxAPIError) {
     console.log(e.statusCode);   // HTTP status (e.g. 404)
-    console.log(e.detail);       // message from API
+    console.log(e.detail);       // string for legacy errors, object for structured ones
   }
 }
 ```
+
+`InkboxAPIError.detail` is typed as `InkboxAPIErrorDetail` — either a string or a structured object. Catch the narrower subclasses when you need the parsed fields:
+
+- `DuplicateContactRuleError` — 409 when creating a contact rule with an already-taken `(matchType, matchTarget)` on the same resource. Exposes `.existingRuleId: string`.
+- `RedundantContactAccessGrantError` — 409 when a contact-access grant is redundant (e.g. per-identity grant on top of an active wildcard). Exposes `.error` and `.detailMessage`.
 
 ## Key Conventions
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -145,7 +145,7 @@ for (const m of thread.messages) {
 
 ### Thread Folders
 
-Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned by the contact-rule engine at ingest, never client-set).
+Threads carry a `folder` field: `inbox`, `spam`, `archive`, or `blocked` (server-assigned, never client-set).
 
 ```typescript
 import { ThreadFolder } from "@inkbox/sdk";
@@ -163,7 +163,7 @@ const call = await identity.placeCall({
   clientWebsocketUrl: "wss://your-agent.example.com/ws",
 });
 console.log(call.status);
-console.log(call.rateLimit.callsRemaining);   // rolling 24h budget
+console.log(call.rateLimit.callsRemaining);
 
 // List calls (offset pagination)
 const calls = await identity.listCalls({ limit: 10, offset: 0 });
@@ -193,7 +193,7 @@ const unread = await identity.listTexts({ isRead: false });
 // Get a single text message
 const text = await identity.getText("text-uuid");
 console.log(text.type);   // "sms" or "mms"
-if (text.media) {          // MMS media attachments (presigned S3 URLs, 1hr expiry)
+if (text.media) {          // MMS media attachments (temporary signed URLs)
   for (const m of text.media) {
     console.log(m.contentType, m.size, m.url);
   }
@@ -459,7 +459,7 @@ Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChang
 
 ## Contact Rules
 
-Per-mailbox or per-phone-number allow/block lists, enforced at ingest. The active `filterMode` on the owning resource decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+Per-mailbox or per-phone-number allow/block lists, enforced server-side. The active `filterMode` on the owning resource decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
 
 ```typescript
 import {
@@ -523,7 +523,7 @@ const contact = await inkbox.contacts.create({
 await inkbox.contacts.get(contact.id);
 await inkbox.contacts.list({ q: "ada", order: "recent", limit: 50, offset: 0 });
 await inkbox.contacts.update(contact.id, { jobTitle: "Analyst" });   // JSON-merge-patch
-await inkbox.contacts.delete(contact.id);                            // soft-delete
+await inkbox.contacts.delete(contact.id);
 
 // Reverse-lookup — exactly one filter required (else thrown before HTTP)
 await inkbox.contacts.lookup({ email: "ada@example.com" });

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -86,11 +86,16 @@ def sdk_integration_config() -> SdkIntegrationConfig:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIntegrationContext, None, None]:
+    # Session-scoped: one Clerk org/user is bootstrapped per pytest invocation
+    # and shared across every test in this directory. Tests are responsible
+    # for cleaning up any identities/secrets they create so that later tests
+    # see a predictable starting state.
     cfg = sdk_integration_config
     api_url = f"{cfg.base_url.rstrip('/')}/api/v1"
 
+    # Bootstrap a fresh test user + org (with API key) via the testing subapp
     resp = httpx.post(
         f"{api_url}/testing/create-test-user-organization",
         headers={"X-Interservice-Secret": cfg.interservice_secret},
@@ -113,6 +118,7 @@ def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIn
     try:
         yield ctx
     finally:
+        # Tear down the shared org once at the end of the session
         ctx.cleanup()
 
 

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -180,8 +180,6 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         identities = inkbox.list_identities()
         assert len(identities) == 0
 
-    # ── final test-org cleanup ────────────────────────────────────
-    log_step(ctx, "cleanup test organization")
-    deleted = ctx.cleanup()
-    assert "deleted" in deleted
-    log_step(ctx, f"cleanup complete: {deleted['deleted']}")
+    # Test-org cleanup is now handled by the session-scoped sdk_context
+    # fixture teardown so that subsequent tests in the same pytest run
+    # (e.g. test_sdk_signup) can reuse the same Clerk org.

--- a/tests/integration/typescript/globalSetup.ts
+++ b/tests/integration/typescript/globalSetup.ts
@@ -1,0 +1,36 @@
+// tests/integration/typescript/globalSetup.ts
+//
+// Runs once per `vitest run` invocation, before any test workers spawn.
+// Bootstraps a single Clerk org/user via the testing subapp and exposes the
+// credentials to test files via env vars (which workers inherit at fork time).
+// All test files in this directory share that one org for the whole run.
+
+import {
+  loadConfig,
+  bootstrapTestOrg,
+  cleanupTestOrg,
+  type BootstrapResult,
+} from "./helpers.js";
+
+let bootstrap: BootstrapResult | undefined;
+
+export async function setup(): Promise<void> {
+  const config = loadConfig();
+
+  // Provision the shared Clerk org/user
+  bootstrap = await bootstrapTestOrg(config);
+
+  // Stash credentials in env so test workers can read them via loadBootstrapFromEnv()
+  process.env.SDK_INTEGRATION_BOOTSTRAP_EMAIL = bootstrap.emailAddress;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_PASSWORD = bootstrap.password;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_USER_ID = bootstrap.userId;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_ORG_ID = bootstrap.orgId;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_API_KEY = bootstrap.apiKey;
+}
+
+export async function teardown(): Promise<void> {
+  if (!bootstrap) return;
+  // Tear the shared org down once, after every test file has finished
+  const config = loadConfig();
+  await cleanupTestOrg(config, bootstrap);
+}

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -90,6 +90,28 @@ export async function cleanupTestOrg(
   return resp.json();
 }
 
+// Read bootstrap credentials that globalSetup.ts has stashed in env vars.
+// Lets each test file share the single Clerk org/user that globalSetup
+// provisioned for the whole vitest run.
+export function loadBootstrapFromEnv(): BootstrapResult {
+  const required = {
+    emailAddress: process.env.SDK_INTEGRATION_BOOTSTRAP_EMAIL,
+    password: process.env.SDK_INTEGRATION_BOOTSTRAP_PASSWORD,
+    userId: process.env.SDK_INTEGRATION_BOOTSTRAP_USER_ID,
+    orgId: process.env.SDK_INTEGRATION_BOOTSTRAP_ORG_ID,
+    apiKey: process.env.SDK_INTEGRATION_BOOTSTRAP_API_KEY,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing bootstrap env vars from globalSetup: ${missing.join(", ")}`,
+    );
+  }
+  return required as BootstrapResult;
+}
+
 export function logStep(config: SdkIntegrationConfig, message: string): void {
   if (config.verbose) {
     console.log(`[sdk-integration] ${message}`);

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -1,12 +1,11 @@
 // tests/integration/typescript/sdk_lifecycle.test.ts
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Inkbox } from "@inkbox/sdk";
 import type { Message, DecryptedVaultSecret } from "@inkbox/sdk";
 import {
   loadConfig,
-  bootstrapTestOrg,
-  cleanupTestOrg,
+  loadBootstrapFromEnv,
   logStep,
   pollUntil,
   type SdkIntegrationConfig,
@@ -17,15 +16,11 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
   let config: SdkIntegrationConfig;
   let bootstrap: BootstrapResult;
 
-  beforeAll(async () => {
+  beforeAll(() => {
+    // Bootstrap is provisioned once per vitest run by globalSetup.ts and
+    // shared across every test file in this directory.
     config = loadConfig();
-    bootstrap = await bootstrapTestOrg(config);
-  });
-
-  afterAll(async () => {
-    if (bootstrap) {
-      await cleanupTestOrg(config, bootstrap);
-    }
+    bootstrap = loadBootstrapFromEnv();
   });
 
   it("exercises the full SDK lifecycle", async () => {

--- a/tests/integration/typescript/sdk_signup.test.ts
+++ b/tests/integration/typescript/sdk_signup.test.ts
@@ -1,12 +1,11 @@
 // tests/integration/typescript/sdk_signup.test.ts
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Inkbox } from "@inkbox/sdk";
 import { randomUUID } from "node:crypto";
 import {
   loadConfig,
-  bootstrapTestOrg,
-  cleanupTestOrg,
+  loadBootstrapFromEnv,
   logStep,
   type SdkIntegrationConfig,
   type BootstrapResult,
@@ -16,15 +15,13 @@ describe("TypeScript SDK signup", { timeout: 300_000 }, () => {
   let config: SdkIntegrationConfig;
   let bootstrap: BootstrapResult;
 
-  beforeAll(async () => {
+  beforeAll(() => {
+    // Bootstrap is provisioned once per vitest run by globalSetup.ts and
+    // shared with the lifecycle test (which runs first and cleans up its
+    // identities). The signup test then approves a fresh agent into the
+    // same org using a random agent_handle, so there's no collision.
     config = loadConfig();
-    bootstrap = await bootstrapTestOrg(config);
-  });
-
-  afterAll(async () => {
-    if (bootstrap) {
-      await cleanupTestOrg(config, bootstrap);
-    }
+    bootstrap = loadBootstrapFromEnv();
   });
 
   it("accepts a custom handle and email local part", async () => {

--- a/tests/integration/typescript/vitest.config.ts
+++ b/tests/integration/typescript/vitest.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   test: {
     testTimeout: 300_000,
     include: ["**/*.test.ts"],
+    // One bootstrap per `vitest run`, shared across every test file in this dir
+    globalSetup: ["./globalSetup.ts"],
+    // Force serial file execution so tests that share the bootstrap org run
+    // in a deterministic order (alphabetical: lifecycle before signup).
+    fileParallelism: false,
+    sequence: { shuffle: false },
   },
 });


### PR DESCRIPTION
Updates include:
- New subsystems: contacts (CRUD + access + vCard), notes (CRUD + access), mail + phone contact rules (per-resource + org-wide list).
- New types: FilterMode, ThreadFolder, Mail/PhoneRuleAction, MatchType, ContactRuleStatus, FilterModeChangeNotice.
- Existing types: filter_mode, filter_mode_change_notice on Mailbox / PhoneNumber / IdentityMailbox / IdentityPhoneNumber; folder on Thread.
- Thread resource: list(folder=...), list_folders, update(folder=...) with client-side reject for blocked; update parses ThreadResponse.
- Transport: raw-body / raw-response paths (vCard import + export).
- Errors: InkboxAPIError detail widened to str|dict; typed 409 subclasses (DuplicateContactRuleError, RedundantContactAccessGrantError); CLI renders each subclass distinctly.
- auth_subtype named constants published.
- CI: bump unit-test coverage threshold to 85% (Python + TypeScript).