### PR TITLE
sdk(phone): add is_blocked filter + response field for blocked-row visibility

### DIFF
--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -545,18 +545,30 @@ class AgentIdentity:
             client_websocket_url=client_websocket_url,
         )
 
-    def list_calls(self, *, limit: int = 50, offset: int = 0) -> list[PhoneCall]:
+    def list_calls(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        is_blocked: bool | None = None,
+    ) -> list[PhoneCall]:
         """List calls made to/from this identity's phone number.
+
+        Identity-scoped credentials never see contact-rule-blocked rows
+        regardless of ``is_blocked`` (server-side access policy).
 
         Args:
             limit: Maximum number of results (default 50).
             offset: Pagination offset (default 0).
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
         self._require_phone()
         return self._inkbox._calls.list(
             self._phone_number.id,  # type: ignore[union-attr]
             limit=limit,
             offset=offset,
+            is_blocked=is_blocked,
         )
 
     def list_transcripts(self, call_id: str) -> list[PhoneTranscript]:
@@ -604,14 +616,24 @@ class AgentIdentity:
         )
 
     def list_texts(
-        self, *, limit: int = 50, offset: int = 0, is_read: bool | None = None
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        is_read: bool | None = None,
+        is_blocked: bool | None = None,
     ) -> list[TextMessage]:
         """List text messages for this identity's phone number.
+
+        Identity-scoped credentials never see contact-rule-blocked rows
+        regardless of ``is_blocked`` (server-side access policy).
 
         Args:
             limit: Maximum number of results (default 50).
             offset: Pagination offset (default 0).
             is_read: Filter by read state (``True``, ``False``, or ``None`` for all).
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
         self._require_phone()
         return self._inkbox._texts.list(
@@ -619,6 +641,7 @@ class AgentIdentity:
             limit=limit,
             offset=offset,
             is_read=is_read,
+            is_blocked=is_blocked,
         )
 
     def get_text(self, text_id: str) -> TextMessage:
@@ -634,19 +657,31 @@ class AgentIdentity:
         )
 
     def list_text_conversations(
-        self, *, limit: int = 50, offset: int = 0
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        is_blocked: bool | None = None,
     ) -> list[TextConversationSummary]:
         """List text conversations (one row per remote number).
+
+        Identity-scoped credentials never see blocked rows in
+        conversation summaries; admin/JWT can use ``is_blocked=False``
+        to hide spam-only counterparties or ``is_blocked=True`` to
+        narrow to conversations made up of blocked rows.
 
         Args:
             limit: Maximum number of results (default 50).
             offset: Pagination offset (default 0).
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
         self._require_phone()
         return self._inkbox._texts.list_conversations(
             self._phone_number.id,  # type: ignore[union-attr]
             limit=limit,
             offset=offset,
+            is_blocked=is_blocked,
         )
 
     def get_text_conversation(

--- a/sdk/python/inkbox/phone/resources/calls.py
+++ b/sdk/python/inkbox/phone/resources/calls.py
@@ -26,17 +26,30 @@ class CallsResource:
         *,
         limit: int = 50,
         offset: int = 0,
+        is_blocked: bool | None = None,
     ) -> list[PhoneCall]:
         """List calls for a phone number, newest first.
+
+        Identity-scoped API keys never see contact-rule-blocked rows
+        regardless of ``is_blocked`` — the server filters them at the
+        access-policy layer. Admin-scoped keys and JWT humans see
+        everything by default; pass ``is_blocked=True`` to surface the
+        blocked-only listing or ``is_blocked=False`` to exclude blocked
+        rows.
 
         Args:
             phone_number_id: UUID of the phone number.
             limit: Max results to return (1–200).
             offset: Pagination offset.
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if is_blocked is not None:
+            params["is_blocked"] = is_blocked
         data = self._http.get(
             f"/numbers/{phone_number_id}/calls",
-            params={"limit": limit, "offset": offset},
+            params=params,
         )
         return [PhoneCall._from_dict(c) for c in data]
 

--- a/sdk/python/inkbox/phone/resources/texts.py
+++ b/sdk/python/inkbox/phone/resources/texts.py
@@ -60,14 +60,24 @@ class TextsResource:
         limit: int = 50,
         offset: int = 0,
         is_read: bool | None = None,
+        is_blocked: bool | None = None,
     ) -> list[TextMessage]:
         """List text messages for a phone number, newest first.
+
+        Identity-scoped API keys never see contact-rule-blocked rows
+        regardless of ``is_blocked`` — the server filters them at the
+        access-policy layer. Admin-scoped keys and JWT humans see
+        everything by default; pass ``is_blocked=True`` to surface the
+        blocked-only listing or ``is_blocked=False`` to exclude blocked
+        rows.
 
         Args:
             phone_number_id: UUID of the phone number.
             limit: Max results to return (1–200).
             offset: Pagination offset.
             is_read: Filter by read state (``True``, ``False``, or ``None`` for all).
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
         params: dict[str, Any] = {
             "limit": limit,
@@ -75,6 +85,8 @@ class TextsResource:
         }
         if is_read is not None:
             params["is_read"] = is_read
+        if is_blocked is not None:
+            params["is_blocked"] = is_blocked
         data = self._http.get(
             f"/numbers/{phone_number_id}/texts",
             params=params,
@@ -124,17 +136,29 @@ class TextsResource:
         *,
         q: str,
         limit: int = 50,
+        is_blocked: bool | None = None,
     ) -> list[TextMessage]:
         """Full-text search across text messages for a phone number.
+
+        Identity-scoped API keys never see contact-rule-blocked rows in
+        results regardless of ``is_blocked``. Admin/JWT callers see
+        everything by default; pass ``is_blocked=False`` to keep search
+        clean of blocked spam, or ``is_blocked=True`` to search only the
+        blocked folder.
 
         Args:
             phone_number_id: UUID of the phone number.
             q: Search query string.
             limit: Max results to return (1–200).
+            is_blocked: Tri-state filter — ``True`` for only blocked,
+                ``False`` for only non-blocked, ``None`` for all.
         """
+        params: dict[str, Any] = {"q": q, "limit": limit}
+        if is_blocked is not None:
+            params["is_blocked"] = is_blocked
         data = self._http.get(
             f"/numbers/{phone_number_id}/texts/search",
-            params={"q": q, "limit": limit},
+            params=params,
         )
         return [TextMessage._from_dict(t) for t in data]
 
@@ -144,17 +168,32 @@ class TextsResource:
         *,
         limit: int = 50,
         offset: int = 0,
+        is_blocked: bool | None = None,
     ) -> list[TextConversationSummary]:
         """List conversations (one row per remote number) with latest message preview.
+
+        Identity-scoped API keys never see blocked rows — both the
+        conversation list and the latest-message previews exclude them
+        automatically. Admin-scoped keys and JWT humans see everything
+        by default; ``is_blocked=False`` hides spam-only counterparties
+        and stops blocked rows from bumping quiet conversations to the
+        top, while ``is_blocked=True`` narrows to conversations made up
+        of blocked rows.
 
         Args:
             phone_number_id: UUID of the phone number.
             limit: Max results to return (1–200).
             offset: Pagination offset.
+            is_blocked: Tri-state filter applied to the underlying
+                messages — ``True`` for only blocked, ``False`` for only
+                non-blocked, ``None`` for all.
         """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if is_blocked is not None:
+            params["is_blocked"] = is_blocked
         data = self._http.get(
             f"/numbers/{phone_number_id}/texts/conversations",
-            params={"limit": limit, "offset": offset},
+            params=params,
         )
         return [TextConversationSummary._from_dict(c) for c in data]
 

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -129,7 +129,15 @@ class PhoneNumber:
 
 @dataclass
 class PhoneCall:
-    """A phone call record."""
+    """A phone call record.
+
+    ``is_blocked`` is ``True`` when this call was rejected by a contact rule
+    or default-block before connect. Identity-scoped (agent) API keys never
+    observe ``is_blocked=True`` rows — the server filters them at the
+    access-policy layer. Admin-scoped API keys and JWT humans see both
+    values mixed by default and can narrow with ``is_blocked`` on
+    ``CallsResource.list``.
+    """
 
     id: UUID
     local_phone_number: str
@@ -144,6 +152,9 @@ class PhoneCall:
     ended_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    # Default False — older server responses without this field were always
+    # non-blocked (predicate hid blocked rows from every caller).
+    is_blocked: bool = False
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> PhoneCall:
@@ -161,6 +172,7 @@ class PhoneCall:
             ended_at=_dt(d.get("ended_at")),
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            is_blocked=bool(d.get("is_blocked", False)),
         )
 
 
@@ -229,6 +241,13 @@ class TextMessage:
     Outbound-only lifecycle fields (``delivery_status``, ``error_code``,
     ``error_detail``, ``sent_at``, ``delivered_at``, ``failed_at``) are
     ``None`` on inbound rows.
+
+    ``is_blocked`` is ``True`` when this text was rejected by a contact rule
+    or default-block. Identity-scoped (agent) API keys never observe
+    ``is_blocked=True`` rows — the server filters them at the
+    access-policy layer. Admin-scoped API keys and JWT humans see both
+    values mixed by default and can narrow with ``is_blocked`` on
+    ``TextsResource.list`` / ``search`` / ``list_conversations``.
     """
 
     id: UUID
@@ -248,6 +267,8 @@ class TextMessage:
     sent_at: datetime | None = None
     delivered_at: datetime | None = None
     failed_at: datetime | None = None
+    # Default False for older server responses that predate the field.
+    is_blocked: bool = False
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> TextMessage:
@@ -278,6 +299,7 @@ class TextMessage:
             sent_at=_dt(d.get("sent_at")),
             delivered_at=_dt(d.get("delivered_at")),
             failed_at=_dt(d.get("failed_at")),
+            is_blocked=bool(d.get("is_blocked", False)),
         )
 
 

--- a/sdk/python/tests/sample_data.py
+++ b/sdk/python/tests/sample_data.py
@@ -30,8 +30,26 @@ PHONE_CALL_DICT = {
     "hangup_reason": None,
     "started_at": "2026-03-09T00:01:00Z",
     "ended_at": "2026-03-09T00:05:00Z",
+    "is_blocked": False,
     "created_at": "2026-03-09T00:00:00Z",
     "updated_at": "2026-03-09T00:05:00Z",
+}
+
+PHONE_CALL_BLOCKED_DICT = {
+    "id": "bbbb2222-0000-0000-0000-0000000000bb",
+    "local_phone_number": "+18335794607",
+    "remote_phone_number": "+15551234567",
+    "direction": "inbound",
+    "status": "failed",
+    "client_websocket_url": None,
+    "use_inkbox_tts": None,
+    "use_inkbox_stt": None,
+    "hangup_reason": "rejected",
+    "started_at": None,
+    "ended_at": None,
+    "is_blocked": True,
+    "created_at": "2026-03-09T00:30:00Z",
+    "updated_at": "2026-03-09T00:30:00Z",
 }
 
 TEXT_MESSAGE_DICT = {
@@ -43,8 +61,23 @@ TEXT_MESSAGE_DICT = {
     "type": "sms",
     "media": None,
     "is_read": False,
+    "is_blocked": False,
     "created_at": "2026-03-09T00:10:00Z",
     "updated_at": "2026-03-09T00:10:00Z",
+}
+
+TEXT_MESSAGE_BLOCKED_DICT = {
+    "id": "dddd4444-0000-0000-0000-0000000000bb",
+    "direction": "inbound",
+    "local_phone_number": "+18335794607",
+    "remote_phone_number": "+15551234567",
+    "text": "Buy crypto now!!!",
+    "type": "sms",
+    "media": None,
+    "is_read": False,
+    "is_blocked": True,
+    "created_at": "2026-03-09T00:35:00Z",
+    "updated_at": "2026-03-09T00:35:00Z",
 }
 
 TEXT_MESSAGE_MMS_DICT = {

--- a/sdk/python/tests/test_calls.py
+++ b/sdk/python/tests/test_calls.py
@@ -6,7 +6,7 @@ Tests for CallsResource.
 
 from uuid import UUID
 
-from sample_data import PHONE_CALL_DICT
+from sample_data import PHONE_CALL_BLOCKED_DICT, PHONE_CALL_DICT
 
 
 NUM_ID = "aaaa1111-0000-0000-0000-000000000001"
@@ -46,6 +46,51 @@ class TestCallsList:
             f"/numbers/{NUM_ID}/calls",
             params={"limit": 10, "offset": 20},
         )
+
+    def test_is_blocked_omitted_by_default(self, client, transport):
+        """When the caller doesn't pass is_blocked, it doesn't appear in the params."""
+        transport.get.return_value = []
+
+        client._calls.list(NUM_ID)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/calls",
+            params={"limit": 50, "offset": 0},
+        )
+
+    def test_is_blocked_true_passes_through(self, client, transport):
+        """is_blocked=True surfaces the admin-side blocked-only listing."""
+        transport.get.return_value = [PHONE_CALL_BLOCKED_DICT]
+
+        calls = client._calls.list(NUM_ID, is_blocked=True)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/calls",
+            params={"limit": 50, "offset": 0, "is_blocked": True},
+        )
+        assert len(calls) == 1
+        assert calls[0].is_blocked is True
+
+    def test_is_blocked_false_passes_through(self, client, transport):
+        """is_blocked=False narrows admin/JWT view to only non-blocked rows."""
+        transport.get.return_value = [PHONE_CALL_DICT]
+
+        calls = client._calls.list(NUM_ID, is_blocked=False)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/calls",
+            params={"limit": 50, "offset": 0, "is_blocked": False},
+        )
+        assert calls[0].is_blocked is False
+
+    def test_is_blocked_default_when_field_missing(self, client, transport):
+        """Older server responses without is_blocked deserialize to False (back-compat)."""
+        old_payload = {k: v for k, v in PHONE_CALL_DICT.items() if k != "is_blocked"}
+        transport.get.return_value = [old_payload]
+
+        calls = client._calls.list(NUM_ID)
+
+        assert calls[0].is_blocked is False
 
 
 class TestCallsGet:

--- a/sdk/python/tests/test_texts.py
+++ b/sdk/python/tests/test_texts.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sample_data import (
     TEXT_CONVERSATION_SUMMARY_DICT,
+    TEXT_MESSAGE_BLOCKED_DICT,
     TEXT_MESSAGE_DICT,
     TEXT_MESSAGE_MMS_DICT,
     TEXT_MESSAGE_OUTBOUND_QUEUED_DICT,
@@ -81,6 +82,39 @@ class TestTextsList:
             params={"limit": 50, "offset": 0, "is_read": False},
         )
 
+    def test_is_blocked_true(self, client, transport):
+        """is_blocked=True surfaces the admin-side blocked-only listing."""
+        transport.get.return_value = [TEXT_MESSAGE_BLOCKED_DICT]
+
+        texts = client._texts.list(NUM_ID, is_blocked=True)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts",
+            params={"limit": 50, "offset": 0, "is_blocked": True},
+        )
+        assert texts[0].is_blocked is True
+
+    def test_is_blocked_false(self, client, transport):
+        """is_blocked=False keeps admin/JWT view clean of blocked spam."""
+        transport.get.return_value = [TEXT_MESSAGE_DICT]
+
+        texts = client._texts.list(NUM_ID, is_blocked=False)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts",
+            params={"limit": 50, "offset": 0, "is_blocked": False},
+        )
+        assert texts[0].is_blocked is False
+
+    def test_is_blocked_default_when_field_missing(self, client, transport):
+        """Older server responses without is_blocked deserialize to False."""
+        old_payload = {k: v for k, v in TEXT_MESSAGE_DICT.items() if k != "is_blocked"}
+        transport.get.return_value = [old_payload]
+
+        texts = client._texts.list(NUM_ID)
+
+        assert texts[0].is_blocked is False
+
     def test_mms_with_media(self, client, transport):
         transport.get.return_value = [TEXT_MESSAGE_MMS_DICT]
 
@@ -138,6 +172,39 @@ class TestTextsSearch:
         )
         assert len(results) == 1
 
+    def test_search_is_blocked_true(self, client, transport):
+        """is_blocked=True searches only the blocked folder (admin/JWT)."""
+        transport.get.return_value = [TEXT_MESSAGE_BLOCKED_DICT]
+
+        results = client._texts.search(NUM_ID, q="crypto", is_blocked=True)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts/search",
+            params={"q": "crypto", "limit": 50, "is_blocked": True},
+        )
+        assert results[0].is_blocked is True
+
+    def test_search_is_blocked_false(self, client, transport):
+        """is_blocked=False keeps admin search clean of blocked spam."""
+        transport.get.return_value = []
+
+        client._texts.search(NUM_ID, q="invoice", is_blocked=False)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts/search",
+            params={"q": "invoice", "limit": 50, "is_blocked": False},
+        )
+
+    def test_search_omits_is_blocked_by_default(self, client, transport):
+        transport.get.return_value = []
+
+        client._texts.search(NUM_ID, q="hello")
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts/search",
+            params={"q": "hello", "limit": 50},
+        )
+
 
 class TestTextsListConversations:
     def test_returns_summaries(self, client, transport):
@@ -154,6 +221,28 @@ class TestTextsListConversations:
         assert convos[0].unread_count == 3
         assert convos[0].total_count == 15
         assert convos[0].latest_direction == "inbound"
+
+    def test_list_conversations_is_blocked_false(self, client, transport):
+        """is_blocked=False hides spam-only counterparties + stops blocked previews from bumping."""
+        transport.get.return_value = []
+
+        client._texts.list_conversations(NUM_ID, is_blocked=False)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts/conversations",
+            params={"limit": 50, "offset": 0, "is_blocked": False},
+        )
+
+    def test_list_conversations_is_blocked_true(self, client, transport):
+        """is_blocked=True narrows summary to conversations made up of blocked rows."""
+        transport.get.return_value = []
+
+        client._texts.list_conversations(NUM_ID, is_blocked=True)
+
+        transport.get.assert_called_once_with(
+            f"/numbers/{NUM_ID}/texts/conversations",
+            params={"limit": 50, "offset": 0, "is_blocked": True},
+        )
 
 
 class TestTextsGetConversation:

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -465,10 +465,17 @@ export class AgentIdentity {
   /**
    * List calls made to/from this identity's phone number.
    *
+   * Identity-scoped credentials never see contact-rule-blocked rows
+   * regardless of `isBlocked` (server-side access policy).
+   *
    * @param options.limit - Maximum number of results. Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
-  async listCalls(options: { limit?: number; offset?: number } = {}): Promise<PhoneCall[]> {
+  async listCalls(
+    options: { limit?: number; offset?: number; isBlocked?: boolean } = {},
+  ): Promise<PhoneCall[]> {
     this._requirePhone();
     return this._inkbox._calls.list(this._phoneNumber!.id, options);
   }
@@ -509,12 +516,22 @@ export class AgentIdentity {
   /**
    * List text messages for this identity's phone number.
    *
+   * Identity-scoped credentials never see contact-rule-blocked rows
+   * regardless of `isBlocked` (server-side access policy).
+   *
    * @param options.limit - Maximum number of results. Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
    * @param options.isRead - Filter by read state.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
   async listTexts(
-    options?: { limit?: number; offset?: number; isRead?: boolean },
+    options?: {
+      limit?: number;
+      offset?: number;
+      isRead?: boolean;
+      isBlocked?: boolean;
+    },
   ): Promise<TextMessage[]> {
     this._requirePhone();
     return this._inkbox._texts.list(this._phoneNumber!.id, options);
@@ -533,11 +550,18 @@ export class AgentIdentity {
   /**
    * List text conversations (one row per remote number).
    *
+   * Identity-scoped credentials never see blocked rows in conversation
+   * summaries; admin/JWT can pass `isBlocked=false` to hide spam-only
+   * counterparties or `isBlocked=true` to narrow to conversations made
+   * up of blocked rows.
+   *
    * @param options.limit - Maximum number of results. Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
   async listTextConversations(
-    options?: { limit?: number; offset?: number },
+    options?: { limit?: number; offset?: number; isBlocked?: boolean },
   ): Promise<TextConversationSummary[]> {
     this._requirePhone();
     return this._inkbox._texts.listConversations(this._phoneNumber!.id, options);

--- a/sdk/typescript/src/phone/resources/calls.ts
+++ b/sdk/typescript/src/phone/resources/calls.ts
@@ -20,17 +20,31 @@ export class CallsResource {
   /**
    * List calls for a phone number, newest first.
    *
+   * Identity-scoped API keys never see contact-rule-blocked rows
+   * regardless of `isBlocked` (filtered server-side). Admin/JWT
+   * callers see everything by default; pass `isBlocked=true` for the
+   * blocked-only listing or `isBlocked=false` to exclude blocked rows.
+   *
    * @param phoneNumberId - UUID of the phone number.
    * @param options.limit - Max results (1–200). Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
   async list(
     phoneNumberId: string,
-    options?: { limit?: number; offset?: number },
+    options?: { limit?: number; offset?: number; isBlocked?: boolean },
   ): Promise<PhoneCall[]> {
+    const params: Record<string, string | number | boolean> = {
+      limit: options?.limit ?? 50,
+      offset: options?.offset ?? 0,
+    };
+    if (options?.isBlocked !== undefined) {
+      params["is_blocked"] = options.isBlocked;
+    }
     const data = await this.http.get<RawPhoneCall[]>(
       `/numbers/${phoneNumberId}/calls`,
-      { limit: options?.limit ?? 50, offset: options?.offset ?? 0 },
+      params,
     );
     return data.map(parsePhoneCall);
   }

--- a/sdk/typescript/src/phone/resources/texts.ts
+++ b/sdk/typescript/src/phone/resources/texts.ts
@@ -48,14 +48,26 @@ export class TextsResource {
   /**
    * List text messages for a phone number, newest first.
    *
+   * Identity-scoped API keys never see contact-rule-blocked rows
+   * regardless of `isBlocked` (filtered server-side). Admin/JWT
+   * callers see everything by default; pass `isBlocked=true` for the
+   * blocked-only listing or `isBlocked=false` to exclude blocked rows.
+   *
    * @param phoneNumberId - UUID of the phone number.
    * @param options.limit - Max results (1–200). Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
    * @param options.isRead - Filter by read state.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
   async list(
     phoneNumberId: string,
-    options?: { limit?: number; offset?: number; isRead?: boolean },
+    options?: {
+      limit?: number;
+      offset?: number;
+      isRead?: boolean;
+      isBlocked?: boolean;
+    },
   ): Promise<TextMessage[]> {
     const params: Record<string, string | number | boolean> = {
       limit: options?.limit ?? 50,
@@ -63,6 +75,9 @@ export class TextsResource {
     };
     if (options?.isRead !== undefined) {
       params["is_read"] = options.isRead;
+    }
+    if (options?.isBlocked !== undefined) {
+      params["is_blocked"] = options.isBlocked;
     }
     const data = await this.http.get<RawTextMessage[]>(
       `/numbers/${phoneNumberId}/texts`,
@@ -108,17 +123,31 @@ export class TextsResource {
   /**
    * Full-text search across text messages for a phone number.
    *
+   * Identity-scoped API keys never see contact-rule-blocked rows in
+   * results regardless of `isBlocked`. Admin/JWT callers see everything
+   * by default; `isBlocked=false` keeps search clean of blocked spam,
+   * `isBlocked=true` searches only the blocked folder.
+   *
    * @param phoneNumberId - UUID of the phone number.
    * @param options.q - Search query string.
    * @param options.limit - Max results (1–200). Defaults to 50.
+   * @param options.isBlocked - Tri-state filter. `true` for only blocked,
+   *   `false` for only non-blocked, omit for all.
    */
   async search(
     phoneNumberId: string,
-    options: { q: string; limit?: number },
+    options: { q: string; limit?: number; isBlocked?: boolean },
   ): Promise<TextMessage[]> {
+    const params: Record<string, string | number | boolean> = {
+      q: options.q,
+      limit: options.limit ?? 50,
+    };
+    if (options.isBlocked !== undefined) {
+      params["is_blocked"] = options.isBlocked;
+    }
     const data = await this.http.get<RawTextMessage[]>(
       `/numbers/${phoneNumberId}/texts/search`,
-      { q: options.q, limit: options.limit ?? 50 },
+      params,
     );
     return data.map(parseTextMessage);
   }
@@ -126,17 +155,33 @@ export class TextsResource {
   /**
    * List conversations (one row per remote number) with latest message preview.
    *
+   * Identity-scoped API keys never see blocked rows in conversation
+   * summaries; admin/JWT callers can pass `isBlocked=false` to hide
+   * spam-only counterparties and stop blocked rows from bumping quiet
+   * conversations to the top, or `isBlocked=true` to narrow to
+   * conversations made up of blocked rows.
+   *
    * @param phoneNumberId - UUID of the phone number.
    * @param options.limit - Max results (1–200). Defaults to 50.
    * @param options.offset - Pagination offset. Defaults to 0.
+   * @param options.isBlocked - Tri-state filter applied to the
+   *   underlying messages. `true` for only blocked, `false` for only
+   *   non-blocked, omit for all.
    */
   async listConversations(
     phoneNumberId: string,
-    options?: { limit?: number; offset?: number },
+    options?: { limit?: number; offset?: number; isBlocked?: boolean },
   ): Promise<TextConversationSummary[]> {
+    const params: Record<string, string | number | boolean> = {
+      limit: options?.limit ?? 50,
+      offset: options?.offset ?? 0,
+    };
+    if (options?.isBlocked !== undefined) {
+      params["is_blocked"] = options.isBlocked;
+    }
     const data = await this.http.get<RawTextConversationSummary[]>(
       `/numbers/${phoneNumberId}/texts/conversations`,
-      { limit: options?.limit ?? 50, offset: options?.offset ?? 0 },
+      params,
     );
     return data.map(parseTextConversationSummary);
   }

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -111,6 +111,14 @@ export interface PhoneCall {
   hangupReason: string | null;
   startedAt: Date | null;
   endedAt: Date | null;
+  /**
+   * `true` when this call was rejected by a contact rule or default-block
+   * before connect. Identity-scoped (agent) API keys never observe `true`
+   * rows — the server filters them at the access-policy layer. Admin/JWT
+   * callers see both values mixed and can narrow with `isBlocked` on
+   * `CallsResource.list`.
+   */
+  isBlocked: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -164,6 +172,14 @@ export interface TextMessage {
   sentAt: Date | null;
   deliveredAt: Date | null;
   failedAt: Date | null;
+  /**
+   * `true` when this text was rejected by a contact rule or default-block.
+   * Identity-scoped (agent) API keys never observe `true` rows — the
+   * server filters them at the access-policy layer. Admin/JWT callers see
+   * both values mixed and can narrow with `isBlocked` on
+   * `TextsResource.list` / `search` / `listConversations`.
+   */
+  isBlocked: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -223,6 +239,9 @@ export interface RawPhoneCall {
   hangup_reason: string | null;
   started_at: string | null;
   ended_at: string | null;
+  // Optional for back-compat with older server responses that predate
+  // the field; parser defaults missing values to false.
+  is_blocked?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -262,6 +281,9 @@ export interface RawTextMessage {
   sent_at?: string | null;
   delivered_at?: string | null;
   failed_at?: string | null;
+  // Optional for back-compat with older server responses that predate
+  // the field; parser defaults missing values to false.
+  is_blocked?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -340,6 +362,7 @@ export function parsePhoneCall(r: RawPhoneCall): PhoneCall {
     hangupReason: r.hangup_reason,
     startedAt: r.started_at ? new Date(r.started_at) : null,
     endedAt: r.ended_at ? new Date(r.ended_at) : null,
+    isBlocked: r.is_blocked ?? false,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
   };
@@ -404,6 +427,7 @@ export function parseTextMessage(r: RawTextMessage): TextMessage {
     sentAt: r.sent_at ? new Date(r.sent_at) : null,
     deliveredAt: r.delivered_at ? new Date(r.delivered_at) : null,
     failedAt: r.failed_at ? new Date(r.failed_at) : null,
+    isBlocked: r.is_blocked ?? false,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
   };

--- a/sdk/typescript/tests/phone/calls.test.ts
+++ b/sdk/typescript/tests/phone/calls.test.ts
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { CallsResource } from "../../src/phone/resources/calls.js";
 import type { HttpTransport } from "../../src/_http.js";
-import { RAW_PHONE_CALL, RAW_PHONE_CALL_WITH_RATE_LIMIT } from "../sampleData.js";
+import {
+  RAW_PHONE_CALL,
+  RAW_PHONE_CALL_BLOCKED,
+  RAW_PHONE_CALL_WITH_RATE_LIMIT,
+} from "../sampleData.js";
 
 function mockHttp() {
   return {
@@ -37,6 +41,62 @@ describe("CallsResource.list", () => {
     await res.list(NUM_ID, { limit: 10, offset: 20 });
 
     expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/calls`, { limit: 10, offset: 20 });
+  });
+
+  it("omits is_blocked when not provided", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new CallsResource(http);
+
+    await res.list(NUM_ID);
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/calls`, {
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it("forwards isBlocked=true for the admin-side blocked listing", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_PHONE_CALL_BLOCKED]);
+    const res = new CallsResource(http);
+
+    const calls = await res.list(NUM_ID, { isBlocked: true });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/calls`, {
+      limit: 50,
+      offset: 0,
+      is_blocked: true,
+    });
+    expect(calls[0].isBlocked).toBe(true);
+  });
+
+  it("forwards isBlocked=false to narrow admin/JWT view to non-blocked rows", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_PHONE_CALL]);
+    const res = new CallsResource(http);
+
+    const calls = await res.list(NUM_ID, { isBlocked: false });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/calls`, {
+      limit: 50,
+      offset: 0,
+      is_blocked: false,
+    });
+    expect(calls[0].isBlocked).toBe(false);
+  });
+
+  it("defaults isBlocked to false when missing from server response (back-compat)", async () => {
+    const http = mockHttp();
+    // Older server payload without the field — parser must default to false.
+    const { is_blocked: _ignored, ...legacyPayload } = RAW_PHONE_CALL;
+    void _ignored;
+    vi.mocked(http.get).mockResolvedValue([legacyPayload]);
+    const res = new CallsResource(http);
+
+    const calls = await res.list(NUM_ID);
+
+    expect(calls[0].isBlocked).toBe(false);
   });
 });
 

--- a/sdk/typescript/tests/phone/texts.test.ts
+++ b/sdk/typescript/tests/phone/texts.test.ts
@@ -4,6 +4,7 @@ import { TextsResource } from "../../src/phone/resources/texts.js";
 import type { HttpTransport } from "../../src/_http.js";
 import {
   RAW_TEXT_MESSAGE,
+  RAW_TEXT_MESSAGE_BLOCKED,
   RAW_TEXT_MESSAGE_MMS,
   RAW_TEXT_MESSAGE_OUTBOUND_QUEUED,
   RAW_TEXT_CONVERSATION_SUMMARY,
@@ -88,6 +89,48 @@ describe("TextsResource.list", () => {
     });
   });
 
+  it("forwards isBlocked=true for the admin-side blocked listing", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_TEXT_MESSAGE_BLOCKED]);
+    const res = new TextsResource(http);
+
+    const texts = await res.list(NUM_ID, { isBlocked: true });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/texts`, {
+      limit: 50,
+      offset: 0,
+      is_blocked: true,
+    });
+    expect(texts[0].isBlocked).toBe(true);
+  });
+
+  it("forwards isBlocked=false to keep the admin/JWT view clean of blocked spam", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_TEXT_MESSAGE]);
+    const res = new TextsResource(http);
+
+    const texts = await res.list(NUM_ID, { isBlocked: false });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/texts`, {
+      limit: 50,
+      offset: 0,
+      is_blocked: false,
+    });
+    expect(texts[0].isBlocked).toBe(false);
+  });
+
+  it("defaults isBlocked to false when missing from server response (back-compat)", async () => {
+    const http = mockHttp();
+    const { is_blocked: _ignored, ...legacyPayload } = RAW_TEXT_MESSAGE;
+    void _ignored;
+    vi.mocked(http.get).mockResolvedValue([legacyPayload]);
+    const res = new TextsResource(http);
+
+    const texts = await res.list(NUM_ID);
+
+    expect(texts[0].isBlocked).toBe(false);
+  });
+
   it("parses MMS with media", async () => {
     const http = mockHttp();
     vi.mocked(http.get).mockResolvedValue([RAW_TEXT_MESSAGE_MMS]);
@@ -146,6 +189,48 @@ describe("TextsResource.search", () => {
     });
     expect(results).toHaveLength(1);
   });
+
+  it("forwards isBlocked=true to search the blocked folder", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_TEXT_MESSAGE_BLOCKED]);
+    const res = new TextsResource(http);
+
+    const results = await res.search(NUM_ID, { q: "crypto", isBlocked: true });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/texts/search`, {
+      q: "crypto",
+      limit: 50,
+      is_blocked: true,
+    });
+    expect(results[0].isBlocked).toBe(true);
+  });
+
+  it("forwards isBlocked=false to keep admin search clean", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new TextsResource(http);
+
+    await res.search(NUM_ID, { q: "invoice", isBlocked: false });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/texts/search`, {
+      q: "invoice",
+      limit: 50,
+      is_blocked: false,
+    });
+  });
+
+  it("omits is_blocked param when not provided", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new TextsResource(http);
+
+    await res.search(NUM_ID, { q: "hello" });
+
+    expect(http.get).toHaveBeenCalledWith(`/numbers/${NUM_ID}/texts/search`, {
+      q: "hello",
+      limit: 50,
+    });
+  });
 });
 
 describe("TextsResource.listConversations", () => {
@@ -164,6 +249,32 @@ describe("TextsResource.listConversations", () => {
     expect(convos[0].remotePhoneNumber).toBe(REMOTE);
     expect(convos[0].unreadCount).toBe(3);
     expect(convos[0].totalCount).toBe(15);
+  });
+
+  it("forwards isBlocked=false to hide spam-only counterparties", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new TextsResource(http);
+
+    await res.listConversations(NUM_ID, { isBlocked: false });
+
+    expect(http.get).toHaveBeenCalledWith(
+      `/numbers/${NUM_ID}/texts/conversations`,
+      { limit: 50, offset: 0, is_blocked: false },
+    );
+  });
+
+  it("forwards isBlocked=true to narrow to blocked-only conversations", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new TextsResource(http);
+
+    await res.listConversations(NUM_ID, { isBlocked: true });
+
+    expect(http.get).toHaveBeenCalledWith(
+      `/numbers/${NUM_ID}/texts/conversations`,
+      { limit: 50, offset: 0, is_blocked: true },
+    );
   });
 });
 

--- a/sdk/typescript/tests/phone/types.test.ts
+++ b/sdk/typescript/tests/phone/types.test.ts
@@ -81,12 +81,27 @@ describe("parsePhoneCall", () => {
     expect(c.clientWebsocketUrl).toBe("wss://agent.example.com/ws");
     expect(c.startedAt).toBeInstanceOf(Date);
     expect(c.endedAt).toBeInstanceOf(Date);
+    expect(c.isBlocked).toBe(false);
   });
 
   it("handles null timestamps", () => {
     const c = parsePhoneCall({ ...RAW_PHONE_CALL, started_at: null, ended_at: null });
     expect(c.startedAt).toBeNull();
     expect(c.endedAt).toBeNull();
+  });
+
+  it("preserves isBlocked=true (admin/JWT view of a blocked call)", () => {
+    const c = parsePhoneCall({ ...RAW_PHONE_CALL, is_blocked: true });
+    expect(c.isBlocked).toBe(true);
+  });
+
+  it("defaults isBlocked to false when missing from server response", () => {
+    // Older server payloads predate the field — parser must default to false
+    // so existing clients keep working.
+    const { is_blocked: _ignored, ...legacyPayload } = RAW_PHONE_CALL;
+    void _ignored;
+    const c = parsePhoneCall(legacyPayload);
+    expect(c.isBlocked).toBe(false);
   });
 });
 

--- a/sdk/typescript/tests/sampleData.ts
+++ b/sdk/typescript/tests/sampleData.ts
@@ -105,8 +105,26 @@ export const RAW_PHONE_CALL = {
   hangup_reason: null,
   started_at: "2026-03-09T00:01:00Z",
   ended_at: "2026-03-09T00:05:00Z",
+  is_blocked: false,
   created_at: "2026-03-09T00:00:00Z",
   updated_at: "2026-03-09T00:05:00Z",
+};
+
+export const RAW_PHONE_CALL_BLOCKED = {
+  id: "bbbb2222-0000-0000-0000-0000000000bb",
+  local_phone_number: "+18335794607",
+  remote_phone_number: "+15551234567",
+  direction: "inbound",
+  status: "failed",
+  client_websocket_url: null,
+  use_inkbox_tts: null,
+  use_inkbox_stt: null,
+  hangup_reason: "rejected",
+  started_at: null,
+  ended_at: null,
+  is_blocked: true,
+  created_at: "2026-03-09T00:30:00Z",
+  updated_at: "2026-03-09T00:30:00Z",
 };
 
 export const RAW_RATE_LIMIT = {
@@ -144,8 +162,23 @@ export const RAW_TEXT_MESSAGE = {
   type: "sms",
   media: null,
   is_read: false,
+  is_blocked: false,
   created_at: "2026-03-09T00:10:00Z",
   updated_at: "2026-03-09T00:10:00Z",
+};
+
+export const RAW_TEXT_MESSAGE_BLOCKED = {
+  id: "dddd4444-0000-0000-0000-0000000000bb",
+  direction: "inbound",
+  local_phone_number: "+18335794607",
+  remote_phone_number: "+15551234567",
+  text: "Buy crypto now!!!",
+  type: "sms",
+  media: null,
+  is_read: false,
+  is_blocked: true,
+  created_at: "2026-03-09T00:35:00Z",
+  updated_at: "2026-03-09T00:35:00Z",
 };
 
 export const RAW_TEXT_MESSAGE_MMS = {


### PR DESCRIPTION
## Summary

Mirrors the server change in inkbox-ai/servers#126 (which adopts the mail blocked-folder pattern for phone). Identity-scoped (agent) API keys never see contact-rule-blocked rows — the server filters them at the access-policy layer. Admin-scoped API keys and JWT humans see everything by default, and can narrow with the new `is_blocked` query filter.

This PR threads that filter through both SDKs and adds the `is_blocked` field to the response types.

## What changed

**Python SDK**
- `phone/types.py`: `PhoneCall` and `TextMessage` gain `is_blocked: bool`. `_from_dict` defaults missing values to `False` (back-compat with older server responses that predate the field).
- `phone/resources/calls.py`: `list()` takes `is_blocked: bool | None = None`.
- `phone/resources/texts.py`: `list()`, `search()`, and `list_conversations()` take `is_blocked: bool | None = None`.
- `agent_identity.py`: identity-level wrappers `list_calls`, `list_texts`, `list_text_conversations` forward the new param.

**TypeScript SDK**
- `phone/types.ts`: `PhoneCall` and `TextMessage` interfaces gain `isBlocked: boolean`. `RawPhoneCall` and `RawTextMessage` carry optional snake-case `is_blocked`. `parsePhoneCall` and `parseTextMessage` default missing values to `false`.
- `phone/resources/calls.ts` and `texts.ts`: `list`, `search`, `listConversations` accept `isBlocked?: boolean`.
- `agent_identity.ts`: matching identity-level wrappers.

## Tri-state semantics

| `is_blocked` | Admin / JWT view | Identity-scoped (agent) view |
|---|---|---|
| omitted | all rows | only non-blocked (predicate) |
| `true` | only blocked | empty (predicate × repo conflict) |
| `false` | only non-blocked | only non-blocked (predicate) |

## Tests

- Both SDKs: pin the new param flows through (true / false / omitted) on every affected list/search method.
- Both SDKs: parser back-compat — server payload without `is_blocked` parses to `false`.
- Existing tests untouched / unchanged behavior — callers that don't pass the new param see no diff.

435 Python tests pass, 449 TS tests pass.

## Cross-repo

- inkbox-ai/servers#126 — server-side change (no new endpoints; `?is_blocked=` is added to the existing list / search / conversations routes).