### PR TITLE
`0.4.4`: Adds `identity visibility / access` support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
+## 0.4.4
+
+### Added
+
+- **Identity visibility controls** — manage which agent identities can see
+  a given identity in API responses.
+  - SDK: new `IdentityAccess` type plus `listAccess` / `grantAccess` /
+    `revokeAccess` (TypeScript) and `list_access` / `grant_access` /
+    `revoke_access` (Python) on both `IdentitiesResource` and
+    `AgentIdentity`. `grantAccess(viewerIdentityId)` adds a per-viewer
+    grant; `grantAccess(null)` resets the target to the org-wide wildcard
+    (every active identity sees it). `revokeAccess(viewerIdentityId)`
+    drops one viewer, keyed by the viewer identity's UUID.
+  - CLI: new `inkbox identity access` group — `list`, `grant`,
+    `grant-everyone`, and `revoke`. `grant` and `revoke` take a viewer
+    **handle** and resolve it to a UUID automatically.
+  - Granting a viewer against an already-wildcard target returns a 409
+    (`RedundantContactAccessGrantError`); revoking a non-existent grant
+    returns a 404 (`InkboxAPIError`).
+
 ## 0.4.2
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.4
+
+### Added
+
+- **`inkbox identity access` command group** for managing agent visibility:
+  - `inkbox identity access list <target-handle>` — list who can see an identity.
+  - `inkbox identity access grant <target-handle> <viewer-handle>` — grant a viewer identity visibility on the target.
+  - `inkbox identity access grant-everyone <target-handle>` — make the target visible to every active identity in the org (wildcard).
+  - `inkbox identity access revoke <target-handle> <viewer-handle>` — revoke a viewer identity's visibility.
+
+  Viewer identities are passed as handles and resolved to UUIDs automatically. This `identity access` group is unrelated to `identity revoke-access`, which manages vault-secret access.
+
 ## 0.4.3
 
 ### Breaking

--- a/cli/README.md
+++ b/cli/README.md
@@ -108,7 +108,14 @@ inkbox identity set-totp <handle> <secret-id>       # Add TOTP to login (vault k
   --uri <otpauth-uri>                        #   otpauth:// URI (required)
 inkbox identity remove-totp <handle> <secret-id>    # Remove TOTP (vault key)
 inkbox identity totp-code <handle> <secret-id>      # Generate TOTP code (vault key)
+
+inkbox identity access list <target-handle>                   # List who can see an identity
+inkbox identity access grant <target-handle> <viewer-handle>  # Grant a viewer identity visibility
+inkbox identity access grant-everyone <target-handle>         # Make visible to every active identity (wildcard)
+inkbox identity access revoke <target-handle> <viewer-handle> # Revoke a viewer identity's visibility
 ```
+
+`identity access` controls which other agent identities can see an identity in API responses (humans and admins always see it). Viewer identities are passed as handles and resolved to UUIDs automatically. This is unrelated to `identity revoke-access`, which manages vault-secret access.
 
 ### email
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.3",
+    "@inkbox/sdk": "^0.4.4",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -5,6 +5,93 @@ import { withErrorHandler } from "../errors.js";
 import type { SecretPayload } from "@inkbox/sdk";
 import { parseTotpUri } from "@inkbox/sdk";
 
+function registerIdentityAccessCommands(parent: Command): void {
+  const access = parent
+    .command("access")
+    .description("Manage who can see an identity (agent visibility)");
+
+  access
+    .command("list <target-handle>")
+    .description("List who can see this identity")
+    .action(
+      withErrorHandler(async function (this: Command, targetHandle: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const target = await inkbox.getIdentity(targetHandle);
+        const rows = await target.listAccess();
+        output(rows, {
+          json: !!opts.json,
+          columns: ["id", "targetIdentityId", "viewerIdentityId", "createdAt"],
+        });
+      }),
+    );
+
+  access
+    .command("grant <target-handle> <viewer-handle>")
+    .description("Grant a viewer identity visibility on the target identity")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        targetHandle: string,
+        viewerHandle: string,
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const target = await inkbox.getIdentity(targetHandle);
+        const viewer = await inkbox.getIdentity(viewerHandle);
+        const grant = await target.grantAccess(viewer.id);
+        if (opts.json) {
+          output(grant as unknown as Record<string, unknown>, { json: true });
+        } else {
+          console.log(
+            `Granted '${viewerHandle}' visibility on '${targetHandle}'.`,
+          );
+        }
+      }),
+    );
+
+  access
+    .command("grant-everyone <target-handle>")
+    .description(
+      "Make the target visible to every active identity in the org (wildcard)",
+    )
+    .action(
+      withErrorHandler(async function (this: Command, targetHandle: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const target = await inkbox.getIdentity(targetHandle);
+        const grant = await target.grantAccess(null);
+        if (opts.json) {
+          output(grant as unknown as Record<string, unknown>, { json: true });
+        } else {
+          console.log(
+            `'${targetHandle}' is now visible to every active identity in the org.`,
+          );
+        }
+      }),
+    );
+
+  access
+    .command("revoke <target-handle> <viewer-handle>")
+    .description("Revoke a viewer identity's visibility on the target identity")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        targetHandle: string,
+        viewerHandle: string,
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const target = await inkbox.getIdentity(targetHandle);
+        const viewer = await inkbox.getIdentity(viewerHandle);
+        await target.revokeAccess(viewer.id);
+        console.log(
+          `Revoked '${viewerHandle}' visibility on '${targetHandle}'.`,
+        );
+      }),
+    );
+}
+
 export function registerIdentityCommands(program: Command): void {
   const identity = program
     .command("identity")
@@ -597,4 +684,6 @@ export function registerIdentityCommands(program: Command): void {
         console.log(`Released phone number from identity '${handle}'.`);
       }),
     );
+
+  registerIdentityAccessCommands(identity);
 }

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -19,8 +19,17 @@ function registerIdentityAccessCommands(parent: Command): void {
         const inkbox = createClient(opts);
         const target = await inkbox.getIdentity(targetHandle);
         const rows = await target.listAccess();
-        output(rows, {
-          json: !!opts.json,
+        if (opts.json) {
+          output(rows, { json: true });
+          return;
+        }
+        // Render the wildcard sentinel (null viewer) as a readable label.
+        const display = rows.map((r) => ({
+          ...r,
+          viewerIdentityId: r.viewerIdentityId ?? "(everyone)",
+        }));
+        output(display, {
+          json: false,
           columns: ["id", "targetIdentityId", "viewerIdentityId", "createdAt"],
         });
       }),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -22,7 +22,7 @@ import { registerDomainCommands } from "./commands/domain.js";
 const program = new Command()
   .name("inkbox")
   .description("CLI for the Inkbox API — email, phone, identities, and vault for AI agents")
-  .version("0.1.0")
+  .version("0.4.4")
   .option("--api-key <key>", "Inkbox API key (or set INKBOX_API_KEY)")
   .option("--vault-key <key>", "Vault key for decrypt operations (or set INKBOX_VAULT_KEY)")
   .option("--base-url <url>", "Override API base URL (or set INKBOX_BASE_URL)")

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.4
+
+### Added
+
+- **Identity visibility controls.** New `IdentityAccess` type and three methods on both `IdentitiesResource` and `AgentIdentity`:
+  - `list_access()` — list who can see an identity. Returns either a single wildcard row (`viewer_identity_id=None` — every active identity in the org sees it) or explicit per-viewer rows. An empty list means no scoped agent can see the identity.
+  - `grant_access(viewer_identity_id)` — grant a viewer identity visibility on the target. Pass `None` to reset the target to the org-wide wildcard.
+  - `revoke_access(viewer_identity_id)` — revoke one viewer's visibility, keyed by the viewer identity's UUID.
+
+  Granting a viewer against an already-wildcard target raises `RedundantContactAccessGrantError` (409); revoking a non-existent grant raises `InkboxAPIError` (404).
+
 ## 0.4.3
 
 ### Breaking

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -158,6 +158,30 @@ identity.release_phone_number()
 identity.delete()
 ```
 
+### Identity visibility
+
+Control which other agent identities can see this identity in API responses.
+Humans and admins always see every identity regardless.
+
+```python
+identity = inkbox.get_identity("sales-bot")
+
+# List the current visibility rules. Either a single wildcard row
+# (viewer_identity_id is None — every active identity sees it) or
+# explicit per-viewer rows. An empty list means no agent can see it.
+rules = identity.list_access()
+
+# Grant one viewer identity visibility
+viewer = inkbox.get_identity("support-bot")
+identity.grant_access(viewer.id)
+
+# Make it visible to every active identity in the org (wildcard)
+identity.grant_access(None)
+
+# Revoke one viewer (keyed by the viewer identity's UUID)
+identity.revoke_access(viewer.id)
+```
+
 ---
 
 ## Mail

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -60,6 +60,7 @@ from inkbox.phone.types import (
 # Identity types
 from inkbox.identities.types import (
     AgentIdentitySummary,
+    IdentityAccess,
     IdentityMailboxCreateOptions,
     IdentityMailbox,
     IdentityPhoneNumberCreateOptions,
@@ -242,6 +243,7 @@ __all__ = [
     "TextMessageOrigin",
     # Identity types
     "AgentIdentitySummary",
+    "IdentityAccess",
     "IdentityMailboxCreateOptions",
     "IdentityMailbox",
     "IdentityPhoneNumberCreateOptions",

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -20,6 +20,7 @@ from inkbox.vault.types import DecryptedVaultSecret, SecretPayload, VaultSecret
 from inkbox.identities.types import (
     _UNSET,
     _AgentIdentityData,
+    IdentityAccess,
     IdentityMailbox,
     IdentityPhoneNumber,
 )
@@ -291,6 +292,40 @@ class AgentIdentity:
         self._require_phone()
         self._inkbox._ids_resource.release_phone_number(self.agent_handle)
         self._phone_number = None
+
+    ## Identity access / visibility
+
+    def list_access(self) -> list[IdentityAccess]:
+        """List who can see this identity.
+
+        See :meth:`IdentitiesResource.list_access`.
+        """
+        return self._inkbox._ids_resource.list_access(self.agent_handle)
+
+    def grant_access(
+        self, viewer_identity_id: UUID | str | None
+    ) -> IdentityAccess:
+        """Grant visibility on this identity.
+
+        Args:
+            viewer_identity_id: UUID of the viewer identity to grant, or
+                ``None`` to reset this identity to the org-wide wildcard
+                (every active identity in the org sees it).
+        """
+        return self._inkbox._ids_resource.grant_access(
+            self.agent_handle, viewer_identity_id
+        )
+
+    def revoke_access(self, viewer_identity_id: UUID | str) -> None:
+        """Revoke one viewer's visibility on this identity.
+
+        Args:
+            viewer_identity_id: UUID of the viewer identity to drop
+                (the viewer identity's UUID, not an access-row id).
+        """
+        self._inkbox._ids_resource.revoke_access(
+            self.agent_handle, viewer_identity_id
+        )
 
     ## Mail helpers
 

--- a/sdk/python/inkbox/identities/__init__.py
+++ b/sdk/python/inkbox/identities/__init__.py
@@ -5,6 +5,7 @@ inkbox.identities — identity types.
 from inkbox.identities.types import (
     AgentIdentitySummary,
     _AgentIdentityData,
+    IdentityAccess,
     IdentityMailbox,
     IdentityPhoneNumber,
 )
@@ -12,6 +13,7 @@ from inkbox.identities.types import (
 __all__ = [
     "AgentIdentitySummary",
     "_AgentIdentityData",
+    "IdentityAccess",
     "IdentityMailbox",
     "IdentityPhoneNumber",
 ]

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -15,6 +15,7 @@ from inkbox.identities.exceptions import map_identity_conflict_error
 from inkbox.identities.types import (
     _UNSET,
     AgentIdentitySummary,
+    IdentityAccess,
     IdentityMailboxCreateOptions,
     IdentityPhoneNumberCreateOptions,
     IdentityTunnelCreateOptions,
@@ -149,3 +150,61 @@ class IdentitiesResource:
         reassignment afterwards.
         """
         self._http.delete(f"/{agent_handle}/phone_number")
+
+    def list_access(self, agent_handle: str) -> list[IdentityAccess]:
+        """List who can see this identity (agent visibility).
+
+        Returns either a single wildcard row
+        (``viewer_identity_id=None`` — every active identity in the org
+        sees it) or explicit per-viewer rows. An empty list means no
+        scoped agent can see this identity (humans and admins always
+        see it).
+        """
+        data = self._http.get(f"/{agent_handle}/access")
+        return [IdentityAccess._from_dict(a) for a in data]
+
+    def grant_access(
+        self,
+        agent_handle: str,
+        viewer_identity_id: UUID | str | None,
+    ) -> IdentityAccess:
+        """Grant visibility on this identity.
+
+        Args:
+            agent_handle: Handle of the target identity.
+            viewer_identity_id: UUID of the viewer identity to grant, or
+                ``None`` to reset the target to the org-wide wildcard
+                (every active identity in the org sees it).
+
+        Raises:
+            RedundantContactAccessGrantError: 409 when granting a
+                per-viewer UUID against a target that is already a
+                wildcard.
+            InkboxAPIError: 409 if the viewer is already granted; 404
+                if the viewer identity does not exist; 422 if the
+                viewer is the target itself.
+        """
+        body = {
+            "viewer_identity_id": (
+                str(viewer_identity_id) if viewer_identity_id is not None else None
+            ),
+        }
+        data = self._http.post(f"/{agent_handle}/access", json=body)
+        return IdentityAccess._from_dict(data)
+
+    def revoke_access(
+        self,
+        agent_handle: str,
+        viewer_identity_id: UUID | str,
+    ) -> None:
+        """Revoke one viewer's visibility on this identity.
+
+        Args:
+            agent_handle: Handle of the target identity.
+            viewer_identity_id: UUID of the viewer identity to drop.
+                This is the viewer identity's UUID, not an access-row id.
+
+        Raises:
+            InkboxAPIError: 404 when there is nothing to drop.
+        """
+        self._http.delete(f"/{agent_handle}/access/{viewer_identity_id}")

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -159,6 +159,8 @@ class IdentitiesResource:
         sees it) or explicit per-viewer rows. An empty list means no
         scoped agent can see this identity (humans and admins always
         see it).
+
+        Requires an admin-scoped API key; agent-scoped keys get a 403.
         """
         data = self._http.get(f"/{agent_handle}/access")
         return [IdentityAccess._from_dict(a) for a in data]
@@ -180,15 +182,22 @@ class IdentitiesResource:
             RedundantContactAccessGrantError: 409 when granting a
                 per-viewer UUID against a target that is already a
                 wildcard.
-            InkboxAPIError: 409 if the viewer is already granted; 404
-                if the viewer identity does not exist; 422 if the
-                viewer is the target itself.
+            InkboxAPIError: 403 if the API key is not admin-scoped; 409
+                if the viewer is already granted; 404 if the viewer
+                identity does not exist; 422 if the viewer is the
+                target itself.
         """
         body = {
             "viewer_identity_id": (
                 str(viewer_identity_id) if viewer_identity_id is not None else None
             ),
         }
+        # Deliberately NOT wrapped in map_identity_conflict_error (unlike
+        # create / update): that mapper blind-converts every 409 to
+        # HandleUnavailableError, which is only right when the sole
+        # possible 409 is a handle collision. This route's 409s are not
+        # collisions, and the wrapper would also catch and downgrade the
+        # RedundantContactAccessGrantError the transport already raised.
         data = self._http.post(f"/{agent_handle}/access", json=body)
         return IdentityAccess._from_dict(data)
 
@@ -205,6 +214,7 @@ class IdentitiesResource:
                 This is the viewer identity's UUID, not an access-row id.
 
         Raises:
-            InkboxAPIError: 404 when there is nothing to drop.
+            InkboxAPIError: 403 if the API key is not admin-scoped;
+                404 when there is nothing to drop.
         """
         self._http.delete(f"/{agent_handle}/access/{viewer_identity_id}")

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -295,3 +295,29 @@ class _AgentIdentityData(AgentIdentitySummary):
             phone_number=IdentityPhoneNumber._from_dict(phone_data) if phone_data else None,
             tunnel=Tunnel._from_dict(tunnel_data) if tunnel_data else None,
         )
+
+
+@dataclass
+class IdentityAccess:
+    """
+    A single identity-visibility grant on a target identity.
+
+    ``viewer_identity_id=None`` is the wildcard sentinel — every active
+    identity in the org can see the target. Otherwise it is a per-viewer
+    grant naming exactly one viewer identity.
+    """
+
+    id: UUID
+    target_identity_id: UUID
+    viewer_identity_id: UUID | None
+    created_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> IdentityAccess:
+        viewer = d.get("viewer_identity_id")
+        return cls(
+            id=UUID(d["id"]),
+            target_identity_id=UUID(d["target_identity_id"]),
+            viewer_identity_id=UUID(viewer) if viewer else None,
+            created_at=datetime.fromisoformat(d["created_at"]),
+        )

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.3"
+version = "0.4.4"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/sample_data_identities.py
+++ b/sdk/python/tests/sample_data_identities.py
@@ -60,3 +60,17 @@ IDENTITY_DETAIL_DICT = {
     "phone_number": IDENTITY_PHONE_DICT,
     "tunnel": IDENTITY_TUNNEL_DICT,
 }
+
+IDENTITY_ACCESS_WILDCARD_DICT = {
+    "id": "cccc3333-0000-0000-0000-000000000001",
+    "target_identity_id": "eeee5555-0000-0000-0000-000000000001",
+    "viewer_identity_id": None,
+    "created_at": "2026-05-21T00:00:00Z",
+}
+
+IDENTITY_ACCESS_VIEWER_DICT = {
+    "id": "cccc3333-0000-0000-0000-000000000002",
+    "target_identity_id": "eeee5555-0000-0000-0000-000000000001",
+    "viewer_identity_id": "dddd4444-0000-0000-0000-000000000001",
+    "created_at": "2026-05-21T00:00:00Z",
+}

--- a/sdk/python/tests/test_identities.py
+++ b/sdk/python/tests/test_identities.py
@@ -7,9 +7,15 @@ Tests for IdentitiesResource.
 from unittest.mock import MagicMock
 from uuid import UUID
 
-from sample_data_identities import IDENTITY_DICT, IDENTITY_DETAIL_DICT
+from sample_data_identities import (
+    IDENTITY_DICT,
+    IDENTITY_DETAIL_DICT,
+    IDENTITY_ACCESS_WILDCARD_DICT,
+    IDENTITY_ACCESS_VIEWER_DICT,
+)
 from inkbox.identities.resources.identities import IdentitiesResource
 from inkbox.identities.types import (
+    IdentityAccess,
     IdentityMailboxCreateOptions,
     IdentityPhoneNumberCreateOptions,
     IdentityTunnelCreateOptions,
@@ -172,3 +178,80 @@ class TestIdentitiesReleasePhoneNumber:
         res.release_phone_number(HANDLE)
 
         http.delete.assert_called_once_with(f"/{HANDLE}/phone_number")
+
+
+VIEWER_ID = "dddd4444-0000-0000-0000-000000000001"
+
+
+class TestIdentitiesListAccess:
+    def test_lists_per_viewer_rows(self):
+        res, http = _resource()
+        http.get.return_value = [IDENTITY_ACCESS_VIEWER_DICT]
+
+        rows = res.list_access(HANDLE)
+
+        http.get.assert_called_once_with(f"/{HANDLE}/access")
+        assert len(rows) == 1
+        assert isinstance(rows[0], IdentityAccess)
+        assert rows[0].viewer_identity_id == UUID(VIEWER_ID)
+        assert rows[0].target_identity_id == UUID(
+            "eeee5555-0000-0000-0000-000000000001"
+        )
+
+    def test_parses_wildcard_row(self):
+        res, http = _resource()
+        http.get.return_value = [IDENTITY_ACCESS_WILDCARD_DICT]
+
+        rows = res.list_access(HANDLE)
+
+        assert rows[0].viewer_identity_id is None
+
+    def test_empty_list(self):
+        res, http = _resource()
+        http.get.return_value = []
+
+        assert res.list_access(HANDLE) == []
+
+
+class TestIdentitiesGrantAccess:
+    def test_grants_per_viewer(self):
+        res, http = _resource()
+        http.post.return_value = IDENTITY_ACCESS_VIEWER_DICT
+
+        grant = res.grant_access(HANDLE, VIEWER_ID)
+
+        http.post.assert_called_once_with(
+            f"/{HANDLE}/access", json={"viewer_identity_id": VIEWER_ID}
+        )
+        assert isinstance(grant, IdentityAccess)
+        assert grant.viewer_identity_id == UUID(VIEWER_ID)
+
+    def test_grant_accepts_uuid_object(self):
+        res, http = _resource()
+        http.post.return_value = IDENTITY_ACCESS_VIEWER_DICT
+
+        res.grant_access(HANDLE, UUID(VIEWER_ID))
+
+        http.post.assert_called_once_with(
+            f"/{HANDLE}/access", json={"viewer_identity_id": VIEWER_ID}
+        )
+
+    def test_grant_wildcard_with_none(self):
+        res, http = _resource()
+        http.post.return_value = IDENTITY_ACCESS_WILDCARD_DICT
+
+        grant = res.grant_access(HANDLE, None)
+
+        http.post.assert_called_once_with(
+            f"/{HANDLE}/access", json={"viewer_identity_id": None}
+        )
+        assert grant.viewer_identity_id is None
+
+
+class TestIdentitiesRevokeAccess:
+    def test_revokes_viewer(self):
+        res, http = _resource()
+
+        res.revoke_access(HANDLE, VIEWER_ID)
+
+        http.delete.assert_called_once_with(f"/{HANDLE}/access/{VIEWER_ID}")

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.4
+
+### Added
+
+- **Identity visibility controls.** New `IdentityAccess` type and three methods on both `IdentitiesResource` and `AgentIdentity`:
+  - `listAccess()` — list who can see an identity. Returns either a single wildcard row (`viewerIdentityId === null` — every active identity in the org sees it) or explicit per-viewer rows. An empty list means no scoped agent can see the identity.
+  - `grantAccess(viewerIdentityId)` — grant a viewer identity visibility on the target. Pass `null` to reset the target to the org-wide wildcard.
+  - `revokeAccess(viewerIdentityId)` — revoke one viewer's visibility, keyed by the viewer identity's UUID.
+
+  Granting a viewer against an already-wildcard target raises `RedundantContactAccessGrantError` (409); revoking a non-existent grant raises `InkboxAPIError` (404).
+
 ## 0.4.3
 
 ### Breaking

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -165,6 +165,30 @@ await identity.releasePhoneNumber();
 await identity.delete();
 ```
 
+### Identity visibility
+
+Control which other agent identities can see this identity in API responses.
+Humans and admins always see every identity regardless.
+
+```ts
+const identity = await inkbox.getIdentity("sales-bot");
+
+// List the current visibility rules. Either a single wildcard row
+// (viewerIdentityId === null — every active identity sees it) or
+// explicit per-viewer rows. An empty list means no agent can see it.
+const rules = await identity.listAccess();
+
+// Grant one viewer identity visibility
+const viewer = await inkbox.getIdentity("support-bot");
+await identity.grantAccess(viewer.id);
+
+// Make it visible to every active identity in the org (wildcard)
+await identity.grantAccess(null);
+
+// Revoke one viewer (keyed by the viewer identity's UUID)
+await identity.revokeAccess(viewer.id);
+```
+
 ---
 
 ## Mail

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -24,6 +24,7 @@ import type {
 } from "./phone/types.js";
 import type {
   _AgentIdentityData,
+  IdentityAccess,
   IdentityMailbox,
   IdentityPhoneNumber,
 } from "./identities/types.js";
@@ -231,6 +232,40 @@ export class AgentIdentity {
     this._requirePhone();
     await this._inkbox._idsResource.releasePhoneNumber(this.agentHandle);
     this._phoneNumber = null;
+  }
+
+  // ------------------------------------------------------------------
+  // Identity access / visibility
+  // ------------------------------------------------------------------
+
+  /**
+   * List who can see this identity.
+   *
+   * See {@link IdentitiesResource.listAccess}.
+   */
+  async listAccess(): Promise<IdentityAccess[]> {
+    return this._inkbox._idsResource.listAccess(this.agentHandle);
+  }
+
+  /**
+   * Grant visibility on this identity.
+   *
+   * @param viewerIdentityId - UUID of the viewer identity to grant, or
+   *   `null` to reset this identity to the org-wide wildcard (every
+   *   active identity in the org sees it).
+   */
+  async grantAccess(viewerIdentityId: string | null): Promise<IdentityAccess> {
+    return this._inkbox._idsResource.grantAccess(this.agentHandle, viewerIdentityId);
+  }
+
+  /**
+   * Revoke one viewer's visibility on this identity.
+   *
+   * @param viewerIdentityId - UUID of the viewer identity to drop
+   *   (the viewer identity's UUID, not an access-row id).
+   */
+  async revokeAccess(viewerIdentityId: string): Promise<void> {
+    await this._inkbox._idsResource.revokeAccess(this.agentHandle, viewerIdentityId);
   }
 
   // ------------------------------------------------------------------

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -160,6 +160,8 @@ export class IdentitiesResource {
    * rows. An empty list means no scoped agent can see this identity
    * (humans and admins always see it).
    *
+   * Requires an admin-scoped API key; agent-scoped keys get a 403.
+   *
    * @param agentHandle - Handle of the target identity.
    */
   async listAccess(agentHandle: string): Promise<IdentityAccess[]> {
@@ -170,20 +172,28 @@ export class IdentitiesResource {
   /**
    * Grant visibility on this identity.
    *
+   * Requires an admin-scoped API key; agent-scoped keys get a 403.
+   *
    * @param agentHandle - Handle of the target identity.
    * @param viewerIdentityId - UUID of the viewer identity to grant, or
    *   `null` to reset the target to the org-wide wildcard (every active
    *   identity in the org sees it).
    * @throws {RedundantContactAccessGrantError} 409 when granting a
    *   per-viewer UUID against a target that is already a wildcard.
-   * @throws {InkboxAPIError} 409 if the viewer is already granted; 404
-   *   if the viewer identity does not exist; 422 if the viewer is the
-   *   target itself.
+   * @throws {InkboxAPIError} 403 if the API key is not admin-scoped; 409
+   *   if the viewer is already granted; 404 if the viewer identity does
+   *   not exist; 422 if the viewer is the target itself.
    */
   async grantAccess(
     agentHandle: string,
     viewerIdentityId: string | null,
   ): Promise<IdentityAccess> {
+    // Deliberately NOT wrapped in mapIdentityConflictError (unlike
+    // create / update): that mapper blind-converts every 409 to
+    // HandleUnavailableError, which is only right when the sole
+    // possible 409 is a handle collision. This route's 409s are not
+    // collisions, and the wrapper would also downgrade the
+    // RedundantContactAccessGrantError the transport already raised.
     const data = await this.http.post<RawIdentityAccess>(
       `/${agentHandle}/access`,
       { viewer_identity_id: viewerIdentityId },
@@ -194,10 +204,13 @@ export class IdentitiesResource {
   /**
    * Revoke one viewer's visibility on this identity.
    *
+   * Requires an admin-scoped API key; agent-scoped keys get a 403.
+   *
    * @param agentHandle - Handle of the target identity.
    * @param viewerIdentityId - UUID of the viewer identity to drop. This
    *   is the viewer identity's UUID, not an access-row id.
-   * @throws {InkboxAPIError} 404 when there is nothing to drop.
+   * @throws {InkboxAPIError} 403 if the API key is not admin-scoped; 404
+   *   when there is nothing to drop.
    */
   async revokeAccess(agentHandle: string, viewerIdentityId: string): Promise<void> {
     await this.http.delete(`/${agentHandle}/access/${viewerIdentityId}`);

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -11,17 +11,20 @@ import { HttpTransport, InkboxAPIError } from "../../_http.js";
 import { mapIdentityConflictError } from "../exceptions.js";
 import {
   AgentIdentitySummary,
+  IdentityAccess,
   IdentityMailboxCreateOptions,
   IdentityPhoneNumberCreateOptions,
   IdentityTunnelCreateOptions,
   _AgentIdentityData,
   RawAgentIdentitySummary,
   RawAgentIdentityData,
+  RawIdentityAccess,
   identityMailboxCreateOptionsToWire,
   identityPhoneNumberCreateOptionsToWire,
   identityTunnelCreateOptionsToWire,
   parseAgentIdentitySummary,
   parseAgentIdentityData,
+  parseIdentityAccess,
   vaultSecretIdsToWire,
 } from "../types.js";
 
@@ -147,5 +150,56 @@ export class IdentitiesResource {
    */
   async releasePhoneNumber(agentHandle: string): Promise<void> {
     await this.http.delete(`/${agentHandle}/phone_number`);
+  }
+
+  /**
+   * List who can see this identity (agent visibility).
+   *
+   * Returns either a single wildcard row (`viewerIdentityId === null` —
+   * every active identity in the org sees it) or explicit per-viewer
+   * rows. An empty list means no scoped agent can see this identity
+   * (humans and admins always see it).
+   *
+   * @param agentHandle - Handle of the target identity.
+   */
+  async listAccess(agentHandle: string): Promise<IdentityAccess[]> {
+    const data = await this.http.get<RawIdentityAccess[]>(`/${agentHandle}/access`);
+    return data.map(parseIdentityAccess);
+  }
+
+  /**
+   * Grant visibility on this identity.
+   *
+   * @param agentHandle - Handle of the target identity.
+   * @param viewerIdentityId - UUID of the viewer identity to grant, or
+   *   `null` to reset the target to the org-wide wildcard (every active
+   *   identity in the org sees it).
+   * @throws {RedundantContactAccessGrantError} 409 when granting a
+   *   per-viewer UUID against a target that is already a wildcard.
+   * @throws {InkboxAPIError} 409 if the viewer is already granted; 404
+   *   if the viewer identity does not exist; 422 if the viewer is the
+   *   target itself.
+   */
+  async grantAccess(
+    agentHandle: string,
+    viewerIdentityId: string | null,
+  ): Promise<IdentityAccess> {
+    const data = await this.http.post<RawIdentityAccess>(
+      `/${agentHandle}/access`,
+      { viewer_identity_id: viewerIdentityId },
+    );
+    return parseIdentityAccess(data);
+  }
+
+  /**
+   * Revoke one viewer's visibility on this identity.
+   *
+   * @param agentHandle - Handle of the target identity.
+   * @param viewerIdentityId - UUID of the viewer identity to drop. This
+   *   is the viewer identity's UUID, not an access-row id.
+   * @throws {InkboxAPIError} 404 when there is nothing to drop.
+   */
+  async revokeAccess(agentHandle: string, viewerIdentityId: string): Promise<void> {
+    await this.http.delete(`/${agentHandle}/access/${viewerIdentityId}`);
   }
 }

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -138,6 +138,22 @@ export interface _AgentIdentityData extends AgentIdentitySummary {
   tunnel: Tunnel | null;
 }
 
+/**
+ * A single identity-visibility grant on a target identity.
+ *
+ * `viewerIdentityId === null` is the wildcard sentinel — every active
+ * identity in the org can see the target. Otherwise it is a per-viewer
+ * grant naming exactly one viewer identity.
+ */
+export interface IdentityAccess {
+  id: string;
+  /** The identity whose visibility this grant controls. */
+  targetIdentityId: string;
+  /** Viewer identity granted access, or `null` for the org-wide wildcard. */
+  viewerIdentityId: string | null;
+  createdAt: Date;
+}
+
 // ---- internal raw API shapes (snake_case from JSON) ----
 
 export interface RawIdentityMailbox {
@@ -188,6 +204,13 @@ export interface RawAgentIdentityData extends RawAgentIdentitySummary {
   mailbox: RawIdentityMailbox | null;
   phone_number: RawIdentityPhoneNumber | null;
   tunnel: RawTunnel | null;
+}
+
+export interface RawIdentityAccess {
+  id: string;
+  target_identity_id: string;
+  viewer_identity_id: string | null;
+  created_at: string;
 }
 
 // ---- parsers ----
@@ -252,6 +275,15 @@ export function parseAgentIdentityData(r: RawAgentIdentityData): _AgentIdentityD
     mailbox: r.mailbox ? parseIdentityMailbox(r.mailbox) : null,
     phoneNumber: r.phone_number ? parseIdentityPhoneNumber(r.phone_number) : null,
     tunnel: r.tunnel ? parseTunnel(r.tunnel) : null,
+  };
+}
+
+export function parseIdentityAccess(r: RawIdentityAccess): IdentityAccess {
+  return {
+    id: r.id,
+    targetIdentityId: r.target_identity_id,
+    viewerIdentityId: r.viewer_identity_id,
+    createdAt: new Date(r.created_at),
   };
 }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -102,6 +102,7 @@ export type {
 export type {
   AgentIdentitySummary,
   CreateIdentityOptions,
+  IdentityAccess,
   IdentityMailboxCreateOptions,
   IdentityMailbox,
   IdentityPhoneNumberCreateOptions,

--- a/sdk/typescript/tests/identities/identities.test.ts
+++ b/sdk/typescript/tests/identities/identities.test.ts
@@ -2,7 +2,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { IdentitiesResource } from "../../src/identities/resources/identities.js";
 import type { HttpTransport } from "../../src/_http.js";
-import { RAW_IDENTITY, RAW_IDENTITY_DETAIL } from "../sampleData.js";
+import {
+  RAW_IDENTITY,
+  RAW_IDENTITY_DETAIL,
+  RAW_IDENTITY_ACCESS_WILDCARD,
+  RAW_IDENTITY_ACCESS_VIEWER,
+} from "../sampleData.js";
 
 function mockHttp() {
   return {
@@ -176,5 +181,84 @@ describe("IdentitiesResource.releasePhoneNumber", () => {
     await res.releasePhoneNumber(HANDLE);
 
     expect(http.delete).toHaveBeenCalledWith(`/${HANDLE}/phone_number`);
+  });
+});
+
+describe("IdentitiesResource.listAccess", () => {
+  it("lists per-viewer access rows", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_IDENTITY_ACCESS_VIEWER]);
+    const res = new IdentitiesResource(http);
+
+    const rows = await res.listAccess(HANDLE);
+
+    expect(http.get).toHaveBeenCalledWith(`/${HANDLE}/access`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].viewerIdentityId).toBe("dddd4444-0000-0000-0000-000000000001");
+    expect(rows[0].targetIdentityId).toBe("eeee5555-0000-0000-0000-000000000001");
+    expect(rows[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  it("parses the wildcard row with a null viewer", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_IDENTITY_ACCESS_WILDCARD]);
+    const res = new IdentitiesResource(http);
+
+    const rows = await res.listAccess(HANDLE);
+
+    expect(rows[0].viewerIdentityId).toBeNull();
+  });
+
+  it("returns an empty list when no agent can see the identity", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([]);
+    const res = new IdentitiesResource(http);
+
+    expect(await res.listAccess(HANDLE)).toEqual([]);
+  });
+});
+
+describe("IdentitiesResource.grantAccess", () => {
+  it("grants a per-viewer access row", async () => {
+    const http = mockHttp();
+    vi.mocked(http.post).mockResolvedValue(RAW_IDENTITY_ACCESS_VIEWER);
+    const res = new IdentitiesResource(http);
+
+    const grant = await res.grantAccess(
+      HANDLE,
+      "dddd4444-0000-0000-0000-000000000001",
+    );
+
+    expect(http.post).toHaveBeenCalledWith(`/${HANDLE}/access`, {
+      viewer_identity_id: "dddd4444-0000-0000-0000-000000000001",
+    });
+    expect(grant.viewerIdentityId).toBe("dddd4444-0000-0000-0000-000000000001");
+  });
+
+  it("resets to the org-wide wildcard when viewerIdentityId is null", async () => {
+    const http = mockHttp();
+    vi.mocked(http.post).mockResolvedValue(RAW_IDENTITY_ACCESS_WILDCARD);
+    const res = new IdentitiesResource(http);
+
+    const grant = await res.grantAccess(HANDLE, null);
+
+    expect(http.post).toHaveBeenCalledWith(`/${HANDLE}/access`, {
+      viewer_identity_id: null,
+    });
+    expect(grant.viewerIdentityId).toBeNull();
+  });
+});
+
+describe("IdentitiesResource.revokeAccess", () => {
+  it("revokes a viewer keyed by the viewer identity UUID", async () => {
+    const http = mockHttp();
+    vi.mocked(http.delete).mockResolvedValue(undefined);
+    const res = new IdentitiesResource(http);
+
+    await res.revokeAccess(HANDLE, "dddd4444-0000-0000-0000-000000000001");
+
+    expect(http.delete).toHaveBeenCalledWith(
+      `/${HANDLE}/access/dddd4444-0000-0000-0000-000000000001`,
+    );
   });
 });

--- a/sdk/typescript/tests/sampleData.ts
+++ b/sdk/typescript/tests/sampleData.ts
@@ -272,6 +272,20 @@ export const RAW_IDENTITY_DETAIL = {
   phone_number: RAW_IDENTITY_PHONE,
 };
 
+export const RAW_IDENTITY_ACCESS_WILDCARD = {
+  id: "cccc3333-0000-0000-0000-000000000001",
+  target_identity_id: "eeee5555-0000-0000-0000-000000000001",
+  viewer_identity_id: null,
+  created_at: "2026-05-21T00:00:00Z",
+};
+
+export const RAW_IDENTITY_ACCESS_VIEWER = {
+  id: "cccc3333-0000-0000-0000-000000000002",
+  target_identity_id: "eeee5555-0000-0000-0000-000000000001",
+  viewer_identity_id: "dddd4444-0000-0000-0000-000000000001",
+  created_at: "2026-05-21T00:00:00Z",
+};
+
 // ---- Domains ----
 
 export const RAW_DOMAIN_VERIFIED = {

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -125,6 +125,19 @@ Notes:
 - `identity get` and `identity refresh` return mailbox, phone-number, and tunnel assignments when present.
 - Most email, phone, and text commands require `-i, --identity <handle>`.
 
+### Identity Visibility
+
+Controls which other agent identities can see an identity in API responses. Humans and admins always see every identity.
+
+```bash
+inkbox identity access list <target-handle>
+inkbox identity access grant <target-handle> <viewer-handle>
+inkbox identity access grant-everyone <target-handle>
+inkbox identity access revoke <target-handle> <viewer-handle>
+```
+
+`list` shows either a single wildcard row (`viewerIdentityId` empty → every active identity sees it), explicit per-viewer rows, or nothing (no agent can see it). `grant` adds one viewer; `grant-everyone` resets to the org-wide wildcard; `revoke` drops one viewer. Viewer identities are passed as handles and resolved to UUIDs automatically. Unrelated to `identity revoke-access` below, which manages vault-secret access.
+
 ### Identity-Scoped Secrets
 
 These require a vault key:

--- a/skills/inkbox-openclaw/README.md
+++ b/skills/inkbox-openclaw/README.md
@@ -6,7 +6,7 @@ An [OpenClaw](https://openclaw.ai) skill for email, phone, and vault via [Inkbox
 
 Once installed, your OpenClaw agent can:
 
-- **Manage identities** — create, list, rename, pause, and delete agent identities; provision and release phone numbers
+- **Manage identities** — create, list, rename, pause, and delete agent identities; provision and release phone numbers; control which other agents can see an identity
 - **Send emails** — compose and send from an Inkbox agent mailbox, with optional CC/BCC
 - **Reply to emails** — thread replies using a message ID
 - **Read inbox** — list recent messages or unread messages only

--- a/skills/inkbox-openclaw/SKILL.md
+++ b/skills/inkbox-openclaw/SKILL.md
@@ -78,6 +78,9 @@ AgentIdentity (identity-scoped helper)
 ├── .mailbox                → IdentityMailbox | null
 ├── .phoneNumber            → IdentityPhoneNumber | null
 ├── .getCredentials()       → Promise<Credentials>  (requires vault unlocked)
+├── .listAccess()           → Promise<IdentityAccess[]>
+├── .grantAccess(viewerId|null) → Promise<IdentityAccess>
+├── .revokeAccess(viewerId) → Promise<void>
 ├── mail methods            (requires assigned mailbox)
 ├── phone methods           (requires assigned phone number)
 └── text methods            (requires assigned phone number)
@@ -131,6 +134,22 @@ await identity.releasePhoneNumber();
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.createIdentity()` to provision both; use `identity.delete()` to remove both (cascade).
+
+## Identity Visibility
+
+Controls which other agent identities can see an identity in API responses. Humans and admins always see every identity.
+
+```typescript
+const rules = await identity.listAccess();   // IdentityAccess[]
+// One wildcard row (viewerIdentityId === null → every active identity sees it),
+// explicit per-viewer rows, or [] (no agent can see it).
+
+await identity.grantAccess(viewer.id);        // grant one viewer identity
+await identity.grantAccess(null);             // reset to org-wide wildcard
+await identity.revokeAccess(viewer.id);       // revoke one viewer (keyed by viewer UUID)
+```
+
+Granting a viewer against an already-wildcard target raises `RedundantContactAccessGrantError` (409); revoking a non-existent grant raises `InkboxAPIError` (404).
 
 ## Mail
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -48,6 +48,9 @@ AgentIdentity (identity-scoped helper)
 ├── .mailbox                 → IdentityMailbox | None
 ├── .phone_number            → IdentityPhoneNumber | None
 ├── .credentials             → Credentials  (requires vault unlocked)
+├── .list_access()           → list[IdentityAccess]
+├── .grant_access(viewer_id|None) → IdentityAccess
+├── .revoke_access(viewer_id) → None
 ├── mail methods             (requires assigned mailbox)
 ├── phone methods            (requires assigned phone number)
 └── text methods             (requires assigned phone number)
@@ -92,6 +95,22 @@ identity.release_phone_number()
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.create_identity()` to provision both; use `identity.delete()` to remove both (cascade).
+
+## Identity Visibility
+
+Controls which other agent identities can see an identity in API responses. Humans and admins always see every identity.
+
+```python
+rules = identity.list_access()    # list[IdentityAccess]
+# One wildcard row (viewer_identity_id is None → every active identity sees it),
+# explicit per-viewer rows, or [] (no agent can see it).
+
+identity.grant_access(viewer.id)  # grant one viewer identity
+identity.grant_access(None)       # reset to org-wide wildcard
+identity.revoke_access(viewer.id) # revoke one viewer (keyed by viewer UUID)
+```
+
+Granting a viewer against an already-wildcard target raises `RedundantContactAccessGrantError` (409); revoking a non-existent grant raises `InkboxAPIError` (404).
 
 ## Mail
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -47,6 +47,9 @@ AgentIdentity (identity-scoped helper)
 ├── .mailbox                → IdentityMailbox | null
 ├── .phoneNumber            → IdentityPhoneNumber | null
 ├── .getCredentials()       → Promise<Credentials>  (requires vault unlocked)
+├── .listAccess()           → Promise<IdentityAccess[]>
+├── .grantAccess(viewerId|null) → Promise<IdentityAccess>
+├── .revokeAccess(viewerId) → Promise<void>
 ├── mail methods            (requires assigned mailbox)
 ├── phone methods           (requires assigned phone number)
 └── text methods            (requires assigned phone number)
@@ -91,6 +94,22 @@ await identity.releasePhoneNumber();
 ```
 
 Mailboxes and tunnels are not separately linkable — they are 1:1 with their owning identity. Use `inkbox.createIdentity()` to provision both; use `identity.delete()` to remove both (cascade).
+
+## Identity Visibility
+
+Controls which other agent identities can see an identity in API responses. Humans and admins always see every identity.
+
+```typescript
+const rules = await identity.listAccess();   // IdentityAccess[]
+// One wildcard row (viewerIdentityId === null → every active identity sees it),
+// explicit per-viewer rows, or [] (no agent can see it).
+
+await identity.grantAccess(viewer.id);        // grant one viewer identity
+await identity.grantAccess(null);             // reset to org-wide wildcard
+await identity.revokeAccess(viewer.id);       // revoke one viewer (keyed by viewer UUID)
+```
+
+Granting a viewer against an already-wildcard target raises `RedundantContactAccessGrantError` (409); revoking a non-existent grant raises `InkboxAPIError` (404).
 
 ## Mail
 


### PR DESCRIPTION
## Summary

Adds **identity visibility / access** support to the SDK (Python + TypeScript) and CLI, matching what shipped in `servers` + `console` on `visible-agents`. Wraps three server endpoints for granting/listing/revoking which agents can see an identity.

## Changes

- **TS SDK**: new `IdentityAccess` type; `listAccess` / `grantAccess` / `revokeAccess` on `IdentitiesResource` + `AgentIdentity`.
- **Python SDK**: `IdentityAccess` dataclass; `list_access` / `grant_access` / `revoke_access` (same surface).
- **CLI**: new `inkbox identity access` group — `list`, `grant`, `grant-everyone`, `revoke`. Viewers passed as handles, resolved to UUIDs.
- `grantAccess(null)` resets an identity to the org-wide wildcard.
- Docs: CHANGELOGs, READMEs, and the `inkbox-ts` / `inkbox-python` / `inkbox-openclaw` skills.
- Removed 20 stray `* 2.*` iCloud conflict files (untracked sync artifacts).

## Versioning

`0.4.3` → `0.4.4` across both SDKs + CLI (additive). SDK and CLI must publish to npm together.

## Testing

Python suite passes (478 tests); TS identity tests 35/35; CLI builds clean.