### PR TITLE
tests(integration): Clerk fixture consolidation

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       target:

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -86,11 +86,16 @@ def sdk_integration_config() -> SdkIntegrationConfig:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIntegrationContext, None, None]:
+    # Session-scoped: one Clerk org/user is bootstrapped per pytest invocation
+    # and shared across every test in this directory. Tests are responsible
+    # for cleaning up any identities/secrets they create so that later tests
+    # see a predictable starting state.
     cfg = sdk_integration_config
     api_url = f"{cfg.base_url.rstrip('/')}/api/v1"
 
+    # Bootstrap a fresh test user + org (with API key) via the testing subapp
     resp = httpx.post(
         f"{api_url}/testing/create-test-user-organization",
         headers={"X-Interservice-Secret": cfg.interservice_secret},
@@ -113,6 +118,7 @@ def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIn
     try:
         yield ctx
     finally:
+        # Tear down the shared org once at the end of the session
         ctx.cleanup()
 
 

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -180,8 +180,6 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         identities = inkbox.list_identities()
         assert len(identities) == 0
 
-    # ── final test-org cleanup ────────────────────────────────────
-    log_step(ctx, "cleanup test organization")
-    deleted = ctx.cleanup()
-    assert "deleted" in deleted
-    log_step(ctx, f"cleanup complete: {deleted['deleted']}")
+    # Test-org cleanup is now handled by the session-scoped sdk_context
+    # fixture teardown so that subsequent tests in the same pytest run
+    # (e.g. test_sdk_signup) can reuse the same Clerk org.

--- a/tests/integration/typescript/globalSetup.ts
+++ b/tests/integration/typescript/globalSetup.ts
@@ -1,0 +1,36 @@
+// tests/integration/typescript/globalSetup.ts
+//
+// Runs once per `vitest run` invocation, before any test workers spawn.
+// Bootstraps a single Clerk org/user via the testing subapp and exposes the
+// credentials to test files via env vars (which workers inherit at fork time).
+// All test files in this directory share that one org for the whole run.
+
+import {
+  loadConfig,
+  bootstrapTestOrg,
+  cleanupTestOrg,
+  type BootstrapResult,
+} from "./helpers.js";
+
+let bootstrap: BootstrapResult | undefined;
+
+export async function setup(): Promise<void> {
+  const config = loadConfig();
+
+  // Provision the shared Clerk org/user
+  bootstrap = await bootstrapTestOrg(config);
+
+  // Stash credentials in env so test workers can read them via loadBootstrapFromEnv()
+  process.env.SDK_INTEGRATION_BOOTSTRAP_EMAIL = bootstrap.emailAddress;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_PASSWORD = bootstrap.password;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_USER_ID = bootstrap.userId;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_ORG_ID = bootstrap.orgId;
+  process.env.SDK_INTEGRATION_BOOTSTRAP_API_KEY = bootstrap.apiKey;
+}
+
+export async function teardown(): Promise<void> {
+  if (!bootstrap) return;
+  // Tear the shared org down once, after every test file has finished
+  const config = loadConfig();
+  await cleanupTestOrg(config, bootstrap);
+}

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -90,6 +90,28 @@ export async function cleanupTestOrg(
   return resp.json();
 }
 
+// Read bootstrap credentials that globalSetup.ts has stashed in env vars.
+// Lets each test file share the single Clerk org/user that globalSetup
+// provisioned for the whole vitest run.
+export function loadBootstrapFromEnv(): BootstrapResult {
+  const required = {
+    emailAddress: process.env.SDK_INTEGRATION_BOOTSTRAP_EMAIL,
+    password: process.env.SDK_INTEGRATION_BOOTSTRAP_PASSWORD,
+    userId: process.env.SDK_INTEGRATION_BOOTSTRAP_USER_ID,
+    orgId: process.env.SDK_INTEGRATION_BOOTSTRAP_ORG_ID,
+    apiKey: process.env.SDK_INTEGRATION_BOOTSTRAP_API_KEY,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing bootstrap env vars from globalSetup: ${missing.join(", ")}`,
+    );
+  }
+  return required as BootstrapResult;
+}
+
 export function logStep(config: SdkIntegrationConfig, message: string): void {
   if (config.verbose) {
     console.log(`[sdk-integration] ${message}`);

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -1,12 +1,11 @@
 // tests/integration/typescript/sdk_lifecycle.test.ts
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Inkbox } from "@inkbox/sdk";
 import type { Message, DecryptedVaultSecret } from "@inkbox/sdk";
 import {
   loadConfig,
-  bootstrapTestOrg,
-  cleanupTestOrg,
+  loadBootstrapFromEnv,
   logStep,
   pollUntil,
   type SdkIntegrationConfig,
@@ -17,15 +16,11 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
   let config: SdkIntegrationConfig;
   let bootstrap: BootstrapResult;
 
-  beforeAll(async () => {
+  beforeAll(() => {
+    // Bootstrap is provisioned once per vitest run by globalSetup.ts and
+    // shared across every test file in this directory.
     config = loadConfig();
-    bootstrap = await bootstrapTestOrg(config);
-  });
-
-  afterAll(async () => {
-    if (bootstrap) {
-      await cleanupTestOrg(config, bootstrap);
-    }
+    bootstrap = loadBootstrapFromEnv();
   });
 
   it("exercises the full SDK lifecycle", async () => {

--- a/tests/integration/typescript/sdk_signup.test.ts
+++ b/tests/integration/typescript/sdk_signup.test.ts
@@ -1,12 +1,11 @@
 // tests/integration/typescript/sdk_signup.test.ts
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Inkbox } from "@inkbox/sdk";
 import { randomUUID } from "node:crypto";
 import {
   loadConfig,
-  bootstrapTestOrg,
-  cleanupTestOrg,
+  loadBootstrapFromEnv,
   logStep,
   type SdkIntegrationConfig,
   type BootstrapResult,
@@ -16,15 +15,13 @@ describe("TypeScript SDK signup", { timeout: 300_000 }, () => {
   let config: SdkIntegrationConfig;
   let bootstrap: BootstrapResult;
 
-  beforeAll(async () => {
+  beforeAll(() => {
+    // Bootstrap is provisioned once per vitest run by globalSetup.ts and
+    // shared with the lifecycle test (which runs first and cleans up its
+    // identities). The signup test then approves a fresh agent into the
+    // same org using a random agent_handle, so there's no collision.
     config = loadConfig();
-    bootstrap = await bootstrapTestOrg(config);
-  });
-
-  afterAll(async () => {
-    if (bootstrap) {
-      await cleanupTestOrg(config, bootstrap);
-    }
+    bootstrap = loadBootstrapFromEnv();
   });
 
   it("accepts a custom handle and email local part", async () => {

--- a/tests/integration/typescript/vitest.config.ts
+++ b/tests/integration/typescript/vitest.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   test: {
     testTimeout: 300_000,
     include: ["**/*.test.ts"],
+    // One bootstrap per `vitest run`, shared across every test file in this dir
+    globalSetup: ["./globalSetup.ts"],
+    // Force serial file execution so tests that share the bootstrap org run
+    // in a deterministic order (alphabetical: lifecycle before signup).
+    fileParallelism: false,
+    sequence: { shuffle: false },
   },
 });


### PR DESCRIPTION
## Summary

Cuts per-PR-CI Clerk org churn from **10 → 6** by sharing a single bootstrap across every test file within the same `pytest`/`vitest` invocation. No workflow YAML restructure required — purely fixture-level changes.

**Python (`tests/integration/python/`)**
- Promote the `sdk_context` fixture in `conftest.py` from function-scope to `scope="session"`.
- Drop the explicit `ctx.cleanup()` at the end of `test_sdk_lifecycle.py` so `test_sdk_signup.py` can reuse the same Clerk org once lifecycle has finished and deleted its identities.

**TypeScript SDK (`tests/integration/typescript/`)**
- New `globalSetup.ts` bootstraps once per `vitest run`, stashes credentials in env vars, and tears the org down at the end.
- Both `*.test.ts` files now read the shared bootstrap via `loadBootstrapFromEnv()` instead of calling `bootstrapTestOrg()` in `beforeAll`.
- `vitest.config.ts` pins `fileParallelism: false` and `sequence.shuffle: false` so files run alphabetically (lifecycle before signup), avoiding `alpha`/`bravo` identity-handle collisions on the shared org.

**CLI** — untouched; only one test file, no in-process consolidation possible.

**Cron** — scheduled SDK integration runs slowed from every 2h to every 3h, matching the sibling crons going out in `inkbox-ai/console` and `inkbox-ai/servers`.

## Heads up

This branch is stacked on top of `contacts-notes-accesslist` (#42), so the diff includes everything from that PR (~6.3k lines of contacts/notes/contact-rules SDK + CLI + skills surface). The Clerk-consolidation work itself is the last 2 commits / ~270 lines under `tests/integration/` and `.github/workflows/sdk_integration.yml`. Easiest review path: merge #42 first; this branch will collapse to just the Clerk commits.