### PR TITLE
v0.3.1: Fix tunnel docs, bump CLI Node version requirement to ≥22

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ API-first communication infrastructure for AI agents — email (with custom send
 | Package | Language | Install |
 |---|---|---|
 | [`inkbox`](./sdk/python/) | Python ≥ 3.11 | `pip install inkbox` |
-| [`@inkbox/sdk`](./sdk/typescript/) | TypeScript / Node ≥ 18 | `npm install @inkbox/sdk` |
-| [`@inkbox/cli`](./cli/) | CLI / Node ≥ 18 | `npm install -g @inkbox/cli` |
+| [`@inkbox/sdk`](./sdk/typescript/) | TypeScript / Node ≥ 22 | `npm install @inkbox/sdk` |
+| [`@inkbox/cli`](./cli/) | CLI / Node ≥ 22 | `npm install -g @inkbox/cli` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ inkbox vault get <secret-id>
 ### Tunnels (Python)
 
 ```python
-# Bring a local server online at https://my-app.tunnel.inkboxwire.com.
+# Bring a local server online at https://my-app.inkboxwire.com.
 # Outbound HTTP/2 only — no inbound port to open. POSIX only.
 listener = inkbox.tunnels.connect(name="my-app", forward_to="http://127.0.0.1:8080")
 print(listener.public_url)

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@ Or run directly with npx:
 npx @inkbox/cli <command>
 ```
 
-Requires Node.js >= 18.
+Requires Node.js >= 22.
 
 ## Authentication
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.3.0",
+    "@inkbox/sdk": "^0.3.1",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -35,6 +35,6 @@
     "url": "https://github.com/inkbox-ai/inkbox/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/examples/use-inkbox-cli/README.md
+++ b/examples/use-inkbox-cli/README.md
@@ -4,7 +4,7 @@ Shell script examples showing how to automate Inkbox from the command line — u
 
 ## Prerequisites
 
-1. Node.js >= 18
+1. Node.js >= 22
 2. An Inkbox API key (`INKBOX_API_KEY`) — get one at [inkbox.ai/console](https://inkbox.ai/console)
 3. A vault key (`INKBOX_VAULT_KEY`) — only needed for vault/TOTP scripts; initialize from the console first
 4. [`jq`](https://jqlang.github.io/jq/) — used to parse `--json` output

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -613,7 +613,7 @@ inkbox.phone_numbers.release(number.id)
 
 ## Tunnels
 
-Bring a local Python process online at a public `https://{name}.tunnel.inkboxwire.com` URL via outbound HTTP/2. No inbound port to open, no static IP needed. POSIX only.
+Bring a local Python process online at a public `https://{name}.inkboxwire.com` URL via outbound HTTP/2. No inbound port to open, no static IP needed. POSIX only.
 
 ```python
 with Inkbox(api_key="ApiKey_...") as inkbox:
@@ -622,7 +622,7 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
         name="my-app",
         forward_to="http://127.0.0.1:8080",
     )
-    print(listener.public_url)        # https://my-app.tunnel.inkboxwire.com
+    print(listener.public_url)        # https://my-app.inkboxwire.com
     listener.wait()                   # blocks until close()/Ctrl-C
 
     # Or forward to an in-process ASGI app (FastAPI / Starlette / yours)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/skills/README.md
+++ b/skills/README.md
@@ -55,9 +55,9 @@ Once the skills are installed, your coding agent will automatically know how to 
 | Skill | Language | Description |
 |-------|----------|-------------|
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `inkbox` Python SDK |
-| **inkbox-ts** | TypeScript / Node ≥ 18 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `@inkbox/sdk` TypeScript SDK |
-| **inkbox-openclaw** | TypeScript / Node ≥ 18 | OpenClaw skill — agent signup, email, phone, text, contacts, notes, contact rules, and vault for your OpenClaw agent |
-| **inkbox-cli** | TypeScript / Node ≥ 18 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |
+| **inkbox-ts** | TypeScript / Node ≥ 22 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `@inkbox/sdk` TypeScript SDK |
+| **inkbox-openclaw** | TypeScript / Node ≥ 22 | OpenClaw skill — agent signup, email, phone, text, contacts, notes, contact rules, and vault for your OpenClaw agent |
+| **inkbox-cli** | TypeScript / Node ≥ 22 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |
 | **inkbox-all** | Language-agnostic | Index of all Inkbox skills in this repository, including example skills and links for choosing the right one |
 | **inkbox-agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -44,7 +44,7 @@ Or run without a global install:
 npx @inkbox/cli <command>
 ```
 
-Requires Node.js >= 18.
+Requires Node.js >= 22.
 
 Inside this repository, prefer running the local source instead of assuming a global install:
 

--- a/skills/inkbox-openclaw/README.md
+++ b/skills/inkbox-openclaw/README.md
@@ -19,7 +19,7 @@ Once installed, your OpenClaw agent can:
 
 ## Requirements
 
-- Node.js ≥ 18
+- Node.js ≥ 22
 - An [Inkbox](https://inkbox.ai) account with an API key
 
 ## Setup

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -647,7 +647,7 @@ Returns `WhoamiApiKeyResponse` or `WhoamiJwtResponse` — discriminated on `auth
 
 ## Tunnels
 
-Bring a local Node process online at a public `https://{name}.tunnel.inkboxwire.com` URL via outbound HTTP/2 — no inbound port required. POSIX only.
+Bring a local Node process online at a public `https://{name}.inkboxwire.com` URL via outbound HTTP/2 — no inbound port required. POSIX only.
 
 > **Lifecycle caveat:** tunnels expect a long-running process and a writable state dir (`~/.inkbox/tunnels/{name}`). One-shot disposable scripts are not the right fit; use this from a sustained service. If you must run from a temporary working directory, pass `stateDir:` to a stable path so the connect secret and (in passthrough) private key persist between invocations.
 
@@ -659,7 +659,7 @@ const listener = await connect(inkbox, {
   name: "my-app",
   forwardTo: "http://127.0.0.1:8080",
 });
-console.log(listener.publicUrl);    // https://my-app.tunnel.inkboxwire.com
+console.log(listener.publicUrl);    // https://my-app.inkboxwire.com
 await listener.wait();              // until SIGINT/SIGTERM
 
 // In-process Fetch-API HTTP handler

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -21,7 +21,7 @@ API-first communication infrastructure for AI agents — email, phone, text/SMS,
 ## Requirements
 
 - `INKBOX_API_KEY` — Inkbox API key
-- `node` on `PATH` (Node.js 18+)
+- `node` on `PATH` (Node.js 22+)
 - `INKBOX_AGENT_HANDLE` is optional; use it when already configured, otherwise ask the user which identity handle to use or create
 
 ## Runtime setup
@@ -46,7 +46,7 @@ Use `.mjs` scripts with standard ESM imports. Avoid relying on `tsx --eval` or t
 npm install @inkbox/sdk
 ```
 
-Requires Node.js ≥ 18. ESM module — no context manager needed:
+Requires Node.js ≥ 22. ESM module — no context manager needed:
 
 ```js
 import { Inkbox } from "@inkbox/sdk";

--- a/skills/inkbox-openclaw/package.json
+++ b/skills/inkbox-openclaw/package.json
@@ -6,6 +6,6 @@
     "@inkbox/sdk": "^0.3.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/skills/inkbox-openclaw/package.json
+++ b/skills/inkbox-openclaw/package.json
@@ -1,9 +1,9 @@
 {
   "name": "inkbox-openclaw",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "dependencies": {
-    "@inkbox/sdk": "^0.3.0"
+    "@inkbox/sdk": "^0.3.1"
   },
   "engines": {
     "node": ">=22"

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -627,7 +627,7 @@ if info.auth_type == "api_key" and info.auth_subtype == AUTH_SUBTYPE_API_KEY_ADM
 
 ## Tunnels
 
-Bring a local process online at a public `https://{name}.tunnel.inkboxwire.com` URL. Outbound HTTP/2 only — no inbound port to open. POSIX only.
+Bring a local process online at a public `https://{name}.inkboxwire.com` URL. Outbound HTTP/2 only — no inbound port to open. POSIX only.
 
 ```python
 # Forward to a local URL (edge mode — Inkbox terminates TLS at the edge)
@@ -635,7 +635,7 @@ listener = inkbox.tunnels.connect(
     name="my-app",
     forward_to="http://127.0.0.1:8080",
 )
-print(listener.public_url)        # https://my-app.tunnel.inkboxwire.com
+print(listener.public_url)        # https://my-app.inkboxwire.com
 listener.wait()                   # blocks until close()/Ctrl-C
 
 # Forward to an in-process ASGI app (FastAPI / Starlette / your own)

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -655,7 +655,7 @@ if (info.authType === "api_key" && info.authSubtype === AUTH_SUBTYPE_API_KEY_ADM
 
 ## Tunnels
 
-Bring a local Node process online at a public `https://{name}.tunnel.inkboxwire.com` URL. Outbound HTTP/2 only — no inbound port to open. POSIX only; the data-plane runtime lives on a separate package subpath so the main `@inkbox/sdk` entry stays browser-safe.
+Bring a local Node process online at a public `https://{name}.inkboxwire.com` URL. Outbound HTTP/2 only — no inbound port to open. POSIX only; the data-plane runtime lives on a separate package subpath so the main `@inkbox/sdk` entry stays browser-safe.
 
 ```typescript
 import { connect } from "@inkbox/sdk/tunnels/connect";
@@ -665,7 +665,7 @@ const listener = await connect(inkbox, {
   name: "my-app",
   forwardTo: "http://127.0.0.1:8080",
 });
-console.log(listener.publicUrl);    // https://my-app.tunnel.inkboxwire.com
+console.log(listener.publicUrl);    // https://my-app.inkboxwire.com
 await listener.wait();              // until SIGINT/SIGTERM
 
 // In-process Fetch-API HTTP handler

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -14,7 +14,7 @@ API-first communication infrastructure for AI agents — email, phone, encrypted
 npm install @inkbox/sdk
 ```
 
-Requires Node.js ≥ 18. ESM module — no context manager needed:
+Requires Node.js ≥ 22. ESM module — no context manager needed:
 
 ```typescript
 import { Inkbox } from "@inkbox/sdk";

--- a/skills/inkbox-tunnels/SKILL.md
+++ b/skills/inkbox-tunnels/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: false
 
 # Inkbox Tunnels
 
-Inkbox Tunnels expose a process running on the developer's machine (or any POSIX host) at a public `https://{name}.tunnel.inkboxwire.com` URL. The SDK opens an outbound HTTP/2 connection to the data plane; inbound third-party traffic rides back over that same connection. No inbound port to open, no static IP needed.
+Inkbox Tunnels expose a process running on the developer's machine (or any POSIX host) at a public `https://{name}.inkboxwire.com` URL. The SDK opens an outbound HTTP/2 connection to the data plane; inbound third-party traffic rides back over that same connection. No inbound port to open, no static IP needed.
 
 Two TLS modes:
 
@@ -39,7 +39,7 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
         name="my-app",
         forward_to="http://127.0.0.1:8080",
     )
-    print(listener.public_url)   # https://my-app.tunnel.inkboxwire.com
+    print(listener.public_url)   # https://my-app.inkboxwire.com
     listener.wait()              # blocks; Ctrl-C to stop
 ```
 
@@ -143,7 +143,7 @@ const listener = await connect(inkbox, {
   name: "my-app",
   forwardTo: "http://127.0.0.1:8080",
 });
-console.log(listener.publicUrl);   // https://my-app.tunnel.inkboxwire.com
+console.log(listener.publicUrl);   // https://my-app.inkboxwire.com
 await listener.wait();              // until Ctrl-C / SIGTERM
 ```
 

--- a/skills/inkbox-tunnels/SKILL.md
+++ b/skills/inkbox-tunnels/SKILL.md
@@ -129,7 +129,7 @@ inkbox.tunnels.rotate_secret("tunnel-uuid") # returns RotatedSecret
 npm install @inkbox/sdk
 ```
 
-Node ≥ 18, POSIX only. The data-plane subpath imports `node:http2` / `node:tls`, so it's loaded from a separate entry — `@inkbox/sdk` itself stays browser-safe.
+Node ≥ 22, POSIX only. The data-plane subpath imports `node:http2` / `node:tls`, so it's loaded from a separate entry — `@inkbox/sdk` itself stays browser-safe.
 
 ### Forward to a local URL (edge mode)
 


### PR DESCRIPTION
Updates include:
- Correction: `{name}.tunnel.inkboxwire.com` → `{name}.inkboxwire.com`
- TS SDK uses Node ≥ 22 now, not Node ≥ 18.