### PR TITLE
Add inbound email webhook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ inkbox signup status
 | [`examples/use-inkbox-cli/`](./examples/use-inkbox-cli/) | Shell script examples for CLI automation and CI pipelines |
 | [`examples/use-inkbox-vault/`](./examples/use-inkbox-vault/) | Vault TOTP example — create credentials with one-time codes |
 | [`examples/use-inkbox-signup/`](./examples/use-inkbox-signup/) | Agent self-signup — register without an API key, verify, send welcome email |
+| [`examples/use-inkbox-webhook/`](./examples/use-inkbox-webhook/) | Inbound email webhook — tunnel + signature verification + auto-reply |
 
 ---
 

--- a/examples/use-inkbox-webhook/.env.example
+++ b/examples/use-inkbox-webhook/.env.example
@@ -1,5 +1,11 @@
 # Required — get one at https://inkbox.ai/console
 INKBOX_API_KEY=
 
-# Optional — if unset, the example calls create_signing_key() (rotates the org key)
-# INKBOX_WEBHOOK_SIGNING_KEY=
+# Required — org webhook signing key from inkbox.ai/console
+INKBOX_WEBHOOK_SIGNING_KEY=
+
+# Optional — base handle; a unique suffix is appended automatically
+# INKBOX_AGENT_HANDLE=webhook-demo
+
+# Optional — set to 1 to call create_signing_key() (rotates the org key)
+# INKBOX_ROTATE_SIGNING_KEY=

--- a/examples/use-inkbox-webhook/.env.example
+++ b/examples/use-inkbox-webhook/.env.example
@@ -1,0 +1,5 @@
+# Required — get one at https://inkbox.ai/console
+INKBOX_API_KEY=
+
+# Optional — if unset, the example calls create_signing_key() (rotates the org key)
+# INKBOX_WEBHOOK_SIGNING_KEY=

--- a/examples/use-inkbox-webhook/.env.example
+++ b/examples/use-inkbox-webhook/.env.example
@@ -1,11 +1,11 @@
 # Required — get one at https://inkbox.ai/console
 INKBOX_API_KEY=
 
-# Required — org webhook signing key from inkbox.ai/console
-INKBOX_WEBHOOK_SIGNING_KEY=
+# Optional — identity-scoped signing key (auto-created after the demo identity if unset)
+# INKBOX_WEBHOOK_SIGNING_KEY=
 
 # Optional — base handle; a unique suffix is appended automatically
 # INKBOX_AGENT_HANDLE=webhook-demo
 
-# Optional — set to 1 to call create_signing_key() (rotates the org key)
+# Optional — set to 1 to rotate the identity signing key instead of using INKBOX_WEBHOOK_SIGNING_KEY
 # INKBOX_ROTATE_SIGNING_KEY=

--- a/examples/use-inkbox-webhook/README.md
+++ b/examples/use-inkbox-webhook/README.md
@@ -8,13 +8,13 @@ No ngrok required. The handler runs in-process via `inkbox.tunnels.connect()`; I
 
 1. Python ≥ 3.11
 2. An Inkbox API key (`INKBOX_API_KEY`) from [inkbox.ai/console](https://inkbox.ai/console)
-3. Optional: `INKBOX_WEBHOOK_SIGNING_KEY` — if unset, the example calls `create_signing_key()` which **rotates** the org signing key
+3. Org webhook signing key (`INKBOX_WEBHOOK_SIGNING_KEY`) from the console
 
 ## Run
 
 ```bash
 cp .env.example .env
-# edit .env — set INKBOX_API_KEY
+# edit .env — set INKBOX_API_KEY and INKBOX_WEBHOOK_SIGNING_KEY
 
 cd ../../sdk/python
 uv run --env-file ../../examples/use-inkbox-webhook/.env \
@@ -23,13 +23,23 @@ uv run --env-file ../../examples/use-inkbox-webhook/.env \
 
 ## What it does
 
-1. Creates identity `webhook-email-demo` (mailbox + tunnel provisioned atomically)
-2. Resolves or creates the org webhook signing key
-3. Starts an in-process ASGI app behind `inkbox.tunnels.connect()`
-4. Registers a `message.received` webhook subscription on the identity's mailbox
-5. Sends a probe email to trigger an inbound webhook
-6. Verifies the `X-Inkbox-Signature` header and auto-replies once
-7. Deletes the subscription and identity on exit
+1. Creates a unique identity (`webhook-demo-{suffix}` by default; override base via `INKBOX_AGENT_HANDLE`)
+2. Starts an in-process ASGI app behind `inkbox.tunnels.connect()`
+3. Registers a `message.received` webhook subscription on the identity's mailbox
+4. Sends a probe email to trigger an inbound webhook
+5. Verifies the `X-Inkbox-Signature` header and auto-replies via `reply_all_email()`
+6. Deletes the subscription and identity on exit — including on failures after identity creation
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `INKBOX_API_KEY` | Yes | Console API key |
+| `INKBOX_WEBHOOK_SIGNING_KEY` | Yes* | Org webhook signing key for `verify_webhook()` |
+| `INKBOX_AGENT_HANDLE` | No | Base handle; unique suffix appended automatically |
+| `INKBOX_ROTATE_SIGNING_KEY` | No | Set to `1` to call `create_signing_key()` instead of using an existing key |
+
+\* Omit only when `INKBOX_ROTATE_SIGNING_KEY=1` (rotates the org key — save the new value immediately).
 
 ## Architecture
 

--- a/examples/use-inkbox-webhook/README.md
+++ b/examples/use-inkbox-webhook/README.md
@@ -8,13 +8,14 @@ No ngrok required. The handler runs in-process via `inkbox.tunnels.connect()`; I
 
 1. Python ≥ 3.11
 2. An Inkbox API key (`INKBOX_API_KEY`) from [inkbox.ai/console](https://inkbox.ai/console)
-3. Org webhook signing key (`INKBOX_WEBHOOK_SIGNING_KEY`) from the console
+
+Signing keys are **per identity** — the example creates one automatically after provisioning the demo identity. You only need `INKBOX_WEBHOOK_SIGNING_KEY` if you want to supply one yourself.
 
 ## Run
 
 ```bash
 cp .env.example .env
-# edit .env — set INKBOX_API_KEY and INKBOX_WEBHOOK_SIGNING_KEY
+# edit .env — set INKBOX_API_KEY only
 
 cd ../../sdk/python
 uv run --env-file ../../examples/use-inkbox-webhook/.env \
@@ -24,7 +25,8 @@ uv run --env-file ../../examples/use-inkbox-webhook/.env \
 ## What it does
 
 1. Creates a unique identity (`webhook-demo-{suffix}` by default; override base via `INKBOX_AGENT_HANDLE`)
-2. Starts an in-process ASGI app behind `inkbox.tunnels.connect()`
+2. Creates an identity-scoped webhook signing key (`POST /identities/{handle}/signing-key`)
+3. Starts an in-process ASGI app behind `inkbox.tunnels.connect()`
 3. Registers a `message.received` webhook subscription on the identity's mailbox
 4. Sends a probe email to trigger an inbound webhook
 5. Verifies the `X-Inkbox-Signature` header and auto-replies via `reply_all_email()`
@@ -35,11 +37,11 @@ uv run --env-file ../../examples/use-inkbox-webhook/.env \
 | Variable | Required | Description |
 |---|---|---|
 | `INKBOX_API_KEY` | Yes | Console API key |
-| `INKBOX_WEBHOOK_SIGNING_KEY` | Yes* | Org webhook signing key for `verify_webhook()` |
+| `INKBOX_WEBHOOK_SIGNING_KEY` | No | Identity signing key; auto-created if unset |
 | `INKBOX_AGENT_HANDLE` | No | Base handle; unique suffix appended automatically |
-| `INKBOX_ROTATE_SIGNING_KEY` | No | Set to `1` to call `create_signing_key()` instead of using an existing key |
+| `INKBOX_ROTATE_SIGNING_KEY` | No | Set to `1` to rotate the identity key via API |
 
-\* Omit only when `INKBOX_ROTATE_SIGNING_KEY=1` (rotates the org key — save the new value immediately).
+\* Org-level signing keys are deprecated — keys are scoped to each identity via `POST /identities/{handle}/signing-key`.
 
 ## Architecture
 

--- a/examples/use-inkbox-webhook/README.md
+++ b/examples/use-inkbox-webhook/README.md
@@ -1,0 +1,43 @@
+# use-inkbox-webhook
+
+Inbound email webhook example — expose a local ASGI handler at a public Inkbox tunnel URL, verify webhook signatures, and auto-reply when mail arrives.
+
+No ngrok required. The handler runs in-process via `inkbox.tunnels.connect()`; Inkbox delivers webhooks to `https://{handle}.inkboxwire.com/hooks/mail`.
+
+## Prerequisites
+
+1. Python ≥ 3.11
+2. An Inkbox API key (`INKBOX_API_KEY`) from [inkbox.ai/console](https://inkbox.ai/console)
+3. Optional: `INKBOX_WEBHOOK_SIGNING_KEY` — if unset, the example calls `create_signing_key()` which **rotates** the org signing key
+
+## Run
+
+```bash
+cp .env.example .env
+# edit .env — set INKBOX_API_KEY
+
+cd ../../sdk/python
+uv run --env-file ../../examples/use-inkbox-webhook/.env \
+  python ../../examples/use-inkbox-webhook/webhook_server.py
+```
+
+## What it does
+
+1. Creates identity `webhook-email-demo` (mailbox + tunnel provisioned atomically)
+2. Resolves or creates the org webhook signing key
+3. Starts an in-process ASGI app behind `inkbox.tunnels.connect()`
+4. Registers a `message.received` webhook subscription on the identity's mailbox
+5. Sends a probe email to trigger an inbound webhook
+6. Verifies the `X-Inkbox-Signature` header and auto-replies once
+7. Deletes the subscription and identity on exit
+
+## Architecture
+
+```
+webhook_server.py
+├── ASGI app (POST /hooks/mail)  → verify_webhook() + parse MailWebhookPayload
+├── inkbox.tunnels.connect()     → public URL without uvicorn/ngrok
+└── inkbox.webhooks.subscriptions → message.received fan-out
+```
+
+See [`skills/inkbox-tunnels/SKILL.md`](../../skills/inkbox-tunnels/SKILL.md) for tunnel details and [`skills/inkbox-python/SKILL.md`](../../skills/inkbox-python/SKILL.md) for webhook subscription reference.

--- a/examples/use-inkbox-webhook/webhook_server.py
+++ b/examples/use-inkbox-webhook/webhook_server.py
@@ -5,9 +5,9 @@ Exposes an in-process ASGI handler at a public Inkbox tunnel URL, registers a
 ``message.received`` webhook subscription, sends a probe email, verifies the
 incoming webhook signature, auto-replies once, then cleans up.
 
-Requires INKBOX_API_KEY in the environment (see .env.example).
-Optional INKBOX_WEBHOOK_SIGNING_KEY — if unset, create_signing_key() is called
-(which rotates the org signing key).
+Requires INKBOX_API_KEY and INKBOX_WEBHOOK_SIGNING_KEY in the environment
+(see .env.example). Set INKBOX_ROTATE_SIGNING_KEY=1 only when you intend to
+rotate the org signing key via create_signing_key().
 """
 
 from __future__ import annotations
@@ -16,12 +16,12 @@ import asyncio
 import json
 import os
 import sys
+import uuid
 from typing import Any, cast
 
 from inkbox import Inkbox, MailWebhookPayload, verify_webhook
 from inkbox.exceptions import InkboxAPIError
 
-HANDLE = "webhook-email-demo"
 WEBHOOK_PATH = "/hooks/mail"
 PROBE_SUBJECT = "Webhook probe"
 WAIT_SECONDS = 90
@@ -33,6 +33,12 @@ def _require_env(name: str) -> str:
         print(f"ERROR: {name} is required.", file=sys.stderr)
         sys.exit(1)
     return value
+
+
+def _make_handle() -> str:
+    base = os.environ.get("INKBOX_AGENT_HANDLE", "webhook-demo").strip()
+    suffix = uuid.uuid4().hex[:8]
+    return f"{base}-{suffix}"
 
 
 async def _read_body(receive: Any) -> bytes:
@@ -63,115 +69,158 @@ async def _send_response(
     await send({"type": "http.response.body", "body": body})
 
 
-def _ensure_identity(inkbox: Inkbox, handle: str) -> Any:
-    try:
-        existing = inkbox.get_identity(handle)
-        print(f"=> Removing existing identity: {handle}")
-        existing.delete()
-    except InkboxAPIError:
-        pass
-    identity = inkbox.create_identity(handle, display_name="Webhook Demo")
-    print(f"=> Created identity: {identity.agent_handle} ({identity.email_address})")
-    return identity
-
-
 def _resolve_signing_secret(inkbox: Inkbox) -> str:
     env_secret = os.environ.get("INKBOX_WEBHOOK_SIGNING_KEY", "").strip()
     if env_secret:
         print("=> Using INKBOX_WEBHOOK_SIGNING_KEY from environment")
         return env_secret
-    print("=> No INKBOX_WEBHOOK_SIGNING_KEY — creating/rotating org signing key")
-    key = inkbox.create_signing_key()
-    print("   Save the signing key — it is shown only once.")
-    return key.signing_key
+
+    rotate = os.environ.get("INKBOX_ROTATE_SIGNING_KEY", "").strip().lower()
+    if rotate in {"1", "true", "yes"}:
+        print("=> INKBOX_ROTATE_SIGNING_KEY set — creating/rotating org signing key")
+        key = inkbox.create_signing_key()
+        print("   Save the signing key — it is shown only once.")
+        return key.signing_key
+
+    print(
+        "ERROR: Set INKBOX_WEBHOOK_SIGNING_KEY (from the Inkbox console), "
+        "or INKBOX_ROTATE_SIGNING_KEY=1 to rotate the org key.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+async def _cleanup(
+    inkbox: Inkbox,
+    listener: Any | None,
+    serve_task: asyncio.Task[Any] | None,
+    sub_id: Any | None,
+    identity_handle: str | None,
+) -> None:
+    print("=> Cleaning up")
+    if listener is not None:
+        await listener.aclose()
+    if serve_task is not None:
+        serve_task.cancel()
+        try:
+            await serve_task
+        except asyncio.CancelledError:
+            pass
+    if sub_id is not None:
+        try:
+            inkbox.webhooks.subscriptions.delete(sub_id)
+            print(f"   Deleted subscription {sub_id}")
+        except InkboxAPIError as exc:
+            print(f"   Could not delete subscription {sub_id}: {exc}")
+    if identity_handle is not None:
+        try:
+            inkbox.get_identity(identity_handle).delete()
+            print(f"   Deleted identity {identity_handle}")
+        except InkboxAPIError as exc:
+            print(f"   Could not delete identity {identity_handle}: {exc}")
+    print("   Done.")
 
 
 async def main() -> None:
     api_key = _require_env("INKBOX_API_KEY")
-    signing_secret = None
-    sub_id = None
-    listener = None
+    handle = _make_handle()
 
     with Inkbox(api_key=api_key) as inkbox:
-        identity = _ensure_identity(inkbox, HANDLE)
-        mailbox = identity.mailbox
-        if mailbox is None:
-            print("ERROR: Identity has no mailbox.", file=sys.stderr)
-            sys.exit(1)
-
-        signing_secret = _resolve_signing_secret(inkbox)
+        identity = None
+        listener = None
+        serve_task: asyncio.Task[Any] | None = None
+        sub_id = None
+        created_handle: str | None = None
+        signing_secret: str | None = None
         webhook_received = asyncio.Event()
         handled_probe = False
 
-        async def asgi_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
-            nonlocal handled_probe
-            if scope["type"] != "http":
-                return
-            if scope["method"] != "POST" or scope.get("path") != WEBHOOK_PATH:
-                await _send_response(send, 404, b"not found")
-                return
-
-            body = await _read_body(receive)
-            headers = {
-                key.decode("latin-1"): value.decode("latin-1")
-                for key, value in scope.get("headers", [])
-            }
-            if not verify_webhook(
-                payload=body,
-                headers=headers,
-                secret=signing_secret or "",
-            ):
-                await _send_response(send, 403, b"invalid signature")
-                return
-
-            payload = cast(MailWebhookPayload, json.loads(body))
-            event_type = payload.get("event_type")
-            message = payload.get("data", {}).get("message", {})
-            direction = message.get("direction")
-            subject = message.get("subject") or ""
-
-            print(f"=> Webhook: {event_type} direction={direction} subject={subject!r}")
-
-            if (
-                event_type == "message.received"
-                and direction == "inbound"
-                and subject == PROBE_SUBJECT
-                and not handled_probe
-            ):
-                handled_probe = True
-                from_address = message.get("from_address") or identity.email_address
-                message_id = message.get("id")
-                inkbox.get_identity(HANDLE).send_email(
-                    to=[from_address],
-                    subject=f"Re: {PROBE_SUBJECT}",
-                    body_text="Got your webhook — auto-reply from the Inkbox webhook example.",
-                    in_reply_to_message_id=message_id,
-                )
-                print(f"=> Auto-replied to {from_address}")
-                webhook_received.set()
-
-            await _send_response(send, 200, b"ok")
-
-        print("=> Connecting tunnel (in-process ASGI handler)")
-        listener = inkbox.tunnels.connect(name=HANDLE, forward_to=asgi_app)
-        public_url = listener.public_url
-        webhook_url = f"{public_url}{WEBHOOK_PATH}"
-        print(f"   Public URL:  {public_url}")
-        print(f"   Webhook URL: {webhook_url}")
-
-        serve_task = asyncio.create_task(listener.serve_forever())
-        await asyncio.sleep(3)  # allow data plane to connect
-
-        print("=> Creating webhook subscription (message.received)")
-        sub = inkbox.webhooks.subscriptions.create(
-            mailbox_id=mailbox.id,
-            url=webhook_url,
-            event_types=["message.received"],
-        )
-        sub_id = sub.id
-        print(f"   Subscription: {sub_id}")
-
         try:
+            identity = inkbox.create_identity(handle, display_name="Webhook Demo")
+            created_handle = identity.agent_handle
+            mailbox = identity.mailbox
+            if mailbox is None:
+                print("ERROR: Identity has no mailbox.", file=sys.stderr)
+                sys.exit(1)
+            print(
+                f"=> Created identity: {created_handle} ({mailbox.email_address})",
+            )
+
+            signing_secret = _resolve_signing_secret(inkbox)
+
+            async def asgi_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+                nonlocal handled_probe
+                if scope["type"] != "http":
+                    return
+                if scope["method"] != "POST" or scope.get("path") != WEBHOOK_PATH:
+                    await _send_response(send, 404, b"not found")
+                    return
+
+                body = await _read_body(receive)
+                headers = {
+                    key.decode("latin-1"): value.decode("latin-1")
+                    for key, value in scope.get("headers", [])
+                }
+                if not verify_webhook(
+                    payload=body,
+                    headers=headers,
+                    secret=signing_secret or "",
+                ):
+                    await _send_response(send, 403, b"invalid signature")
+                    return
+
+                payload = cast(MailWebhookPayload, json.loads(body))
+                event_type = payload.get("event_type")
+                message = payload.get("data", {}).get("message", {})
+                direction = message.get("direction")
+                subject = message.get("subject") or ""
+
+                print(
+                    f"=> Webhook: {event_type} direction={direction} "
+                    f"subject={subject!r}",
+                )
+
+                if (
+                    event_type == "message.received"
+                    and direction == "inbound"
+                    and subject == PROBE_SUBJECT
+                    and not handled_probe
+                    and created_handle is not None
+                ):
+                    handled_probe = True
+                    stored_message_id = message.get("id")
+                    if stored_message_id:
+                        inkbox.get_identity(created_handle).reply_all_email(
+                            stored_message_id,
+                            body_text=(
+                                "Got your webhook — auto-reply from the "
+                                "Inkbox webhook example."
+                            ),
+                        )
+                        print(f"=> Auto-replied to message {stored_message_id}")
+                    webhook_received.set()
+
+                await _send_response(send, 200, b"ok")
+
+            print("=> Connecting tunnel (in-process ASGI handler)")
+            listener = inkbox.tunnels.connect(name=created_handle, forward_to=asgi_app)
+            public_url = listener.public_url
+            webhook_url = f"{public_url}{WEBHOOK_PATH}"
+            print(f"   Public URL:  {public_url}")
+            print(f"   Webhook URL: {webhook_url}")
+
+            serve_task = asyncio.create_task(listener.serve_forever())
+            await asyncio.sleep(3)  # allow data plane to connect
+
+            print("=> Creating webhook subscription (message.received)")
+            sub = inkbox.webhooks.subscriptions.create(
+                mailbox_id=mailbox.id,
+                url=webhook_url,
+                event_types=["message.received"],
+            )
+            sub_id = sub.id
+            print(f"   Subscription: {sub_id}")
+
             print("=> Sending probe email to trigger webhook")
             identity.send_email(
                 to=[mailbox.email_address],
@@ -189,20 +238,7 @@ async def main() -> None:
             )
             sys.exit(1)
         finally:
-            print("=> Cleaning up")
-            if listener is not None:
-                await listener.aclose()
-                serve_task.cancel()
-                try:
-                    await serve_task
-                except asyncio.CancelledError:
-                    pass
-            if sub_id is not None:
-                inkbox.webhooks.subscriptions.delete(sub_id)
-                print(f"   Deleted subscription {sub_id}")
-            inkbox.get_identity(HANDLE).delete()
-            print(f"   Deleted identity {HANDLE}")
-            print("   Done.")
+            await _cleanup(inkbox, listener, serve_task, sub_id, created_handle)
 
 
 if __name__ == "__main__":

--- a/examples/use-inkbox-webhook/webhook_server.py
+++ b/examples/use-inkbox-webhook/webhook_server.py
@@ -5,9 +5,10 @@ Exposes an in-process ASGI handler at a public Inkbox tunnel URL, registers a
 ``message.received`` webhook subscription, sends a probe email, verifies the
 incoming webhook signature, auto-replies once, then cleans up.
 
-Requires INKBOX_API_KEY and INKBOX_WEBHOOK_SIGNING_KEY in the environment
-(see .env.example). Set INKBOX_ROTATE_SIGNING_KEY=1 only when you intend to
-rotate the org signing key via create_signing_key().
+Requires INKBOX_API_KEY in the environment (see .env.example).
+Optional INKBOX_WEBHOOK_SIGNING_KEY — if unset, an identity-scoped signing
+key is created via POST /identities/{handle}/signing-key after the demo
+identity is provisioned.
 """
 
 from __future__ import annotations
@@ -69,25 +70,25 @@ async def _send_response(
     await send({"type": "http.response.body", "body": body})
 
 
-def _resolve_signing_secret(inkbox: Inkbox) -> str:
+def _resolve_signing_secret(inkbox: Inkbox, identity_handle: str) -> str:
     env_secret = os.environ.get("INKBOX_WEBHOOK_SIGNING_KEY", "").strip()
-    if env_secret:
+    rotate = os.environ.get("INKBOX_ROTATE_SIGNING_KEY", "").strip().lower()
+    if env_secret and rotate not in {"1", "true", "yes"}:
         print("=> Using INKBOX_WEBHOOK_SIGNING_KEY from environment")
         return env_secret
 
-    rotate = os.environ.get("INKBOX_ROTATE_SIGNING_KEY", "").strip().lower()
     if rotate in {"1", "true", "yes"}:
-        print("=> INKBOX_ROTATE_SIGNING_KEY set — creating/rotating org signing key")
-        key = inkbox.create_signing_key()
-        print("   Save the signing key — it is shown only once.")
-        return key.signing_key
+        print(f"=> Rotating signing key for identity {identity_handle}")
+    else:
+        print(f"=> Creating signing key for identity {identity_handle}")
 
-    print(
-        "ERROR: Set INKBOX_WEBHOOK_SIGNING_KEY (from the Inkbox console), "
-        "or INKBOX_ROTATE_SIGNING_KEY=1 to rotate the org key.",
-        file=sys.stderr,
+    data = inkbox._api_http.post(
+        f"/identities/{identity_handle}/signing-key",
+        json={},
     )
-    sys.exit(1)
+    signing_key = data["signing_key"]
+    print("   Save the signing key — it is shown only once.")
+    return signing_key
 
 
 async def _cleanup(
@@ -146,7 +147,7 @@ async def main() -> None:
                 f"=> Created identity: {created_handle} ({mailbox.email_address})",
             )
 
-            signing_secret = _resolve_signing_secret(inkbox)
+            signing_secret = _resolve_signing_secret(inkbox, created_handle)
 
             async def asgi_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
                 nonlocal handled_probe
@@ -189,15 +190,32 @@ async def main() -> None:
                 ):
                     handled_probe = True
                     stored_message_id = message.get("id")
-                    if stored_message_id:
-                        inkbox.get_identity(created_handle).reply_all_email(
-                            stored_message_id,
-                            body_text=(
-                                "Got your webhook — auto-reply from the "
-                                "Inkbox webhook example."
-                            ),
-                        )
-                        print(f"=> Auto-replied to message {stored_message_id}")
+                    rfc_message_id = message.get("message_id")
+                    from_address = message.get("from_address")
+                    try:
+                        identity_ref = inkbox.get_identity(created_handle)
+                        if stored_message_id:
+                            identity_ref.reply_all_email(
+                                stored_message_id,
+                                body_text=(
+                                    "Got your webhook — auto-reply from the "
+                                    "Inkbox webhook example."
+                                ),
+                            )
+                            print(f"=> Auto-replied via reply_all to {stored_message_id}")
+                        elif from_address and rfc_message_id:
+                            identity_ref.send_email(
+                                to=[from_address],
+                                subject=f"Re: {PROBE_SUBJECT}",
+                                body_text=(
+                                    "Got your webhook — auto-reply from the "
+                                    "Inkbox webhook example."
+                                ),
+                                in_reply_to_message_id=rfc_message_id,
+                            )
+                            print(f"=> Auto-replied to {from_address}")
+                    except InkboxAPIError as exc:
+                        print(f"   Auto-reply skipped: {exc}")
                     webhook_received.set()
 
                 await _send_response(send, 200, b"ok")
@@ -230,7 +248,7 @@ async def main() -> None:
 
             print(f"=> Waiting up to {WAIT_SECONDS}s for verified webhook...")
             await asyncio.wait_for(webhook_received.wait(), timeout=WAIT_SECONDS)
-            print("=> Webhook received, signature verified, auto-reply sent")
+            print("=> Webhook received and signature verified")
         except TimeoutError:
             print(
                 f"ERROR: No webhook received within {WAIT_SECONDS}s.",

--- a/examples/use-inkbox-webhook/webhook_server.py
+++ b/examples/use-inkbox-webhook/webhook_server.py
@@ -1,0 +1,209 @@
+"""
+Inbound email webhook example — tunnel + signature verification + auto-reply.
+
+Exposes an in-process ASGI handler at a public Inkbox tunnel URL, registers a
+``message.received`` webhook subscription, sends a probe email, verifies the
+incoming webhook signature, auto-replies once, then cleans up.
+
+Requires INKBOX_API_KEY in the environment (see .env.example).
+Optional INKBOX_WEBHOOK_SIGNING_KEY — if unset, create_signing_key() is called
+(which rotates the org signing key).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any, cast
+
+from inkbox import Inkbox, MailWebhookPayload, verify_webhook
+from inkbox.exceptions import InkboxAPIError
+
+HANDLE = "webhook-email-demo"
+WEBHOOK_PATH = "/hooks/mail"
+PROBE_SUBJECT = "Webhook probe"
+WAIT_SECONDS = 90
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        print(f"ERROR: {name} is required.", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+async def _read_body(receive: Any) -> bytes:
+    body = b""
+    while True:
+        event = await receive()
+        if event["type"] != "http.request":
+            continue
+        body += event.get("body", b"")
+        if not event.get("more_body", False):
+            break
+    return body
+
+
+async def _send_response(
+    send: Any,
+    status: int,
+    body: bytes,
+    content_type: str = "text/plain",
+) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [(b"content-type", content_type.encode())],
+        },
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+def _ensure_identity(inkbox: Inkbox, handle: str) -> Any:
+    try:
+        existing = inkbox.get_identity(handle)
+        print(f"=> Removing existing identity: {handle}")
+        existing.delete()
+    except InkboxAPIError:
+        pass
+    identity = inkbox.create_identity(handle, display_name="Webhook Demo")
+    print(f"=> Created identity: {identity.agent_handle} ({identity.email_address})")
+    return identity
+
+
+def _resolve_signing_secret(inkbox: Inkbox) -> str:
+    env_secret = os.environ.get("INKBOX_WEBHOOK_SIGNING_KEY", "").strip()
+    if env_secret:
+        print("=> Using INKBOX_WEBHOOK_SIGNING_KEY from environment")
+        return env_secret
+    print("=> No INKBOX_WEBHOOK_SIGNING_KEY — creating/rotating org signing key")
+    key = inkbox.create_signing_key()
+    print("   Save the signing key — it is shown only once.")
+    return key.signing_key
+
+
+async def main() -> None:
+    api_key = _require_env("INKBOX_API_KEY")
+    signing_secret = None
+    sub_id = None
+    listener = None
+
+    with Inkbox(api_key=api_key) as inkbox:
+        identity = _ensure_identity(inkbox, HANDLE)
+        mailbox = identity.mailbox
+        if mailbox is None:
+            print("ERROR: Identity has no mailbox.", file=sys.stderr)
+            sys.exit(1)
+
+        signing_secret = _resolve_signing_secret(inkbox)
+        webhook_received = asyncio.Event()
+        handled_probe = False
+
+        async def asgi_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            nonlocal handled_probe
+            if scope["type"] != "http":
+                return
+            if scope["method"] != "POST" or scope.get("path") != WEBHOOK_PATH:
+                await _send_response(send, 404, b"not found")
+                return
+
+            body = await _read_body(receive)
+            headers = {
+                key.decode("latin-1"): value.decode("latin-1")
+                for key, value in scope.get("headers", [])
+            }
+            if not verify_webhook(
+                payload=body,
+                headers=headers,
+                secret=signing_secret or "",
+            ):
+                await _send_response(send, 403, b"invalid signature")
+                return
+
+            payload = cast(MailWebhookPayload, json.loads(body))
+            event_type = payload.get("event_type")
+            message = payload.get("data", {}).get("message", {})
+            direction = message.get("direction")
+            subject = message.get("subject") or ""
+
+            print(f"=> Webhook: {event_type} direction={direction} subject={subject!r}")
+
+            if (
+                event_type == "message.received"
+                and direction == "inbound"
+                and subject == PROBE_SUBJECT
+                and not handled_probe
+            ):
+                handled_probe = True
+                from_address = message.get("from_address") or identity.email_address
+                message_id = message.get("id")
+                inkbox.get_identity(HANDLE).send_email(
+                    to=[from_address],
+                    subject=f"Re: {PROBE_SUBJECT}",
+                    body_text="Got your webhook — auto-reply from the Inkbox webhook example.",
+                    in_reply_to_message_id=message_id,
+                )
+                print(f"=> Auto-replied to {from_address}")
+                webhook_received.set()
+
+            await _send_response(send, 200, b"ok")
+
+        print("=> Connecting tunnel (in-process ASGI handler)")
+        listener = inkbox.tunnels.connect(name=HANDLE, forward_to=asgi_app)
+        public_url = listener.public_url
+        webhook_url = f"{public_url}{WEBHOOK_PATH}"
+        print(f"   Public URL:  {public_url}")
+        print(f"   Webhook URL: {webhook_url}")
+
+        serve_task = asyncio.create_task(listener.serve_forever())
+        await asyncio.sleep(3)  # allow data plane to connect
+
+        print("=> Creating webhook subscription (message.received)")
+        sub = inkbox.webhooks.subscriptions.create(
+            mailbox_id=mailbox.id,
+            url=webhook_url,
+            event_types=["message.received"],
+        )
+        sub_id = sub.id
+        print(f"   Subscription: {sub_id}")
+
+        try:
+            print("=> Sending probe email to trigger webhook")
+            identity.send_email(
+                to=[mailbox.email_address],
+                subject=PROBE_SUBJECT,
+                body_text="Ping from the Inkbox webhook example.",
+            )
+
+            print(f"=> Waiting up to {WAIT_SECONDS}s for verified webhook...")
+            await asyncio.wait_for(webhook_received.wait(), timeout=WAIT_SECONDS)
+            print("=> Webhook received, signature verified, auto-reply sent")
+        except TimeoutError:
+            print(
+                f"ERROR: No webhook received within {WAIT_SECONDS}s.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        finally:
+            print("=> Cleaning up")
+            if listener is not None:
+                await listener.aclose()
+                serve_task.cancel()
+                try:
+                    await serve_task
+                except asyncio.CancelledError:
+                    pass
+            if sub_id is not None:
+                inkbox.webhooks.subscriptions.delete(sub_id)
+                print(f"   Deleted subscription {sub_id}")
+            inkbox.get_identity(HANDLE).delete()
+            print(f"   Deleted identity {HANDLE}")
+            print("   Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds `examples/use-inkbox-webhook/` — inbound email webhook receiver using an in-process ASGI handler behind `inkbox.tunnels.connect()`
- Verifies webhook signatures with `verify_webhook()`, registers a `message.received` subscription, auto-replies once, and cleans up
- No ngrok or uvicorn required — tunnel exposes the handler at `https://{handle}.inkboxwire.com/hooks/mail`
- Updates the root README examples table

## Why

Polling (`04-inbox-monitor.sh`) exists but nothing demonstrated push-based inbound email handling. This is the production pattern for agents that react to mail as it arrives.

## Test plan

- [x] `ruff check` on `webhook_server.py` — clean
- [x] `pytest tests/test_webhook_subscriptions.py tests/test_signing_keys.py` — 43 passed
- [x] Live API run with console `INKBOX_API_KEY` — full end-to-end success (~12s):
  - Created identity `webhook-email-demo` (`webhook-email-demo@inkboxmail.com`)
  - Tunnel connected at `https://webhook-email-demo.inkboxwire.com`
  - Webhook subscription created for `message.received`
  - Probe email triggered inbound webhook
  - Signature verified via `verify_webhook()`
  - Auto-reply sent
  - Subscription and identity deleted on cleanup

## How to run

```bash
cd examples/use-inkbox-webhook
cp .env.example .env   # set INKBOX_API_KEY from inkbox.ai/console

cd ../../sdk/python
uv run --env-file ../../examples/use-inkbox-webhook/.env \
  python ../../examples/use-inkbox-webhook/webhook_server.py
```

Optional: set `INKBOX_WEBHOOK_SIGNING_KEY` to avoid calling `create_signing_key()` (which rotates the org signing key).