### PR TITLE
SDK: drop assign_phone_number; unlink_phone_number now releases

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.4.3
+
+### Breaking
+
+- **`inkbox identity unlink-phone <handle>` was renamed to `inkbox identity release-phone <handle>`** and now releases the number at the carrier in addition to detaching it from the identity. Previously it only cleared the FK and left the carrier-side number live. There is no "unlink without release" path anymore.
+- **`inkbox identity assign-phone` was removed.** The server no longer supports cross-identity reassignment; phone numbers are bound to the identity they were provisioned on. Use `--phone-number` on identity create, or `inkbox phone provision --agent-handle <handle>` to attach a number to an existing identity.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,4 +5,4 @@
 ### Breaking
 
 - **`inkbox identity unlink-phone <handle>` was renamed to `inkbox identity release-phone <handle>`** and now releases the number at the carrier in addition to detaching it from the identity. Previously it only cleared the FK and left the carrier-side number live. There is no "unlink without release" path anymore.
-- **`inkbox identity assign-phone` was removed.** The server no longer supports cross-identity reassignment; phone numbers are bound to the identity they were provisioned on. Use `--phone-number` on identity create, or `inkbox phone provision --agent-handle <handle>` to attach a number to an existing identity.
+- **`inkbox identity assign-phone` was removed.** The server no longer supports cross-identity reassignment; phone numbers are bound to the identity they were provisioned on. To attach a number, create the identity first with `inkbox identity create <handle>`, then run `inkbox number provision --handle <handle>`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -102,9 +102,7 @@ inkbox identity get-secret <handle> <secret-id>     # Decrypt a secret (vault ke
 inkbox identity delete-secret <handle> <secret-id>  # Delete a secret (vault key)
 inkbox identity revoke-access <handle> <secret-id>  # Revoke credential access
 
-inkbox identity assign-phone <handle>                # Assign an existing phone number
-  --phone-number-id <id>                       #   Phone number UUID (required)
-inkbox identity unlink-phone <handle>                # Unlink phone number from identity
+inkbox identity release-phone <handle>               # Release phone number back to the carrier
 
 inkbox identity set-totp <handle> <secret-id>       # Add TOTP to login (vault key)
   --uri <otpauth-uri>                        #   otpauth:// URI (required)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.2",
+    "@inkbox/sdk": "^0.4.3",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -586,40 +586,15 @@ export function registerIdentityCommands(program: Command): void {
     );
 
   identity
-    .command("assign-phone <handle>")
-    .description("Assign an existing phone number to an identity")
-    .requiredOption("--phone-number-id <id>", "UUID of the phone number to assign")
-    .action(
-      withErrorHandler(async function (
-        this: Command,
-        handle: string,
-        cmdOpts: { phoneNumberId: string },
-      ) {
-        const opts = getGlobalOpts(this);
-        const inkbox = createClient(opts);
-        const id = await inkbox.getIdentity(handle);
-        const pn = await id.assignPhoneNumber(cmdOpts.phoneNumberId);
-        output(
-          {
-            agentHandle: id.agentHandle,
-            phoneNumberId: pn.id,
-            number: pn.number,
-          },
-          { json: !!opts.json },
-        );
-      }),
-    );
-
-  identity
-    .command("unlink-phone <handle>")
-    .description("Unlink the phone number from an identity (does not release the number)")
+    .command("release-phone <handle>")
+    .description("Release the identity's phone number back to the carrier (permanent)")
     .action(
       withErrorHandler(async function (this: Command, handle: string) {
         const opts = getGlobalOpts(this);
         const inkbox = createClient(opts);
         const id = await inkbox.getIdentity(handle);
-        await id.unlinkPhoneNumber();
-        console.log(`Unlinked phone number from identity '${handle}'.`);
+        await id.releasePhoneNumber();
+        console.log(`Released phone number from identity '${handle}'.`);
       }),
     );
 }

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.4.3
+
+### Breaking
+
+- **`identity.unlink_phone_number()` / `IdentitiesResource.unlink_phone_number()` were renamed to `release_phone_number()`** and their behavior changed accordingly. The method now releases the number at the carrier and removes it locally; previously it only cleared the FK on the row and left the carrier-side number live. There is no "unlink without release" path anymore — once a number is released, it cannot be reattached.
+- **`identity.assign_phone_number()` (and the underlying `IdentitiesResource.assign_phone_number()`) were removed.** The server no longer supports cross-identity reassignment; phone numbers are bound to the identity they were provisioned on. To attach a number to an identity, either pass the nested `phone_number` payload to `inkbox.create_identity(...)`, or call `inkbox.phone_numbers.provision(agent_handle=..., ...)` for an existing identity.
+- **`identity.delete()` cascade now releases the linked phone number** (vendor + local), instead of clearing the FK and leaving the carrier-side number live.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -155,7 +155,7 @@ identity.update(new_handle="sales-bot-v2")
 identity.update(display_name="New Name", description="New blurb")
 identity.update(description=None)  # clear
 
-# Release the phone number (carrier release + soft-delete).
+# Release the phone number (vendor + local).
 identity.unlink_phone_number()
 
 # Delete (cascades to mailbox + tunnel; revokes scoped API keys).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -137,10 +137,6 @@ inkbox.create_identity("sales-bot-2", sending_domain="mail.acme.com")
 from inkbox import IdentityTunnelCreateOptions
 inkbox.create_identity("sales-bot-pt", tunnel=IdentityTunnelCreateOptions(tls_mode="passthrough"))
 
-# Link an existing phone number to an identity (mailbox + tunnel are
-# 1:1 with their identity and cannot be relinked).
-identity.assign_phone_number("phone-number-uuid-here")
-
 # Get an existing identity
 identity = inkbox.get_identity("sales-bot")
 identity.refresh()  # re-fetch channels from API

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -155,7 +155,7 @@ identity.update(new_handle="sales-bot-v2")
 identity.update(display_name="New Name", description="New blurb")
 identity.update(description=None)  # clear
 
-# Unlink the phone number (without releasing it).
+# Release the phone number (carrier release + soft-delete).
 identity.unlink_phone_number()
 
 # Delete (cascades to mailbox + tunnel; revokes scoped API keys).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -152,7 +152,7 @@ identity.update(display_name="New Name", description="New blurb")
 identity.update(description=None)  # clear
 
 # Release the phone number (vendor + local).
-identity.unlink_phone_number()
+identity.release_phone_number()
 
 # Delete (cascades to mailbox + tunnel + phone-number release; revokes scoped API keys).
 identity.delete()
@@ -614,7 +614,7 @@ inkbox.domains.set_default("inkboxmail.com")  # -> None
 
 ## Org-level Phone Numbers
 
-Manage phone numbers directly without going through an identity. Access via `inkbox.phone_numbers`.
+Read, search, and release phone numbers org-wide via `inkbox.phone_numbers`. Provisioning still goes through an identity — pass `agent_handle` so the new number is bound to it from the start.
 
 ```python
 # List all phone numbers in the organisation
@@ -624,8 +624,8 @@ numbers = inkbox.phone_numbers.list()
 number = inkbox.phone_numbers.get("phone-number-uuid")
 
 # Provision a new number
-number = inkbox.phone_numbers.provision(type="toll_free")
-local  = inkbox.phone_numbers.provision(type="local", state="NY")
+number = inkbox.phone_numbers.provision(agent_handle="sales-bot", type="toll_free")
+local  = inkbox.phone_numbers.provision(agent_handle="sales-bot", type="local", state="NY")
 
 # Update incoming call behaviour
 inkbox.phone_numbers.update(
@@ -869,7 +869,7 @@ Runnable example scripts are available in the [examples/python](https://github.c
 
 | Script | What it demonstrates |
 |---|---|
-| `register_agent_identity.py` | Create an identity, assign mailbox + phone number |
+| `register_agent_identity.py` | Create an identity with a linked mailbox and phone number |
 | `agent_send_email.py` | Send an email and a threaded reply |
 | `read_agent_messages.py` | List messages and threads |
 | `create_agent_mailbox.py` | Create, update, search, and delete a mailbox |

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -154,7 +154,7 @@ identity.update(description=None)  # clear
 # Release the phone number (vendor + local).
 identity.unlink_phone_number()
 
-# Delete (cascades to mailbox + tunnel; revokes scoped API keys).
+# Delete (cascades to mailbox + tunnel + phone-number release; revokes scoped API keys).
 identity.delete()
 ```
 

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -304,7 +304,7 @@ class AgentIdentity:
         return self._phone_number  # type: ignore[return-value]
 
     def unlink_phone_number(self) -> None:
-        """Unlink this identity's phone number (does not release the number)."""
+        """Release this identity's phone number (vendor + local)."""
         self._require_phone()
         self._inkbox._ids_resource.unlink_phone_number(self.agent_handle)
         self._phone_number = None

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -286,10 +286,10 @@ class AgentIdentity:
         self._data = data
         return self._phone_number  # type: ignore[return-value]
 
-    def unlink_phone_number(self) -> None:
+    def release_phone_number(self) -> None:
         """Release this identity's phone number (vendor + local)."""
         self._require_phone()
-        self._inkbox._ids_resource.unlink_phone_number(self.agent_handle)
+        self._inkbox._ids_resource.release_phone_number(self.agent_handle)
         self._phone_number = None
 
     ## Mail helpers

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -286,23 +286,6 @@ class AgentIdentity:
         self._data = data
         return self._phone_number  # type: ignore[return-value]
 
-    def assign_phone_number(self, phone_number_id: str) -> IdentityPhoneNumber:
-        """Link an existing phone number to this identity.
-
-        Args:
-            phone_number_id: UUID of the phone number to link. Obtain via
-                ``inkbox.phone_numbers.list()`` or ``inkbox.phone_numbers.get()``.
-
-        Returns:
-            The linked phone number.
-        """
-        data = self._inkbox._ids_resource.assign_phone_number(
-            self.agent_handle, phone_number_id=phone_number_id
-        )
-        self._phone_number = data.phone_number
-        self._data = data
-        return self._phone_number  # type: ignore[return-value]
-
     def unlink_phone_number(self) -> None:
         """Release this identity's phone number (vendor + local)."""
         self._require_phone()
@@ -776,8 +759,7 @@ class AgentIdentity:
 
         Cascades: flips the linked mailbox to ``deleted``, force-finalizes
         the linked tunnel to ``deleted``, revokes any identity-scoped
-        API keys, and unassigns (but does not delete) any linked phone
-        number.
+        API keys, and releases any linked phone number (vendor + local).
         """
         self._inkbox._ids_resource.delete(self.agent_handle)
 
@@ -794,7 +776,7 @@ class AgentIdentity:
         if not self._phone_number:
             raise InkboxError(
                 f"Identity '{self.agent_handle}' has no phone number assigned. "
-                "Call identity.provision_phone_number() or identity.assign_phone_number() first."
+                "Call identity.provision_phone_number() first, or pass phone_number to create_identity()."
             )
 
     def _require_vault_unlocked(self) -> None:

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -138,23 +138,9 @@ class IdentitiesResource:
 
         Cascades: flips the linked mailbox to ``deleted``, force-finalizes
         the linked tunnel to ``deleted``, revokes any identity-scoped
-        API keys, and unassigns (but does not delete) any linked phone
-        number.
+        API keys, and releases any linked phone number (vendor + local).
         """
         self._http.delete(f"/{agent_handle}")
-
-    def assign_phone_number(
-        self,
-        agent_handle: str,
-        *,
-        phone_number_id: UUID | str,
-    ) -> _AgentIdentityData:
-        """Assign a phone number to an identity."""
-        data = self._http.post(
-            f"/{agent_handle}/phone_number",
-            json={"phone_number_id": str(phone_number_id)},
-        )
-        return _AgentIdentityData._from_dict(data)
 
     def unlink_phone_number(self, agent_handle: str) -> None:
         """Release the identity's phone number (vendor + local).

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -142,7 +142,7 @@ class IdentitiesResource:
         """
         self._http.delete(f"/{agent_handle}")
 
-    def unlink_phone_number(self, agent_handle: str) -> None:
+    def release_phone_number(self, agent_handle: str) -> None:
         """Release the identity's phone number (vendor + local).
 
         Released at the carrier; the number is not available for

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -159,7 +159,7 @@ class IdentitiesResource:
     def unlink_phone_number(self, agent_handle: str) -> None:
         """Release the identity's phone number (vendor + local).
 
-        The number is released at the carrier and marked released
-        server-side; it is not available for reassignment afterwards.
+        Released at the carrier; the number is not available for
+        reassignment afterwards.
         """
         self._http.delete(f"/{agent_handle}/phone_number")

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -157,6 +157,9 @@ class IdentitiesResource:
         return _AgentIdentityData._from_dict(data)
 
     def unlink_phone_number(self, agent_handle: str) -> None:
-        """Unlink the phone number from an identity (does not delete
-        the number)."""
+        """Release the identity's phone number (vendor + local).
+
+        The number is released at the carrier and marked released
+        server-side; it is not available for reassignment afterwards.
+        """
         self._http.delete(f"/{agent_handle}/phone_number")

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -69,8 +69,9 @@ class PhoneNumber:
     """A phone number owned by your organisation.
 
     ``agent_identity_id`` is the UUID of the owning agent identity, or
-    ``None`` if the phone number is standalone (not tied to any agent).
-    Always populated on every phone-number response.
+    ``None`` only for the pool / released states. Active org-owned
+    numbers are always bound to an identity. Always populated on
+    every phone-number response.
 
     SMS-readiness fields (``sms_status``, ``sms_error_code``,
     ``sms_error_detail``, ``sms_ready_at``) reflect 10DLC / TFV

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_identities.py
+++ b/sdk/python/tests/test_identities.py
@@ -165,20 +165,6 @@ class TestIdentitiesDelete:
         http.delete.assert_called_once_with(f"/{HANDLE}")
 
 
-class TestIdentitiesAssignPhoneNumber:
-    def test_assigns_phone_number(self):
-        res, http = _resource()
-        phone_id = "bbbb2222-0000-0000-0000-000000000001"
-        http.post.return_value = IDENTITY_DETAIL_DICT
-
-        detail = res.assign_phone_number(HANDLE, phone_number_id=phone_id)
-
-        http.post.assert_called_once_with(
-            f"/{HANDLE}/phone_number", json={"phone_number_id": phone_id}
-        )
-        assert isinstance(detail, _AgentIdentityData)
-
-
 class TestIdentitiesUnlinkPhoneNumber:
     def test_unlinks_phone_number(self):
         res, http = _resource()

--- a/sdk/python/tests/test_identities.py
+++ b/sdk/python/tests/test_identities.py
@@ -165,10 +165,10 @@ class TestIdentitiesDelete:
         http.delete.assert_called_once_with(f"/{HANDLE}")
 
 
-class TestIdentitiesUnlinkPhoneNumber:
-    def test_unlinks_phone_number(self):
+class TestIdentitiesReleasePhoneNumber:
+    def test_releases_phone_number(self):
         res, http = _resource()
 
-        res.unlink_phone_number(HANDLE)
+        res.release_phone_number(HANDLE)
 
         http.delete.assert_called_once_with(f"/{HANDLE}/phone_number")

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.4.3
+
+### Breaking
+
+- **`identity.unlinkPhoneNumber()` / `IdentitiesResource.unlinkPhoneNumber()` were renamed to `releasePhoneNumber()`** and their behavior changed accordingly. The method now releases the number at the carrier and removes it locally; previously it only cleared the FK on the row and left the carrier-side number live. There is no "unlink without release" path anymore — once a number is released, it cannot be reattached.
+- **`identity.assignPhoneNumber()` (and the underlying `IdentitiesResource.assignPhoneNumber()`) were removed.** The server no longer supports cross-identity reassignment; phone numbers are bound to the identity they were provisioned on. To attach a number to an identity, either pass the nested `phoneNumber` option to `inkbox.createIdentity(...)`, or call `inkbox.phoneNumbers.provision({ agentHandle, ... })` for an existing identity.
+- **`identity.delete()` cascade now releases the linked phone number** (vendor + local), instead of clearing the FK and leaving the carrier-side number live.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -157,9 +157,9 @@ const allIdentities = await inkbox.listIdentities();
 await identity.update({ status: "paused" });
 await identity.update({ newHandle: "sales-bot-v2" });
 
-// Release the phone number (carrier release + soft-delete). Mailbox and
+// Release the phone number (carrier release + local delete). Mailbox and
 // tunnel are 1:1 with the identity and can only be removed by deleting it.
-await identity.unlinkPhoneNumber();
+await identity.releasePhoneNumber();
 
 // Delete (cascades to mailbox + tunnel + phone-number release; revokes scoped API keys).
 await identity.delete();
@@ -652,7 +652,7 @@ await inkbox.domains.setDefault("inkboxmail.com");  // -> null
 
 ## Org-level Phone Numbers
 
-Manage phone numbers directly without going through an identity. Access via `inkbox.phoneNumbers`.
+Read, search, and release phone numbers org-wide via `inkbox.phoneNumbers`. Provisioning still goes through an identity — pass `agentHandle` so the new number is bound to it from the start.
 
 ```ts
 // List all phone numbers in the organisation
@@ -662,8 +662,8 @@ const numbers = await inkbox.phoneNumbers.list();
 const number = await inkbox.phoneNumbers.get("phone-number-uuid");
 
 // Provision a new number
-const num   = await inkbox.phoneNumbers.provision({ type: "toll_free" });
-const local = await inkbox.phoneNumbers.provision({ type: "local", state: "NY" });
+const num   = await inkbox.phoneNumbers.provision({ agentHandle: "sales-bot", type: "toll_free" });
+const local = await inkbox.phoneNumbers.provision({ agentHandle: "sales-bot", type: "local", state: "NY" });
 
 // Update incoming call behaviour
 await inkbox.phoneNumbers.update(num.id, {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -146,10 +146,6 @@ await inkbox.createIdentity("sales-bot-2", { sendingDomain: "mail.acme.com" });
 // Provision a passthrough tunnel (tls_mode is fixed at create time)
 await inkbox.createIdentity("sales-bot-pt", { tunnel: { tlsMode: "passthrough" } });
 
-// Link an existing phone number to an identity (mailbox + tunnel are
-// 1:1 with their identity and cannot be relinked).
-await identity.assignPhoneNumber("phone-number-uuid-here");
-
 // Get an existing identity (returned with current channel state)
 const identity2 = await inkbox.getIdentity("sales-bot");
 await identity2.refresh();  // re-fetch channels from API

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -157,11 +157,11 @@ const allIdentities = await inkbox.listIdentities();
 await identity.update({ status: "paused" });
 await identity.update({ newHandle: "sales-bot-v2" });
 
-// Unlink phone number (without releasing it). Mailbox is 1:1 with the
-// identity and cannot be unlinked — delete the identity instead.
+// Release the phone number (carrier release + soft-delete). Mailbox and
+// tunnel are 1:1 with the identity and can only be removed by deleting it.
 await identity.unlinkPhoneNumber();
 
-// Delete
+// Delete (cascades to mailbox + tunnel + phone-number release; revokes scoped API keys).
 await identity.delete();
 ```
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -225,22 +225,6 @@ export class AgentIdentity {
   }
 
   /**
-   * Link an existing phone number to this identity.
-   *
-   * @param phoneNumberId - UUID of the phone number to link. Obtain via
-   *   `inkbox.phoneNumbers.list()` or `inkbox.phoneNumbers.get()`.
-   * @returns The linked {@link IdentityPhoneNumber}.
-   */
-  async assignPhoneNumber(phoneNumberId: string): Promise<IdentityPhoneNumber> {
-    const data   = await this._inkbox._idsResource.assignPhoneNumber(this.agentHandle, {
-      phoneNumberId,
-    });
-    this._phoneNumber = data.phoneNumber;
-    this._data        = data;
-    return this._phoneNumber!;
-  }
-
-  /**
    * Release this identity's phone number (vendor + local).
    */
   async unlinkPhoneNumber(): Promise<void> {
@@ -654,7 +638,7 @@ export class AgentIdentity {
   private _requirePhone(): void {
     if (!this._phoneNumber) {
       throw new InkboxError(
-        `Identity '${this.agentHandle}' has no phone number assigned. Call identity.provisionPhoneNumber() or identity.assignPhoneNumber() first.`,
+        `Identity '${this.agentHandle}' has no phone number assigned. Call identity.provisionPhoneNumber() first, or pass phoneNumber to createIdentity().`,
       );
     }
   }

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -227,9 +227,9 @@ export class AgentIdentity {
   /**
    * Release this identity's phone number (vendor + local).
    */
-  async unlinkPhoneNumber(): Promise<void> {
+  async releasePhoneNumber(): Promise<void> {
     this._requirePhone();
-    await this._inkbox._idsResource.unlinkPhoneNumber(this.agentHandle);
+    await this._inkbox._idsResource.releasePhoneNumber(this.agentHandle);
     this._phoneNumber = null;
   }
 

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -241,7 +241,7 @@ export class AgentIdentity {
   }
 
   /**
-   * Unlink this identity's phone number (does not release the number).
+   * Release this identity's phone number (vendor + local).
    */
   async unlinkPhoneNumber(): Promise<void> {
     this._requirePhone();

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -609,7 +609,7 @@ export class AgentIdentity {
    *
    * Cascades: flips the linked mailbox to `deleted`, force-finalizes the
    * linked tunnel to `deleted`, revokes any identity-scoped API keys, and
-   * unassigns (but does not delete) any linked phone number.
+   * releases any linked phone number (vendor + local).
    */
   async delete(): Promise<void> {
     await this._inkbox._idsResource.delete(this.agentHandle);

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -155,10 +155,10 @@ export class IdentitiesResource {
   }
 
   /**
-   * Release the identity's phone number (carrier release + soft-delete).
+   * Release the identity's phone number (vendor + local).
    *
-   * The number is released at the carrier and marked released
-   * server-side; it is not available for reassignment afterwards.
+   * Released at the carrier; the number is not available for
+   * reassignment afterwards.
    *
    * @param agentHandle - Handle of the identity.
    */

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -2,9 +2,9 @@
  * inkbox-identities/resources/identities.ts
  *
  * Identity create / list / get / update / delete, plus phone-number
- * assign / unlink. Mailbox and tunnel are provisioned atomically by
- * `create()` and removed by `delete()` (cascade); there is no
- * standalone mailbox or tunnel create / link surface.
+ * release. Mailbox and tunnel are provisioned atomically by `create()`
+ * and removed by `delete()` (cascade); there is no standalone mailbox
+ * or tunnel create / link surface.
  */
 
 import { HttpTransport, InkboxAPIError } from "../../_http.js";
@@ -129,29 +129,12 @@ export class IdentitiesResource {
    *
    * Cascades: flips the linked mailbox to `deleted`, force-finalizes the
    * linked tunnel to `deleted`, revokes any identity-scoped API keys, and
-   * unassigns (but does not delete) any linked phone number.
+   * releases any linked phone number (vendor + local).
    *
    * @param agentHandle - Handle of the identity to delete.
    */
   async delete(agentHandle: string): Promise<void> {
     await this.http.delete(`/${agentHandle}`);
-  }
-
-  /**
-   * Assign a phone number to an identity.
-   *
-   * @param agentHandle - Handle of the identity.
-   * @param options.phoneNumberId - UUID of the phone number to assign.
-   */
-  async assignPhoneNumber(
-    agentHandle: string,
-    options: { phoneNumberId: string },
-  ): Promise<_AgentIdentityData> {
-    const data = await this.http.post<RawAgentIdentityData>(
-      `/${agentHandle}/phone_number`,
-      { phone_number_id: options.phoneNumberId },
-    );
-    return parseAgentIdentityData(data);
   }
 
   /**

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -155,7 +155,10 @@ export class IdentitiesResource {
   }
 
   /**
-   * Unlink the phone number from an identity (does not delete the number).
+   * Release the identity's phone number (carrier release + soft-delete).
+   *
+   * The number is released at the carrier and marked released
+   * server-side; it is not available for reassignment afterwards.
    *
    * @param agentHandle - Handle of the identity.
    */

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -145,7 +145,7 @@ export class IdentitiesResource {
    *
    * @param agentHandle - Handle of the identity.
    */
-  async unlinkPhoneNumber(agentHandle: string): Promise<void> {
+  async releasePhoneNumber(agentHandle: string): Promise<void> {
     await this.http.delete(`/${agentHandle}/phone_number`);
   }
 }

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -106,8 +106,8 @@ export interface IdentityPhoneNumber {
    */
   state: string | null;
   /**
-   * UUID of the owning agent identity, or `null` if standalone. On the
-   * embedded variant this always equals the owning identity's ID.
+   * UUID of the owning agent identity. On the embedded variant this
+   * always equals the owning identity's ID.
    */
   agentIdentityId: string | null;
   createdAt: Date;

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -80,9 +80,9 @@ export interface PhoneNumber {
    */
   state: string | null;
   /**
-   * UUID of the owning agent identity, or `null` if the phone number is
-   * standalone (not tied to any agent). Always present on every
-   * phone-number response shape.
+   * UUID of the owning agent identity. `null` only for pool / released
+   * states — active org-owned numbers are always bound to an identity.
+   * Always present on every phone-number response shape.
    */
   agentIdentityId: string | null;
   createdAt: Date;

--- a/sdk/typescript/tests/agent_identity.test.ts
+++ b/sdk/typescript/tests/agent_identity.test.ts
@@ -74,7 +74,6 @@ function mockInkbox() {
       delete: vi.fn(),
       assignMailbox: vi.fn(),
       unlinkMailbox: vi.fn(),
-      assignPhoneNumber: vi.fn(),
       unlinkPhoneNumber: vi.fn(),
     },
   } as unknown as Inkbox;
@@ -115,17 +114,6 @@ describe("AgentIdentity channel management", () => {
       type: "toll_free",
     });
     expect(phone).toEqual(PARSED_PHONE);
-  });
-
-  it("assignPhoneNumber links existing number", async () => {
-    const ink = mockInkbox();
-    vi.mocked(ink._idsResource.assignPhoneNumber).mockResolvedValue(makeData());
-    const identity = new AgentIdentity(makeData({ phoneNumber: null }), ink);
-
-    const result = await identity.assignPhoneNumber("phone-id");
-
-    expect(ink._idsResource.assignPhoneNumber).toHaveBeenCalledWith("sales-agent", { phoneNumberId: "phone-id" });
-    expect(result).toEqual(PARSED_PHONE);
   });
 
   it("unlinkPhoneNumber removes phone", async () => {

--- a/sdk/typescript/tests/agent_identity.test.ts
+++ b/sdk/typescript/tests/agent_identity.test.ts
@@ -74,7 +74,7 @@ function mockInkbox() {
       delete: vi.fn(),
       assignMailbox: vi.fn(),
       unlinkMailbox: vi.fn(),
-      unlinkPhoneNumber: vi.fn(),
+      releasePhoneNumber: vi.fn(),
     },
   } as unknown as Inkbox;
 }
@@ -116,20 +116,20 @@ describe("AgentIdentity channel management", () => {
     expect(phone).toEqual(PARSED_PHONE);
   });
 
-  it("unlinkPhoneNumber removes phone", async () => {
+  it("releasePhoneNumber releases the linked number", async () => {
     const ink = mockInkbox();
-    vi.mocked(ink._idsResource.unlinkPhoneNumber).mockResolvedValue(undefined);
+    vi.mocked(ink._idsResource.releasePhoneNumber).mockResolvedValue(undefined);
     const identity = new AgentIdentity(makeData(), ink);
 
-    await identity.unlinkPhoneNumber();
+    await identity.releasePhoneNumber();
 
-    expect(ink._idsResource.unlinkPhoneNumber).toHaveBeenCalledWith("sales-agent");
+    expect(ink._idsResource.releasePhoneNumber).toHaveBeenCalledWith("sales-agent");
     expect(identity.phoneNumber).toBeNull();
   });
 
-  it("unlinkPhoneNumber throws when no phone", async () => {
+  it("releasePhoneNumber throws when no phone", async () => {
     const identity = new AgentIdentity(makeData({ phoneNumber: null }), mockInkbox());
-    await expect(identity.unlinkPhoneNumber()).rejects.toThrow(InkboxError);
+    await expect(identity.releasePhoneNumber()).rejects.toThrow(InkboxError);
   });
 });
 

--- a/sdk/typescript/tests/identities/identities.test.ts
+++ b/sdk/typescript/tests/identities/identities.test.ts
@@ -167,22 +167,6 @@ describe("IdentitiesResource.delete", () => {
 });
 
 
-describe("IdentitiesResource.assignPhoneNumber", () => {
-  it("posts phone_number_id and returns detail", async () => {
-    const http = mockHttp();
-    vi.mocked(http.post).mockResolvedValue(RAW_IDENTITY_DETAIL);
-    const res = new IdentitiesResource(http);
-    const phoneNumberId = "bbbb2222-0000-0000-0000-000000000001";
-
-    const detail = await res.assignPhoneNumber(HANDLE, { phoneNumberId });
-
-    expect(http.post).toHaveBeenCalledWith(`/${HANDLE}/phone_number`, {
-      phone_number_id: phoneNumberId,
-    });
-    expect(detail.phoneNumber!.number).toBe("+18335794607");
-  });
-});
-
 describe("IdentitiesResource.unlinkPhoneNumber", () => {
   it("deletes phone number link", async () => {
     const http = mockHttp();

--- a/sdk/typescript/tests/identities/identities.test.ts
+++ b/sdk/typescript/tests/identities/identities.test.ts
@@ -167,13 +167,13 @@ describe("IdentitiesResource.delete", () => {
 });
 
 
-describe("IdentitiesResource.unlinkPhoneNumber", () => {
-  it("deletes phone number link", async () => {
+describe("IdentitiesResource.releasePhoneNumber", () => {
+  it("releases the identity's phone number", async () => {
     const http = mockHttp();
     vi.mocked(http.delete).mockResolvedValue(undefined);
     const res = new IdentitiesResource(http);
 
-    await res.unlinkPhoneNumber(HANDLE);
+    await res.releasePhoneNumber(HANDLE);
 
     expect(http.delete).toHaveBeenCalledWith(`/${HANDLE}/phone_number`);
   });

--- a/sdk/typescript/tests/phone/types.test.ts
+++ b/sdk/typescript/tests/phone/types.test.ts
@@ -30,7 +30,7 @@ describe("parsePhoneNumber", () => {
     expect(n.updatedAt).toBeInstanceOf(Date);
   });
 
-  it("null agentIdentityId for standalone number", () => {
+  it("null agentIdentityId on released-state response", () => {
     const n = parsePhoneNumber({ ...RAW_PHONE_NUMBER, agent_identity_id: null });
     expect(n.agentIdentityId).toBeNull();
   });

--- a/skills/inkbox-openclaw/README.md
+++ b/skills/inkbox-openclaw/README.md
@@ -6,7 +6,7 @@ An [OpenClaw](https://openclaw.ai) skill for email, phone, and vault via [Inkbox
 
 Once installed, your OpenClaw agent can:
 
-- **Manage identities** — create, list, rename, pause, and delete agent identities; assign and unlink channels
+- **Manage identities** — create, list, rename, pause, and delete agent identities; provision and release phone numbers
 - **Send emails** — compose and send from an Inkbox agent mailbox, with optional CC/BCC
 - **Reply to emails** — thread replies using a message ID
 - **Read inbox** — list recent messages or unread messages only

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -126,10 +126,7 @@ console.log(identity.tunnel?.publicHost);      // e.g. "sales-agent.inkboxwire.c
 const phone = await identity.provisionPhoneNumber({ type: "toll_free" });
 console.log(phone.number);                     // e.g. "+18005551234"
 
-// Existing phone number? Link it instead:
-await identity.assignPhoneNumber("phone-number-uuid");
-
-// Unlink the phone number without releasing it
+// Release the phone number (vendor + local)
 await identity.unlinkPhoneNumber();
 ```
 

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -127,7 +127,7 @@ const phone = await identity.provisionPhoneNumber({ type: "toll_free" });
 console.log(phone.number);                     // e.g. "+18005551234"
 
 // Release the phone number (vendor + local)
-await identity.unlinkPhoneNumber();
+await identity.releasePhoneNumber();
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.createIdentity()` to provision both; use `identity.delete()` to remove both (cascade).

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -105,7 +105,7 @@ const identities = await inkbox.listIdentities();   // AgentIdentitySummary[]
 await identity.update({ newHandle: "new-name" });   // rename
 await identity.update({ status: "paused" });         // or "active"
 await identity.refresh();                            // re-fetch from API, updates cached channels
-await identity.delete();                             // unlinks channels
+await identity.delete();                             // cascades: mailbox + tunnel + phone-number release
 ```
 
 If `INKBOX_AGENT_HANDLE` is not configured, ask the user for the handle to use.

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -87,9 +87,6 @@ print(identity.tunnel.public_host)       # e.g. "sales-agent.inkboxwire.com"
 phone = identity.provision_phone_number(type="toll_free")       # or type="local", state="NY"
 print(phone.number)                      # e.g. "+18005551234"
 
-# Existing phone number? Link it instead:
-identity.assign_phone_number("phone-number-uuid")
-
 # Release the phone number (vendor + local)
 identity.unlink_phone_number()
 ```

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -88,7 +88,7 @@ phone = identity.provision_phone_number(type="toll_free")       # or type="local
 print(phone.number)                      # e.g. "+18005551234"
 
 # Release the phone number (vendor + local)
-identity.unlink_phone_number()
+identity.release_phone_number()
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.create_identity()` to provision both; use `identity.delete()` to remove both (cascade).

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -90,7 +90,7 @@ print(phone.number)                      # e.g. "+18005551234"
 # Existing phone number? Link it instead:
 identity.assign_phone_number("phone-number-uuid")
 
-# Unlink the phone number without releasing it
+# Release the phone number (vendor + local)
 identity.unlink_phone_number()
 ```
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -73,7 +73,7 @@ identities = inkbox.list_identities()  # → list[AgentIdentitySummary]
 identity.update(new_handle="new-name")   # rename
 identity.update(status="paused")         # or "active"
 identity.refresh()                       # re-fetch from API, updates cached channels
-identity.delete()                        # unlinks channels
+identity.delete()                        # cascades: mailbox + tunnel + phone-number release
 ```
 
 ## Channel Management

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -86,9 +86,6 @@ console.log(identity.tunnel?.publicHost);      // e.g. "sales-agent.inkboxwire.c
 const phone = await identity.provisionPhoneNumber({ type: "toll_free" });
 console.log(phone.number);                     // e.g. "+18005551234"
 
-// Existing phone number? Link it instead:
-await identity.assignPhoneNumber("phone-number-uuid");
-
 // Release the phone number (vendor + local)
 await identity.unlinkPhoneNumber();
 ```

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -87,7 +87,7 @@ const phone = await identity.provisionPhoneNumber({ type: "toll_free" });
 console.log(phone.number);                     // e.g. "+18005551234"
 
 // Release the phone number (vendor + local)
-await identity.unlinkPhoneNumber();
+await identity.releasePhoneNumber();
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.createIdentity()` to provision both; use `identity.delete()` to remove both (cascade).

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -89,7 +89,7 @@ console.log(phone.number);                     // e.g. "+18005551234"
 // Existing phone number? Link it instead:
 await identity.assignPhoneNumber("phone-number-uuid");
 
-// Unlink the phone number without releasing it
+// Release the phone number (vendor + local)
 await identity.unlinkPhoneNumber();
 ```
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -72,7 +72,7 @@ const identities = await inkbox.listIdentities();   // AgentIdentitySummary[]
 await identity.update({ newHandle: "new-name" });   // rename
 await identity.update({ status: "paused" });         // or "active"
 await identity.refresh();                            // re-fetch from API, updates cached channels
-await identity.delete();                             // unlinks channels
+await identity.delete();                             // cascades: mailbox + tunnel + phone-number release
 ```
 
 ## Channel Management


### PR DESCRIPTION
## Related PRs (must land together)
- **servers** → [inkbox-ai/servers#177](https://github.com/inkbox-ai/servers/pull/177)
- **inkbox SDK** → this PR (#59)
- **console** → [inkbox-ai/console#130](https://github.com/inkbox-ai/console/pull/130)
- **website docs** → [inkbox-ai/website#92](https://github.com/inkbox-ai/website/pull/92)

---

Server-side, two behaviors changed in [servers#177](https://github.com/inkbox-ai/servers/pull/177):

1. `DELETE /identities/{handle}/phone_number` was redefined to **release** the number (carrier delete + soft-delete locally) instead of unlinking. Org-owned phone numbers can no longer sit without an identity.
2. `POST /identities/{handle}/phone_number` was **removed entirely**. Cross-identity reassignment is no longer a supported flow; the only ways to put a number on an identity are now identity-create with a nested phone payload, or pool claim.

This PR brings the SDKs + skills + docs in line.

## Diff scope

### Behavior-breaking removals
- `sdk/python/inkbox/identities/resources/identities.py` — `assign_phone_number()` deleted
- `sdk/python/inkbox/agent_identity.py` — `identity.assign_phone_number()` deleted
- `sdk/typescript/src/identities/resources/identities.ts` — `assignPhoneNumber()` deleted
- `sdk/typescript/src/agent_identity.ts` — `identity.assignPhoneNumber()` deleted
- Tests: SDK-level assign tests dropped in both languages

### Doc updates
- README examples (Python + TS) lose the "link an existing number" snippet
- `unlink_phone_number()` / `unlinkPhoneNumber()` docstrings now describe release semantics
- `delete()` docstring updated — cascade now *releases* the linked number (vendor + local), not just unassigns it
- SKILL files (`inkbox-python`, `inkbox-ts`, `inkbox-openclaw`) updated
- "no phone" guard message in both SDKs no longer suggests the removed `assign_phone_number` method

## Migration notes for SDK consumers

Customers using `identity.assign_phone_number(...)` / `identity.assignPhoneNumber(...)` need to switch to provisioning the number at identity-create time:

```python
identity = inkbox.create_identity("sales-agent", phone_number={"type": "local"})
```

There is no "move number from identity A to identity B" path anymore. To move workloads between identities, provision a new number on the new identity and release the old one.

## Rollout

Land alongside `servers#177` so the SDK shape and the server behavior stay in sync.