### PR TITLE
Add agent self-signup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ inkbox signup status
 | [`examples/use-inkbox-kernel/`](./examples/use-inkbox-kernel/) | Inkbox + Kernel — give your agent an email and browser |
 | [`examples/use-inkbox-cli/`](./examples/use-inkbox-cli/) | Shell script examples for CLI automation and CI pipelines |
 | [`examples/use-inkbox-vault/`](./examples/use-inkbox-vault/) | Vault TOTP example — create credentials with one-time codes |
+| [`examples/use-inkbox-signup/`](./examples/use-inkbox-signup/) | Agent self-signup — register without an API key, verify, send welcome email |
 
 ---
 

--- a/examples/use-inkbox-signup/.env.example
+++ b/examples/use-inkbox-signup/.env.example
@@ -1,0 +1,12 @@
+# Required for register
+INKBOX_HUMAN_EMAIL=
+INKBOX_NOTE_TO_HUMAN="Hey! This is my agent signing up via the Inkbox signup example."
+
+# Optional — requested handle (a unique suffix is appended automatically)
+# INKBOX_AGENT_HANDLE=signup-demo
+
+# Set after register (save the one-time API key from the register output)
+# INKBOX_API_KEY=
+
+# Required for verify
+# INKBOX_VERIFICATION_CODE=

--- a/examples/use-inkbox-signup/.env.example
+++ b/examples/use-inkbox-signup/.env.example
@@ -8,5 +8,8 @@ INKBOX_NOTE_TO_HUMAN="Hey! This is my agent signing up via the Inkbox signup exa
 # Set after register (save the one-time API key from the register output)
 # INKBOX_API_KEY=
 
+# Set after register (the handle returned by register; needed for send-welcome and cleanup)
+# INKBOX_AGENT_HANDLE_SAVED=
+
 # Required for verify
 # INKBOX_VERIFICATION_CODE=

--- a/examples/use-inkbox-signup/README.md
+++ b/examples/use-inkbox-signup/README.md
@@ -1,0 +1,79 @@
+# use-inkbox-signup
+
+Agent self-signup example — register without a pre-existing API key, verify with a human approval code, check restrictions, send a welcome email, and clean up.
+
+No Inkbox account or API key is required to start. The flow provisions a mailbox, identity, and one-time API key in a single call, then sends a verification email to the specified human.
+
+## Prerequisites
+
+1. Python ≥ 3.11 (for the Python script) or Node.js ≥ 22 (for TypeScript)
+2. A human email address (`INKBOX_HUMAN_EMAIL`) — receives the 6-digit verification code
+3. After registration, save the one-time `INKBOX_API_KEY` from the output
+
+## Flow
+
+| Step | Command | Auth required |
+|------|---------|---------------|
+| 1. Register | `register` | None |
+| 2. Check status | `status` | Signup API key |
+| 3. Verify | `verify` | Signup API key + 6-digit code from email |
+| 4. Send welcome | `send-welcome` | Signup API key (after verify) |
+| 5. Clean up | `cleanup` | Signup API key |
+
+While unclaimed, outbound email is restricted to the human email only (max 10 sends/day). After verification, restrictions lift.
+
+## Run (Python)
+
+```bash
+cp .env.example .env
+# edit .env — set INKBOX_HUMAN_EMAIL at minimum
+
+cd ../../sdk/python
+uv run --env-file ../../examples/use-inkbox-signup/.env \
+  python ../../examples/use-inkbox-signup/agent_signup.py register
+
+# Save the printed API key into .env as INKBOX_API_KEY, then:
+uv run --env-file ../../examples/use-inkbox-signup/.env \
+  python ../../examples/use-inkbox-signup/agent_signup.py status
+
+# After the human shares the 6-digit code:
+uv run --env-file ../../examples/use-inkbox-signup/.env \
+  python ../../examples/use-inkbox-signup/agent_signup.py verify --code 483921
+
+uv run --env-file ../../examples/use-inkbox-signup/.env \
+  python ../../examples/use-inkbox-signup/agent_signup.py send-welcome
+
+uv run --env-file ../../examples/use-inkbox-signup/.env \
+  python ../../examples/use-inkbox-signup/agent_signup.py cleanup
+```
+
+Other subcommands: `resend` (5-minute cooldown).
+
+## Run (TypeScript)
+
+```bash
+cp .env.example .env
+# edit .env — set INKBOX_HUMAN_EMAIL at minimum
+
+cd ../../sdk/typescript
+npm run build
+cd ../../examples/use-inkbox-signup
+npm install ../../sdk/typescript
+
+npx tsx --env-file .env agent-signup.ts register
+# Save the API key, then continue with status / verify / send-welcome / cleanup
+npx tsx --env-file .env agent-signup.ts status
+npx tsx --env-file .env agent-signup.ts verify --code 483921
+npx tsx --env-file .env agent-signup.ts send-welcome
+npx tsx --env-file .env agent-signup.ts cleanup
+```
+
+## Restrictions (unclaimed vs claimed)
+
+| | Unclaimed | Claimed (after verify) |
+|---|---|---|
+| Max sends/day | 10 | 500 |
+| Allowed recipients | `human_email` only | No restriction |
+| Can receive email | Yes | Yes |
+
+See [`skills/inkbox-agent-self-signup/SKILL.md`](../../skills/inkbox-agent-self-signup/SKILL.md) for the full reference.

--- a/examples/use-inkbox-signup/agent-signup.ts
+++ b/examples/use-inkbox-signup/agent-signup.ts
@@ -1,0 +1,183 @@
+/**
+ * Agent self-signup example — register, verify, check status, send welcome email.
+ *
+ * Requires no pre-existing API key for registration. After the human approves
+ * with the 6-digit code, verify and optionally send a welcome email.
+ *
+ * Environment variables (see .env.example):
+ *   INKBOX_HUMAN_EMAIL        — human who receives the verification email (register)
+ *   INKBOX_NOTE_TO_HUMAN      — message included in the verification email (register)
+ *   INKBOX_AGENT_HANDLE       — optional base handle; a unique suffix is appended
+ *   INKBOX_API_KEY            — one-time key returned by register (all other steps)
+ *   INKBOX_AGENT_HANDLE_SAVED — handle returned by register (send-welcome, cleanup)
+ */
+
+import { randomUUID } from "node:crypto";
+import { Inkbox } from "@inkbox/sdk";
+import type { AgentSignupStatusResponse } from "@inkbox/sdk";
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    console.error(`ERROR: ${name} is required.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function requireApiKey(): string {
+  return requireEnv("INKBOX_API_KEY");
+}
+
+function printStatus(status: AgentSignupStatusResponse): void {
+  console.log(`  claim_status:         ${status.claimStatus}`);
+  console.log(`  human_state:          ${status.humanState}`);
+  console.log(`  human_email:          ${status.humanEmail}`);
+  console.log(`  max_sends_per_day:    ${status.restrictions.maxSendsPerDay}`);
+  console.log(
+    `  allowed_recipients:   ${status.restrictions.allowedRecipients.join(", ") || "-"}`,
+  );
+  console.log(`  can_receive:          ${status.restrictions.canReceive}`);
+  console.log(
+    `  can_create_mailboxes: ${status.restrictions.canCreateMailboxes}`,
+  );
+}
+
+async function cmdRegister(): Promise<void> {
+  const humanEmail = requireEnv("INKBOX_HUMAN_EMAIL");
+  const note =
+    process.env.INKBOX_NOTE_TO_HUMAN?.trim() ??
+    "Hey! This is my agent signing up via the Inkbox signup example.";
+  const baseHandle = process.env.INKBOX_AGENT_HANDLE?.trim() ?? "signup-demo";
+  const suffix = randomUUID().replace(/-/g, "").slice(0, 8);
+  const agentHandle = `${baseHandle}-${suffix}`;
+
+  const result = await Inkbox.signup({
+    humanEmail,
+    noteToHuman: note,
+    displayName: "Signup Demo Agent",
+    agentHandle,
+    emailLocalPart: agentHandle,
+    harness: "cursor",
+  });
+
+  console.log();
+  console.log("Agent registered successfully!");
+  console.log();
+  console.log(`  Email:    ${result.emailAddress}`);
+  console.log(`  Handle:   ${result.agentHandle}`);
+  console.log(`  Org:      ${result.organizationId}`);
+  console.log(`  Status:   ${result.claimStatus}`);
+  console.log();
+  console.log(`  API Key:  ${result.apiKey}`);
+  console.log();
+  console.log("Save the API key — it is shown only once.");
+  console.log(`A verification email has been sent to ${result.humanEmail}.`);
+  console.log();
+  console.log("Next steps:");
+  console.log("  1. Add INKBOX_API_KEY to your .env");
+  console.log(`  2. Add INKBOX_AGENT_HANDLE_SAVED=${result.agentHandle} to your .env`);
+  console.log("  3. Run: agent-signup.ts status");
+  console.log("  4. After the human shares the code: agent-signup.ts verify --code <code>");
+}
+
+async function cmdStatus(): Promise<void> {
+  const apiKey = requireApiKey();
+  const status = await Inkbox.getSignupStatus(apiKey);
+  console.log("Signup status:");
+  printStatus(status);
+}
+
+async function cmdVerify(codeArg?: string): Promise<void> {
+  const apiKey = requireApiKey();
+  const code = codeArg?.trim() ?? process.env.INKBOX_VERIFICATION_CODE?.trim();
+  if (!code) {
+    console.error("ERROR: Pass --code or set INKBOX_VERIFICATION_CODE.");
+    process.exit(1);
+  }
+
+  const result = await Inkbox.verifySignup(apiKey, { verificationCode: code });
+  console.log();
+  console.log("Verification successful!");
+  console.log(`  claim_status: ${result.claimStatus}`);
+  console.log(`  org:          ${result.organizationId}`);
+  console.log(`  message:      ${result.message}`);
+  console.log();
+  console.log("Next: agent-signup.ts send-welcome");
+}
+
+async function cmdResend(): Promise<void> {
+  const apiKey = requireApiKey();
+  const result = await Inkbox.resendSignupVerification(apiKey);
+  console.log();
+  console.log("Verification email resent.");
+  console.log(`  claim_status: ${result.claimStatus}`);
+  console.log(`  org:          ${result.organizationId}`);
+  console.log(`  message:      ${result.message}`);
+}
+
+async function cmdSendWelcome(): Promise<void> {
+  const apiKey = requireApiKey();
+  const handle = requireEnv("INKBOX_AGENT_HANDLE_SAVED");
+
+  const inkbox = new Inkbox({ apiKey });
+  const identity = await inkbox.getIdentity(handle);
+  const status = await Inkbox.getSignupStatus(apiKey);
+  await identity.sendEmail({
+    to: [status.humanEmail],
+    subject: "Hello from your agent!",
+    bodyText:
+      `Hi! I'm ${identity.agentHandle} (${identity.emailAddress}). ` +
+      "I'm all set up after verification.",
+  });
+  console.log(`Sent welcome email to ${status.humanEmail}`);
+  console.log(`  from: ${identity.emailAddress}`);
+}
+
+async function cmdCleanup(): Promise<void> {
+  const apiKey = requireApiKey();
+  const handle = requireEnv("INKBOX_AGENT_HANDLE_SAVED");
+
+  const inkbox = new Inkbox({ apiKey });
+  const identity = await inkbox.getIdentity(handle);
+  await identity.delete();
+  console.log(`Deleted identity: ${handle}`);
+}
+
+const [, , command, ...rest] = process.argv;
+
+async function main(): Promise<void> {
+  switch (command) {
+    case "register":
+      await cmdRegister();
+      break;
+    case "status":
+      await cmdStatus();
+      break;
+    case "verify": {
+      const codeIdx = rest.indexOf("--code");
+      const code = codeIdx >= 0 ? rest[codeIdx + 1] : undefined;
+      await cmdVerify(code);
+      break;
+    }
+    case "resend":
+      await cmdResend();
+      break;
+    case "send-welcome":
+      await cmdSendWelcome();
+      break;
+    case "cleanup":
+      await cmdCleanup();
+      break;
+    default:
+      console.error(
+        "Usage: agent-signup.ts <register|status|verify|resend|send-welcome|cleanup> [--code <code>]",
+      );
+      process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/examples/use-inkbox-signup/agent_signup.py
+++ b/examples/use-inkbox-signup/agent_signup.py
@@ -1,0 +1,176 @@
+"""
+Agent self-signup example — register, verify, check status, send welcome email.
+
+Requires no pre-existing API key for registration. After the human approves
+with the 6-digit code, verify and optionally send a welcome email.
+
+Environment variables (see .env.example):
+  INKBOX_HUMAN_EMAIL       — human who receives the verification email (register)
+  INKBOX_NOTE_TO_HUMAN     — message included in the verification email (register)
+  INKBOX_AGENT_HANDLE      — optional base handle; a unique suffix is appended
+  INKBOX_API_KEY           — one-time key returned by register (all other steps)
+  INKBOX_AGENT_HANDLE_SAVED — handle returned by register (send-welcome, cleanup)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import uuid
+
+from inkbox import Inkbox
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        print(f"ERROR: {name} is required.", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _require_api_key() -> str:
+    return _require_env("INKBOX_API_KEY")
+
+
+def _print_status(status) -> None:
+    print(f"  claim_status:        {status.claim_status}")
+    print(f"  human_state:         {status.human_state}")
+    print(f"  human_email:         {status.human_email}")
+    print(f"  max_sends_per_day:   {status.restrictions.max_sends_per_day}")
+    print(f"  allowed_recipients:  {', '.join(status.restrictions.allowed_recipients) or '-'}")
+    print(f"  can_receive:         {status.restrictions.can_receive}")
+    print(f"  can_create_mailboxes: {status.restrictions.can_create_mailboxes}")
+
+
+def cmd_register(args: argparse.Namespace) -> None:
+    human_email = _require_env("INKBOX_HUMAN_EMAIL")
+    note = os.environ.get(
+        "INKBOX_NOTE_TO_HUMAN",
+        "Hey! This is my agent signing up via the Inkbox signup example.",
+    ).strip()
+    base_handle = os.environ.get("INKBOX_AGENT_HANDLE", "signup-demo").strip()
+    suffix = uuid.uuid4().hex[:8]
+    agent_handle = f"{base_handle}-{suffix}"
+
+    result = Inkbox.signup(
+        human_email=human_email,
+        note_to_human=note,
+        display_name="Signup Demo Agent",
+        agent_handle=agent_handle,
+        email_local_part=agent_handle,
+        harness="cursor",
+    )
+
+    print()
+    print("Agent registered successfully!")
+    print()
+    print(f"  Email:    {result.email_address}")
+    print(f"  Handle:   {result.agent_handle}")
+    print(f"  Org:      {result.organization_id}")
+    print(f"  Status:   {result.claim_status}")
+    print()
+    print(f"  API Key:  {result.api_key}")
+    print()
+    print("Save the API key — it is shown only once.")
+    print(f"A verification email has been sent to {result.human_email}.")
+    print()
+    print("Next steps:")
+    print("  1. Add INKBOX_API_KEY to your .env")
+    print(f"  2. Add INKBOX_AGENT_HANDLE_SAVED={result.agent_handle} to your .env")
+    print("  3. Run: agent_signup.py status")
+    print("  4. After the human shares the code: agent_signup.py verify --code <code>")
+
+
+def cmd_status(_args: argparse.Namespace) -> None:
+    api_key = _require_api_key()
+    status = Inkbox.get_signup_status(api_key)
+    print("Signup status:")
+    _print_status(status)
+
+
+def cmd_verify(args: argparse.Namespace) -> None:
+    api_key = _require_api_key()
+    code = args.code or os.environ.get("INKBOX_VERIFICATION_CODE", "").strip()
+    if not code:
+        print("ERROR: Pass --code or set INKBOX_VERIFICATION_CODE.", file=sys.stderr)
+        sys.exit(1)
+
+    result = Inkbox.verify_signup(api_key, verification_code=code)
+    print()
+    print("Verification successful!")
+    print(f"  claim_status: {result.claim_status}")
+    print(f"  org:          {result.organization_id}")
+    print(f"  message:      {result.message}")
+    print()
+    print("Next: agent_signup.py send-welcome")
+
+
+def cmd_resend(_args: argparse.Namespace) -> None:
+    api_key = _require_api_key()
+    result = Inkbox.resend_signup_verification(api_key)
+    print()
+    print("Verification email resent.")
+    print(f"  claim_status: {result.claim_status}")
+    print(f"  org:          {result.organization_id}")
+    print(f"  message:      {result.message}")
+
+
+def cmd_send_welcome(_args: argparse.Namespace) -> None:
+    api_key = _require_api_key()
+    handle = _require_env("INKBOX_AGENT_HANDLE_SAVED")
+
+    with Inkbox(api_key=api_key) as inkbox:
+        identity = inkbox.get_identity(handle)
+        status = Inkbox.get_signup_status(api_key)
+        identity.send_email(
+            to=[status.human_email],
+            subject="Hello from your agent!",
+            body_text=(
+                f"Hi! I'm {identity.agent_handle} ({identity.email_address}). "
+                "I'm all set up after verification."
+            ),
+        )
+        print(f"Sent welcome email to {status.human_email}")
+        print(f"  from: {identity.email_address}")
+
+
+def cmd_cleanup(_args: argparse.Namespace) -> None:
+    api_key = _require_api_key()
+    handle = _require_env("INKBOX_AGENT_HANDLE_SAVED")
+
+    with Inkbox(api_key=api_key) as inkbox:
+        identity = inkbox.get_identity(handle)
+        identity.delete()
+        print(f"Deleted identity: {handle}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Inkbox agent self-signup example",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("register", help="Register a new agent (no API key required)")
+    sub.add_parser("status", help="Check signup claim status and restrictions")
+    verify_p = sub.add_parser("verify", help="Submit the 6-digit verification code")
+    verify_p.add_argument("--code", help="6-digit code from the verification email")
+    sub.add_parser("resend", help="Resend the verification email (5-minute cooldown)")
+    sub.add_parser("send-welcome", help="Send a welcome email to the human (after verify)")
+    sub.add_parser("cleanup", help="Delete the demo identity")
+
+    args = parser.parse_args()
+    commands = {
+        "register": cmd_register,
+        "status": cmd_status,
+        "verify": cmd_verify,
+        "resend": cmd_resend,
+        "send-welcome": cmd_send_welcome,
+        "cleanup": cmd_cleanup,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `examples/use-inkbox-signup/` — a runnable agent self-signup walkthrough in Python and TypeScript
- Covers the full flow: `register` (no API key) → `status` → `verify` → `send-welcome` → `cleanup`
- Mirrors the `use-inkbox-vault` pattern (`.env.example`, README, dual-language scripts)
- Updates the root README examples table

## Why

Signup is documented in the README and skills, but there was no dedicated example folder. This gives new users a step-by-step reference for the most common onboarding path.

## Test plan

- [x] Python SDK unit tests pass (`pytest tests/test_agent_signup.py` — 11/11)
- [x] `agent_signup.py register` — live API call succeeded
- [x] `agent_signup.py status` — returned unclaimed restrictions as expected
- [x] TypeScript SDK `getSignupStatus` verified against live API
- [x] `ruff check` passes on the Python script
- [x] Manual: run `verify --code <code>` after receiving the verification email
- [x] Manual: run `send-welcome` and `cleanup` after verify