### PR TITLE
Remove stale OpenClaw skill references

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ inkbox signup status
 | [`cli/`](./cli/) | CLI (`@inkbox/cli`) |
 | [`skills/inkbox-python/`](./skills/inkbox-python/) | Python agent skill for Claude Code and other coding agents |
 | [`skills/inkbox-ts/`](./skills/inkbox-ts/) | TypeScript agent skill for Claude Code and other coding agents |
-| [`skills/inkbox-openclaw/`](./skills/inkbox-openclaw/) | Inkbox OpenClaw skill — email and phone for your OpenClaw agent |
 | [`skills/inkbox-tunnels/`](./skills/inkbox-tunnels/) | Tunnels skill — bring a local server online at a public Inkbox URL |
 | [`examples/use-inkbox-browser-use/`](./examples/use-inkbox-browser-use/) | Inkbox + Browser Use — give your agent an email, phone, and vault |
 | [`examples/use-inkbox-kernel/`](./examples/use-inkbox-kernel/) | Inkbox + Kernel — give your agent an email and browser |

--- a/skills/README.md
+++ b/skills/README.md
@@ -56,7 +56,6 @@ Once the skills are installed, your coding agent will automatically know how to 
 |-------|----------|-------------|
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `inkbox` Python SDK |
 | **inkbox-ts** | TypeScript / Node ≥ 22 | Agent signup, identities, email, phone, text, contacts, notes, contact rules, vault, and webhooks using the `@inkbox/sdk` TypeScript SDK |
-| **inkbox-openclaw** | TypeScript / Node ≥ 22 | OpenClaw skill — agent signup, email, phone, text, contacts, notes, contact rules, and vault for your OpenClaw agent |
 | **inkbox-cli** | TypeScript / Node ≥ 22 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |
 | **inkbox-all** | Language-agnostic | Index of all Inkbox skills in this repository, including example skills and links for choosing the right one |
 | **inkbox-agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -26,10 +26,6 @@ This skill is just a directory of the other Inkbox skills in this repository. Us
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-cli/SKILL.md
   Reference for running the Inkbox CLI (`inkbox` / `@inkbox/cli`) for identities, email, phone, text, vault, mailbox, number, signing key, and webhook operations.
 
-- `inkbox-openclaw`
-  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-openclaw/SKILL.md
-  OpenClaw-oriented Inkbox skill for TypeScript usage with environment and dependency setup guidance.
-
 - `inkbox-python`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-python/SKILL.md
   Python SDK reference for `inkbox`, including identities, email, phone, text/SMS, contacts, notes, contact rules, custom sending domains, vault, signing keys, and tunnels.
@@ -71,6 +67,5 @@ These example directories are useful references, but they are not standalone ski
 - Use `inkbox-cli` when the task is operational and best handled with shell commands.
 - Use `inkbox-tunnels` when bringing a local server online at a public Inkbox URL via `inkbox.tunnels.connect(...)`.
 - Use `inkbox-agent-self-signup` when the agent does not have an API key yet and needs to self-register.
-- Use `inkbox-openclaw` when the environment is specifically OpenClaw.
 - Use the example skills when you want a reusable agent prompt rather than SDK integration code.
 - Use the related examples when you want runnable scripts or end-to-end sample workflows instead of a reusable skill prompt.


### PR DESCRIPTION
## Summary
- remove the deleted OpenClaw skill from the root README repo contents table
- remove the stale OpenClaw skill row from the skills README
- remove the stale OpenClaw entry from the aggregate inkbox-all skill index

## Verification
- rg "inkbox-openclaw|OpenClaw skill|skills/inkbox-openclaw" README.md skills
- git diff --check