### PR TITLE
chore: bump inkbox package versions to 0.2.16

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.2.15",
+    "@inkbox/sdk": "^0.2.16",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.2.15"
+version = "0.2.16"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/skills/inkbox-openclaw/package.json
+++ b/skills/inkbox-openclaw/package.json
@@ -1,9 +1,9 @@
 {
   "name": "inkbox-openclaw",
-  "version": "0.1.0",
+  "version": "0.2.16",
   "type": "module",
   "dependencies": {
-    "@inkbox/sdk": "^0.1.1"
+    "@inkbox/sdk": "^0.2.16"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- bump Python SDK, TypeScript SDK, CLI, and OpenClaw package versions to 0.2.16
- align CLI and OpenClaw @inkbox/sdk dependency ranges to ^0.2.16

## Verification
- git diff --check