### PR TITLE
Webhooks: per-event id + delivery log & replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
+## 0.4.14 — Webhook delivery log
+
+### Added
+
+- **Webhook delivery log + manual replay** in the TypeScript, Python, and Rust SDKs, plus the CLI. Every outbound webhook attempt is logged with its signed request body, the endpoint's response (or transport error), timing, and a replay flag.
+  - SDKs: `inkbox.webhooks.deliveries.list(...)` / `.replay(deliveryId)` (Python `inkbox.webhooks.deliveries`, Rust `inkbox.webhooks().deliveries()`), returning the new `WebhookDelivery` type. `list` filters on subscription, phone number, event type, and 2xx success, with `limit` / `offset` paging.
+  - CLI: `inkbox webhook delivery list` (with `--subscription-id` / `--phone-number-id` / `--event-type` / `--success` / `--failed` / `--limit` / `--offset`) and `inkbox webhook delivery replay <delivery-id>`.
+  - Replay reuses the original envelope `event_id`, so a compliant endpoint dedupes a replay it already processed — it recovers a miss rather than forcing reprocessing. Incoming-call deliveries are logged but not replayable.
+
+### Fixed
+
+- **Rust webhook payloads tolerate a missing `id`.** The per-event `id` added to `MailWebhookPayload` / `TextWebhookPayload` / `IMessageWebhookPayload` in 0.4.13 was a required serde field, so a 0.4.13 Rust consumer hard-failed deserializing any payload without it (an older or mixed-deployment server, or a recorded/mocked payload predating the field). The field is now `#[serde(default)]` — an absent `id` parses to `""`. The TypeScript and Python types were already runtime-tolerant (compile-time-only `interface` / `TypedDict`).
+
 ## 0.4.13 — Webhook event id
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
+## 0.4.13 — Webhook event id
+
+### Added
+
+- **Stable per-event `id` on webhook payloads** in the TypeScript, Python, and Rust SDKs. The mail / text / iMessage webhook envelopes now carry a top-level `id` (`evt_...`) — a stable idempotency key that is the same across the original delivery and any retries or replays. Dedupe on it instead of the per-delivery `X-Inkbox-Request-ID` header. (Incoming-call payloads are flat and keep their own call `id`.)
+
 ## 0.4.12 — Tunnel DX
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.12",
+    "@inkbox/sdk": "^0.4.14",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/webhook.ts
+++ b/cli/src/commands/webhook.ts
@@ -3,7 +3,7 @@ import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
 import { verifyWebhook } from "@inkbox/sdk";
-import type { WebhookSubscription } from "@inkbox/sdk";
+import type { WebhookSubscription, WebhookDelivery } from "@inkbox/sdk";
 
 const WEBHOOK_SUBSCRIPTION_LIST_COLUMNS = [
   "id",
@@ -165,6 +165,101 @@ function registerSubscriptionCommands(parent: Command): void {
     );
 }
 
+const WEBHOOK_DELIVERY_LIST_COLUMNS = [
+  "id",
+  "eventType",
+  "eventId",
+  "url",
+  "responseStatus",
+  "isReplay",
+  "createdAt",
+];
+
+function flattenDeliveryForOutput(d: WebhookDelivery): Record<string, unknown> {
+  return {
+    id: d.id,
+    organizationId: d.organizationId,
+    webhookSubscriptionId: d.webhookSubscriptionId,
+    phoneNumberId: d.phoneNumberId,
+    eventId: d.eventId,
+    eventType: d.eventType,
+    url: d.url,
+    requestPayload: d.requestPayload,
+    responseStatus: d.responseStatus,
+    responseBody: d.responseBody,
+    errorDetail: d.errorDetail,
+    durationMs: d.durationMs,
+    isReplay: d.isReplay,
+    createdAt: d.createdAt,
+  };
+}
+
+function registerDeliveryCommands(parent: Command): void {
+  const delivery = parent
+    .command("delivery")
+    .description("Inspect the webhook delivery log and replay missed deliveries");
+
+  delivery
+    .command("list")
+    .description("List logged webhook delivery attempts, newest first (filters AND-combine)")
+    .option("--subscription-id <id>", "Filter by the targeted subscription id")
+    .option("--phone-number-id <id>", "Filter by phone number id (incoming-call deliveries)")
+    .option("--event-type <type>", "Filter by event type wire value")
+    .option("--success", "Only deliveries with a 2xx response")
+    .option("--failed", "Only deliveries that failed or got no response")
+    .option("--limit <n>", "Page size (1-200, default 50)", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Row offset for pagination", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          subscriptionId?: string;
+          phoneNumberId?: string;
+          eventType?: string;
+          success?: boolean;
+          failed?: boolean;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        if (cmdOpts.success && cmdOpts.failed) {
+          throw new Error("Pass at most one of --success / --failed.");
+        }
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const success = cmdOpts.success
+          ? true
+          : cmdOpts.failed
+            ? false
+            : undefined;
+        const rows = await inkbox.webhooks.deliveries.list({
+          subscriptionId: cmdOpts.subscriptionId,
+          phoneNumberId: cmdOpts.phoneNumberId,
+          eventType: cmdOpts.eventType,
+          success,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows.map(flattenDeliveryForOutput), {
+          json: !!opts.json,
+          columns: WEBHOOK_DELIVERY_LIST_COLUMNS,
+        });
+      }),
+    );
+
+  delivery
+    .command("replay <delivery-id>")
+    .description("Re-deliver a logged event to its subscription's current URL")
+    .action(
+      withErrorHandler(async function (this: Command, deliveryId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const row = await inkbox.webhooks.deliveries.replay(deliveryId);
+        output(flattenDeliveryForOutput(row), { json: !!opts.json });
+      }),
+    );
+}
+
 export function registerWebhookCommands(program: Command): void {
   const webhook = program
     .command("webhook")
@@ -224,4 +319,5 @@ export function registerWebhookCommands(program: Command): void {
     );
 
   registerSubscriptionCommands(webhook);
+  registerDeliveryCommands(webhook);
 }

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -241,6 +241,12 @@ from inkbox.webhook_subscriptions import (
     WebhookSubscriptionStatus,
 )
 
+# Webhook delivery log + replay
+from inkbox.webhook_deliveries import (
+    WebhookDelivery,
+    WebhookDeliveriesResource,
+)
+
 # API keys
 from inkbox.api_keys.types import ApiKey, ApiKeyStatus, CreatedApiKey
 
@@ -440,6 +446,9 @@ __all__ = [
     "WebhookSubscription",
     "WebhookSubscriptionsResource",
     "WebhookSubscriptionStatus",
+    # Webhook deliveries
+    "WebhookDelivery",
+    "WebhookDeliveriesResource",
     # API keys
     "ApiKey",
     "ApiKeyStatus",

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -49,6 +49,7 @@ from inkbox.phone.resources.texts import TextsResource
 from inkbox.phone.resources.transcripts import TranscriptsResource
 from inkbox.signing_keys import SigningKey, SigningKeysResource
 from inkbox.tunnels.resources.tunnels import TunnelsResource
+from inkbox.webhook_deliveries import WebhookDeliveriesResource
 from inkbox.webhook_subscriptions import WebhookSubscriptionsResource
 from inkbox.vault.resources.vault import VaultResource
 from inkbox.whoami.types import WhoamiResponse, _parse_whoami
@@ -67,10 +68,15 @@ class _WebhooksNamespace:
     Single allocation per ``Inkbox`` instance so identity checks
     (``client.webhooks is client.webhooks``) hold.
     """
-    __slots__ = ("subscriptions",)
+    __slots__ = ("subscriptions", "deliveries")
 
-    def __init__(self, subscriptions: WebhookSubscriptionsResource) -> None:
+    def __init__(
+        self,
+        subscriptions: WebhookSubscriptionsResource,
+        deliveries: WebhookDeliveriesResource,
+    ) -> None:
         self.subscriptions = subscriptions
+        self.deliveries = deliveries
 
 
 class Inkbox:
@@ -225,7 +231,11 @@ class Inkbox:
 
         self._signing_keys = SigningKeysResource(self._api_http)
         self._webhook_subscriptions = WebhookSubscriptionsResource(self._api_http)
-        self._webhooks = _WebhooksNamespace(self._webhook_subscriptions)
+        self._webhook_deliveries = WebhookDeliveriesResource(self._api_http)
+        self._webhooks = _WebhooksNamespace(
+            self._webhook_subscriptions,
+            self._webhook_deliveries,
+        )
         self._api_keys = ApiKeysResource(self._api_http)
         self._ids_resource = IdentitiesResource(self._ids_http)
 
@@ -355,13 +365,14 @@ class Inkbox:
 
     @property
     def webhooks(self) -> "_WebhooksNamespace":
-        """Webhook subscription management.
+        """Webhook subscription management and delivery log.
 
         Use ``inkbox.webhooks.subscriptions`` to attach HTTPS receivers
-        to mail (``message.*``) or phone-text (``text.*``) events.
-        Incoming-call webhooks still live on the phone-number resource
-        (``incoming_call_webhook_url``) because the response body
-        controls call routing.
+        to mail (``message.*``) or phone-text (``text.*``) events, and
+        ``inkbox.webhooks.deliveries`` to inspect logged delivery
+        attempts and replay missed ones. Incoming-call webhooks still
+        live on the phone-number resource (``incoming_call_webhook_url``)
+        because the response body controls call routing.
         """
         return self._webhooks
 

--- a/sdk/python/inkbox/webhook_deliveries.py
+++ b/sdk/python/inkbox/webhook_deliveries.py
@@ -1,0 +1,140 @@
+"""
+inkbox/webhook_deliveries.py
+
+Webhook delivery log + manual replay.
+
+Every outbound webhook attempt is recorded as a delivery row: the signed
+request body that was sent, the endpoint's HTTP response (or transport
+error), and timing. Use ``list`` to inspect what was (or was not)
+delivered, and ``replay`` to re-deliver a logged event to its
+subscription's current URL.
+
+Replay reuses the original envelope ``event_id``, so it only recovers a
+*miss*: a compliant endpoint that already processed the original event
+dedupes the replay away. It does not force reprocessing. Incoming-call
+deliveries (which have a ``phone_number_id`` and no
+``webhook_subscription_id``) are logged but not replayable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from inkbox._http import HttpTransport
+
+
+_BASE = "/webhooks/deliveries"
+
+
+@dataclass
+class WebhookDelivery:
+    """One logged outbound webhook delivery attempt.
+
+    ``webhook_subscription_id`` is populated for subscription deliveries
+    and ``None`` for incoming-call deliveries (which instead carry
+    ``phone_number_id``). ``organization_id`` is an ``"org_..."`` token
+    string, not a UUID. ``request_payload`` is the raw signed request
+    body that was delivered. ``response_status`` / ``response_body`` are
+    ``None`` on transport failure (in which case ``error_detail`` is
+    set). ``is_replay`` is ``True`` for rows produced by ``replay``.
+    """
+
+    id: UUID
+    organization_id: str
+    webhook_subscription_id: UUID | None
+    phone_number_id: UUID | None
+    event_id: str
+    event_type: str
+    url: str
+    request_payload: str
+    response_status: int | None
+    response_body: str | None
+    error_detail: str | None
+    duration_ms: int | None
+    is_replay: bool
+    created_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> WebhookDelivery:
+        return cls(
+            id=UUID(d["id"]),
+            organization_id=d["organization_id"],
+            webhook_subscription_id=(
+                UUID(d["webhook_subscription_id"])
+                if d.get("webhook_subscription_id")
+                else None
+            ),
+            phone_number_id=(
+                UUID(d["phone_number_id"]) if d.get("phone_number_id") else None
+            ),
+            event_id=d["event_id"],
+            event_type=d["event_type"],
+            url=d["url"],
+            request_payload=d["request_payload"],
+            response_status=d.get("response_status"),
+            response_body=d.get("response_body"),
+            error_detail=d.get("error_detail"),
+            duration_ms=d.get("duration_ms"),
+            is_replay=d["is_replay"],
+            created_at=datetime.fromisoformat(d["created_at"]),
+        )
+
+
+def _uuid_str(value: UUID | str) -> str:
+    return str(value)
+
+
+class WebhookDeliveriesResource:
+
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def list(
+        self,
+        *,
+        subscription_id: UUID | str | None = None,
+        phone_number_id: UUID | str | None = None,
+        event_type: str | None = None,
+        success: bool | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[WebhookDelivery]:
+        """List logged webhook delivery attempts, newest first.
+
+        Filters AND-combine. ``subscription_id`` scopes to one
+        subscription's deliveries; ``phone_number_id`` scopes to a phone
+        number's incoming-call deliveries. ``success`` filters on a 2xx
+        response (``True`` -> delivered, ``False`` -> failed or no
+        response). ``limit`` is clamped to ``[1, 200]`` by the API
+        (default 50); ``offset`` paginates.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if subscription_id is not None:
+            params["subscription_id"] = _uuid_str(subscription_id)
+        if phone_number_id is not None:
+            params["phone_number_id"] = _uuid_str(phone_number_id)
+        if event_type is not None:
+            params["event_type"] = event_type
+        if success is not None:
+            params["success"] = success
+        data = self._http.get(_BASE, params=params)
+        return [WebhookDelivery._from_dict(d) for d in data["deliveries"]]
+
+    def replay(self, delivery_id: UUID | str) -> WebhookDelivery:
+        """Re-deliver a logged event to its subscription's current URL.
+
+        Reuses the original envelope ``event_id`` (so a compliant
+        endpoint dedupes a replay it already processed) but re-signs with
+        a fresh request-id/timestamp, and records a new delivery row with
+        ``is_replay=True`` -- which is what this returns.
+
+        Raises if the delivery is an incoming-call row (not replayable,
+        422), or if its subscription is no longer active or no longer
+        subscribes to the event type (409).
+        """
+        data = self._http.post(f"{_BASE}/{_uuid_str(delivery_id)}/replay")
+        return WebhookDelivery._from_dict(data)

--- a/sdk/python/inkbox/webhooks.py
+++ b/sdk/python/inkbox/webhooks.py
@@ -207,6 +207,7 @@ class MailWebhookData(TypedDict):
 
 
 class MailWebhookPayload(TypedDict):
+    id: str  # stable per-event id (evt_...); idempotency key, stable across replays
     event_type: MailWebhookEventType
     timestamp: str
     data: MailWebhookData
@@ -271,6 +272,7 @@ class TextWebhookData(TypedDict):
 
 
 class TextWebhookPayload(TypedDict):
+    id: str  # stable per-event id (evt_...); idempotency key, stable across replays
     event_type: TextWebhookEventType
     timestamp: str
     data: TextWebhookData
@@ -432,6 +434,7 @@ class IMessageWebhookData(TypedDict):
 
 
 class IMessageWebhookPayload(TypedDict):
+    id: str  # stable per-event id (evt_...); idempotency key, stable across replays
     event_type: IMessageWebhookEventType
     timestamp: str
     data: IMessageWebhookData

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.12"
+version = "0.4.13"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.14"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.12"
+version = "0.4.14"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -44,6 +44,7 @@ use crate::phone::resources::transcripts::TranscriptsResource;
 use crate::signing_keys::{SigningKey, SigningKeysResource};
 use crate::tunnels::resources::tunnels::TunnelsResource;
 use crate::vault::resources::vault::VaultResource;
+use crate::webhooks::deliveries::WebhookDeliveriesResource;
 use crate::webhooks::subscriptions::WebhookSubscriptionsResource;
 use crate::whoami::types::{parse_whoami, WhoamiResponse};
 
@@ -134,6 +135,7 @@ pub struct Inkbox {
     // Org-level
     signing_keys: SigningKeysResource,
     webhook_subscriptions: WebhookSubscriptionsResource,
+    webhook_deliveries: WebhookDeliveriesResource,
     api_keys: ApiKeysResource,
     identities: IdentitiesResource,
     tunnels: TunnelsResource,
@@ -247,6 +249,7 @@ impl Inkbox {
 
             signing_keys: SigningKeysResource::new(api_http.clone()),
             webhook_subscriptions: WebhookSubscriptionsResource::new(api_http.clone()),
+            webhook_deliveries: WebhookDeliveriesResource::new(api_http.clone()),
             api_keys: ApiKeysResource::new(api_http.clone()),
             identities: IdentitiesResource::new(ids_http.clone()),
             tunnels: TunnelsResource::new(api_http.clone(), weak.clone()),
@@ -333,10 +336,12 @@ impl Inkbox {
         &self.tunnels
     }
 
-    /// Webhook subscription management (`inkbox.webhooks().subscriptions()`).
+    /// Webhook subscription management and delivery log
+    /// (`inkbox.webhooks().subscriptions()` / `inkbox.webhooks().deliveries()`).
     pub fn webhooks(&self) -> WebhooksNamespace<'_> {
         WebhooksNamespace {
             subscriptions: &self.webhook_subscriptions,
+            deliveries: &self.webhook_deliveries,
         }
     }
 
@@ -517,14 +522,20 @@ impl Inkbox {
     }
 }
 
-/// Typed namespace for `inkbox.webhooks().subscriptions()`.
+/// Typed namespace for `inkbox.webhooks().subscriptions()` and
+/// `inkbox.webhooks().deliveries()`.
 pub struct WebhooksNamespace<'a> {
     subscriptions: &'a WebhookSubscriptionsResource,
+    deliveries: &'a WebhookDeliveriesResource,
 }
 
 impl<'a> WebhooksNamespace<'a> {
     pub fn subscriptions(&self) -> &'a WebhookSubscriptionsResource {
         self.subscriptions
+    }
+
+    pub fn deliveries(&self) -> &'a WebhookDeliveriesResource {
+        self.deliveries
     }
 }
 

--- a/sdk/rust/src/webhooks/deliveries.rs
+++ b/sdk/rust/src/webhooks/deliveries.rs
@@ -1,0 +1,152 @@
+//! Webhook delivery log + manual replay.
+//!
+//! Every outbound webhook attempt is recorded as a delivery row: the signed
+//! request body that was sent, the endpoint's HTTP response (or transport
+//! error), and timing. Use [`WebhookDeliveriesResource::list`] to inspect what
+//! was (or was not) delivered, and [`WebhookDeliveriesResource::replay`] to
+//! re-deliver a logged event to its subscription's current URL.
+//!
+//! Replay reuses the original envelope `event_id`, so it only recovers a
+//! *miss*: a compliant endpoint that already processed the original event
+//! dedupes the replay away. It does not force reprocessing. Incoming-call
+//! deliveries (which carry a `phone_number_id` and no `webhook_subscription_id`)
+//! are logged but not replayable.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::http::HttpTransport;
+
+const BASE: &str = "/webhooks/deliveries";
+
+/// One logged outbound webhook delivery attempt.
+///
+/// `webhook_subscription_id` is populated for subscription deliveries and
+/// `None` for incoming-call deliveries (which instead carry `phone_number_id`).
+/// `organization_id` is an `"org_..."` token string, not a UUID.
+/// `request_payload` is the raw signed request body that was delivered.
+/// `response_status` / `response_body` are `None` on transport failure (in which
+/// case `error_detail` is set). `is_replay` is `true` for rows produced by
+/// [`WebhookDeliveriesResource::replay`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookDelivery {
+    pub id: Uuid,
+    pub organization_id: String,
+    #[serde(default)]
+    pub webhook_subscription_id: Option<Uuid>,
+    #[serde(default)]
+    pub phone_number_id: Option<Uuid>,
+    pub event_id: String,
+    pub event_type: String,
+    pub url: String,
+    pub request_payload: String,
+    #[serde(default)]
+    pub response_status: Option<i32>,
+    #[serde(default)]
+    pub response_body: Option<String>,
+    #[serde(default)]
+    pub error_detail: Option<String>,
+    #[serde(default)]
+    pub duration_ms: Option<i64>,
+    pub is_replay: bool,
+    // ISO 8601 timestamp string (the contract keeps ISO strings as `String`).
+    pub created_at: String,
+}
+
+/// Envelope for the `list` response.
+#[derive(Debug, Deserialize)]
+struct ListResponse {
+    deliveries: Vec<WebhookDelivery>,
+}
+
+/// Webhook delivery-log + replay resource.
+pub struct WebhookDeliveriesResource {
+    http: Arc<HttpTransport>,
+}
+
+impl WebhookDeliveriesResource {
+    pub fn new(http: Arc<HttpTransport>) -> Self {
+        Self { http }
+    }
+
+    /// List logged webhook delivery attempts, newest first.
+    ///
+    /// Filters AND-combine. `subscription_id` scopes to one subscription's
+    /// deliveries; `phone_number_id` scopes to a phone number's incoming-call
+    /// deliveries. `success` filters on a 2xx response (`Some(true)` ->
+    /// delivered, `Some(false)` -> failed or no response). `limit` is clamped to
+    /// `[1, 200]` by the API (default 50); `offset` paginates.
+    ///
+    /// # Arguments
+    /// * `subscription_id` - optional subscription UUID filter.
+    /// * `phone_number_id` - optional phone-number UUID filter.
+    /// * `event_type` - optional single event-type filter.
+    /// * `success` - optional 2xx-response filter.
+    /// * `limit` - page size; `None` uses the API default of 50.
+    /// * `offset` - row offset; `None` starts at 0.
+    ///
+    /// # Returns
+    /// The matching delivery rows.
+    pub fn list(
+        &self,
+        subscription_id: Option<Uuid>,
+        phone_number_id: Option<Uuid>,
+        event_type: Option<&str>,
+        success: Option<bool>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<WebhookDelivery>> {
+        // Build the query, omitting any filter the caller left as `None`.
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(id) = subscription_id {
+            params.push(("subscription_id", id.to_string()));
+        }
+        if let Some(id) = phone_number_id {
+            params.push(("phone_number_id", id.to_string()));
+        }
+        if let Some(e) = event_type {
+            params.push(("event_type", e.to_string()));
+        }
+        if let Some(s) = success {
+            params.push(("success", s.to_string()));
+        }
+        if let Some(l) = limit {
+            params.push(("limit", l.to_string()));
+        }
+        if let Some(o) = offset {
+            params.push(("offset", o.to_string()));
+        }
+        let data = self.http.get(BASE, &params)?;
+        let parsed: ListResponse = serde_json::from_value(data)?;
+        Ok(parsed.deliveries)
+    }
+
+    /// Re-deliver a logged event to its subscription's current URL.
+    ///
+    /// Reuses the original envelope `event_id` (so a compliant endpoint dedupes
+    /// a replay it already processed) but re-signs with a fresh
+    /// request-id/timestamp, and records a new delivery row with
+    /// `is_replay = true` -- which is what this returns.
+    ///
+    /// Errors if the delivery is an incoming-call row (not replayable, 422), or
+    /// if its subscription is no longer active or no longer subscribes to the
+    /// event type (409).
+    ///
+    /// # Arguments
+    /// * `delivery_id` - the logged delivery row to replay.
+    ///
+    /// # Returns
+    /// The new replay delivery row.
+    pub fn replay(&self, delivery_id: Uuid) -> Result<WebhookDelivery> {
+        // No request body; annotate `B` since `None` can't infer it.
+        let data = self.http.post::<serde_json::Value>(
+            &format!("{BASE}/{delivery_id}/replay"),
+            None,
+            crate::http::NO_QUERY,
+        )?;
+        Ok(serde_json::from_value(data)?)
+    }
+}

--- a/sdk/rust/src/webhooks/mod.rs
+++ b/sdk/rust/src/webhooks/mod.rs
@@ -1,16 +1,19 @@
 //! Webhooks domain: receiver-side payload types and subscription CRUD.
 //!
-//! Faithful port of `inkbox/webhooks.py` (payload types) and
-//! `inkbox/webhook_subscriptions.py` (subscription resource). The wire shape
+//! Faithful port of `inkbox/webhooks.py` (payload types),
+//! `inkbox/webhook_subscriptions.py` (subscription resource), and
+//! `inkbox/webhook_deliveries.py` (delivery log + replay). The wire shape
 //! (JSON field names, enum string values, request bodies, query params, paths)
 //! matches the Python and TypeScript SDKs exactly.
 //!
 //! Signing keys and `verify_webhook` live in the top-level
 //! [`crate::signing_keys`] module, mirroring `inkbox/signing_keys.py`.
 
+pub mod deliveries;
 pub mod subscriptions;
 pub mod types;
 
+pub use deliveries::{WebhookDeliveriesResource, WebhookDelivery};
 pub use subscriptions::{
     WebhookSubscription, WebhookSubscriptionStatus, WebhookSubscriptionsResource,
 };

--- a/sdk/rust/src/webhooks/types.rs
+++ b/sdk/rust/src/webhooks/types.rs
@@ -249,6 +249,8 @@ pub struct MailWebhookData {
 /// Top-level mail webhook payload (`{event_type, timestamp, data}` envelope).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MailWebhookPayload {
+    /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    pub id: String,
     pub event_type: MailWebhookEventType,
     pub timestamp: String,
     pub data: MailWebhookData,
@@ -320,6 +322,8 @@ pub struct TextWebhookData {
 /// Top-level phone-text webhook payload (`{event_type, timestamp, data}`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextWebhookPayload {
+    /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    pub id: String,
     pub event_type: TextWebhookEventType,
     pub timestamp: String,
     pub data: TextWebhookData,
@@ -516,6 +520,8 @@ pub struct IMessageWebhookData {
 /// Top-level iMessage webhook payload (`{event_type, timestamp, data}`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IMessageWebhookPayload {
+    /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    pub id: String,
     pub event_type: IMessageWebhookEventType,
     pub timestamp: String,
     pub data: IMessageWebhookData,

--- a/sdk/rust/src/webhooks/types.rs
+++ b/sdk/rust/src/webhooks/types.rs
@@ -250,6 +250,10 @@ pub struct MailWebhookData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MailWebhookPayload {
     /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    // `serde(default)` so payloads that predate this field (older or
+    // mixed-deployment servers, recorded fixtures) still deserialize instead of
+    // hard-failing on a missing field; an absent id parses to "".
+    #[serde(default)]
     pub id: String,
     pub event_type: MailWebhookEventType,
     pub timestamp: String,
@@ -323,6 +327,10 @@ pub struct TextWebhookData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextWebhookPayload {
     /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    // `serde(default)` so payloads that predate this field (older or
+    // mixed-deployment servers, recorded fixtures) still deserialize instead of
+    // hard-failing on a missing field; an absent id parses to "".
+    #[serde(default)]
     pub id: String,
     pub event_type: TextWebhookEventType,
     pub timestamp: String,
@@ -521,6 +529,10 @@ pub struct IMessageWebhookData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IMessageWebhookPayload {
     /// Stable per-event id (`evt_...`); idempotency key, stable across replays.
+    // `serde(default)` so payloads that predate this field (older or
+    // mixed-deployment servers, recorded fixtures) still deserialize instead of
+    // hard-failing on a missing field; an absent id parses to "".
+    #[serde(default)]
     pub id: String,
     pub event_type: IMessageWebhookEventType,
     pub timestamp: String,

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -76,6 +76,11 @@ export type {
   ListWebhookSubscriptionsOptions,
 } from "./webhooks/subscriptions.js";
 export type { WebhookSubscriptionsResource } from "./webhooks/subscriptions.js";
+export type {
+  WebhookDelivery,
+  ListWebhookDeliveriesOptions,
+} from "./webhooks/deliveries.js";
+export type { WebhookDeliveriesResource } from "./webhooks/deliveries.js";
 // Snake_case wire shapes referenced by the webhook payload types above.
 // Re-exported from the root entry because package.json#exports only
 // publishes `"."` and `"./tunnels/connect"` — deep imports of

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -16,6 +16,7 @@ import { DomainsResource } from "./mail/resources/domains.js";
 import { SigningKeysResource } from "./signing_keys.js";
 import type { SigningKey } from "./signing_keys.js";
 import { WebhookSubscriptionsResource } from "./webhooks/subscriptions.js";
+import { WebhookDeliveriesResource } from "./webhooks/deliveries.js";
 import { IMessagesResource } from "./imessage/resources/imessages.js";
 import { IMessageContactRulesResource } from "./imessage/resources/contactRules.js";
 import { PhoneNumbersResource } from "./phone/resources/numbers.js";
@@ -128,7 +129,11 @@ export class Inkbox {
   readonly _domains: DomainsResource;
   readonly _signingKeys: SigningKeysResource;
   readonly _webhookSubscriptions: WebhookSubscriptionsResource;
-  private readonly _webhooks: { readonly subscriptions: WebhookSubscriptionsResource };
+  readonly _webhookDeliveries: WebhookDeliveriesResource;
+  private readonly _webhooks: {
+    readonly subscriptions: WebhookSubscriptionsResource;
+    readonly deliveries: WebhookDeliveriesResource;
+  };
   readonly _numbers: PhoneNumbersResource;
   readonly _calls: CallsResource;
   readonly _texts: TextsResource;
@@ -195,7 +200,11 @@ export class Inkbox {
     this._domains          = new DomainsResource(domainsHttp);
     this._signingKeys      = new SigningKeysResource(apiHttp);
     this._webhookSubscriptions = new WebhookSubscriptionsResource(apiHttp);
-    this._webhooks = Object.freeze({ subscriptions: this._webhookSubscriptions });
+    this._webhookDeliveries = new WebhookDeliveriesResource(apiHttp);
+    this._webhooks = Object.freeze({
+      subscriptions: this._webhookSubscriptions,
+      deliveries: this._webhookDeliveries,
+    });
 
     this._numbers          = new PhoneNumbersResource(phoneHttp);
     this._calls            = new CallsResource(phoneHttp);
@@ -312,14 +321,18 @@ export class Inkbox {
   get apiKeys(): ApiKeysResource { return this._apiKeys; }
 
   /**
-   * Webhook subscription management. Use `inkbox.webhooks.subscriptions`
-   * to attach HTTPS receivers to mail (`message.*`), phone-text
-   * (`text.*`), or iMessage (`imessage.*`) events. Incoming-call
-   * webhooks still live on the phone-number resource
-   * (`incomingCallWebhookUrl`) because the response body controls call
-   * routing.
+   * Webhook subscription management and delivery log. Use
+   * `inkbox.webhooks.subscriptions` to attach HTTPS receivers to mail
+   * (`message.*`), phone-text (`text.*`), or iMessage (`imessage.*`)
+   * events, and `inkbox.webhooks.deliveries` to inspect logged delivery
+   * attempts and replay missed ones. Incoming-call webhooks still live
+   * on the phone-number resource (`incomingCallWebhookUrl`) because the
+   * response body controls call routing.
    */
-  get webhooks(): { readonly subscriptions: WebhookSubscriptionsResource } {
+  get webhooks(): {
+    readonly subscriptions: WebhookSubscriptionsResource;
+    readonly deliveries: WebhookDeliveriesResource;
+  } {
     return this._webhooks;
   }
 

--- a/sdk/typescript/src/webhooks/deliveries.ts
+++ b/sdk/typescript/src/webhooks/deliveries.ts
@@ -1,0 +1,138 @@
+/**
+ * Webhook delivery log + manual replay.
+ *
+ * Every outbound webhook attempt is recorded as a delivery row: the
+ * signed request body that was sent, the endpoint's HTTP response (or
+ * transport error), and timing. Use `list` to inspect what was (or was
+ * not) delivered, and `replay` to re-deliver a logged event to its
+ * subscription's current URL.
+ *
+ * Replay reuses the original envelope `eventId`, so it only recovers a
+ * *miss*: a compliant endpoint that already processed the original event
+ * dedupes the replay away. It does not force reprocessing. Incoming-call
+ * deliveries (which carry a `phoneNumberId` and no
+ * `webhookSubscriptionId`) are logged but not replayable.
+ */
+
+import { HttpTransport } from "../_http.js";
+
+const PATH = "/webhooks/deliveries";
+
+export interface WebhookDelivery {
+  id: string;
+  /** `"org_..."` token; not a UUID. */
+  organizationId: string;
+  /** Subscription this delivery targeted; null for incoming-call deliveries. */
+  webhookSubscriptionId: string | null;
+  /** Phone number for incoming-call deliveries (which have no subscription). */
+  phoneNumberId: string | null;
+  /** Envelope event id (`evt_...`), or the call id for incoming-call rows. */
+  eventId: string;
+  eventType: string;
+  url: string;
+  /** Raw signed request body that was delivered. */
+  requestPayload: string;
+  /** HTTP status returned by the endpoint; null on transport failure. */
+  responseStatus: number | null;
+  /** Truncated response body snippet. */
+  responseBody: string | null;
+  /** Transport error summary, if any. */
+  errorDetail: string | null;
+  durationMs: number | null;
+  /** True if this row was produced by a manual replay. */
+  isReplay: boolean;
+  createdAt: Date;
+}
+
+export interface RawWebhookDelivery {
+  id: string;
+  organization_id: string;
+  webhook_subscription_id: string | null;
+  phone_number_id: string | null;
+  event_id: string;
+  event_type: string;
+  url: string;
+  request_payload: string;
+  response_status: number | null;
+  response_body: string | null;
+  error_detail: string | null;
+  duration_ms: number | null;
+  is_replay: boolean;
+  created_at: string;
+}
+
+interface RawListWebhookDeliveriesResponse {
+  deliveries: RawWebhookDelivery[];
+}
+
+export function parseWebhookDelivery(r: RawWebhookDelivery): WebhookDelivery {
+  return {
+    id: r.id,
+    organizationId: r.organization_id,
+    webhookSubscriptionId: r.webhook_subscription_id,
+    phoneNumberId: r.phone_number_id,
+    eventId: r.event_id,
+    eventType: r.event_type,
+    url: r.url,
+    requestPayload: r.request_payload,
+    responseStatus: r.response_status,
+    responseBody: r.response_body,
+    errorDetail: r.error_detail,
+    durationMs: r.duration_ms,
+    isReplay: r.is_replay,
+    createdAt: new Date(r.created_at),
+  };
+}
+
+export interface ListWebhookDeliveriesOptions {
+  subscriptionId?: string;
+  phoneNumberId?: string;
+  eventType?: string;
+  /** Filter on a 2xx response: `true` → delivered, `false` → failed or no response. */
+  success?: boolean;
+  /** Clamped to `[1, 200]` by the API (default 50). */
+  limit?: number;
+  offset?: number;
+}
+
+export class WebhookDeliveriesResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  /**
+   * List logged webhook delivery attempts, newest first. Filters
+   * AND-combine. `subscriptionId` scopes to one subscription's
+   * deliveries; `phoneNumberId` scopes to a phone number's incoming-call
+   * deliveries. `success` filters on a 2xx response.
+   */
+  async list(
+    filters: ListWebhookDeliveriesOptions = {},
+  ): Promise<WebhookDelivery[]> {
+    const params: Record<string, string> = {};
+    if (filters.subscriptionId !== undefined) params["subscription_id"] = filters.subscriptionId;
+    if (filters.phoneNumberId !== undefined) params["phone_number_id"] = filters.phoneNumberId;
+    if (filters.eventType !== undefined) params["event_type"] = filters.eventType;
+    if (filters.success !== undefined) params["success"] = String(filters.success);
+    if (filters.limit !== undefined) params["limit"] = String(filters.limit);
+    if (filters.offset !== undefined) params["offset"] = String(filters.offset);
+    const data = await this.http.get<RawListWebhookDeliveriesResponse>(PATH, params);
+    return data.deliveries.map(parseWebhookDelivery);
+  }
+
+  /**
+   * Re-deliver a logged event to its subscription's current URL. Reuses
+   * the original envelope `eventId` (so a compliant endpoint dedupes a
+   * replay it already processed) but re-signs with a fresh
+   * request-id/timestamp, and records a new delivery row with
+   * `isReplay: true` — which is what this returns.
+   *
+   * Rejects incoming-call deliveries (not replayable, 422) and
+   * deliveries whose subscription is no longer active or no longer
+   * subscribes to the event type (409).
+   */
+  async replay(deliveryId: string): Promise<WebhookDelivery> {
+    const data = await this.http.post<RawWebhookDelivery>(
+      `${PATH}/${deliveryId}/replay`,
+    );
+    return parseWebhookDelivery(data);
+  }
+}

--- a/sdk/typescript/src/webhooks/index.ts
+++ b/sdk/typescript/src/webhooks/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./types.js";
 export * from "./subscriptions.js";
+export * from "./deliveries.js";

--- a/sdk/typescript/src/webhooks/types.ts
+++ b/sdk/typescript/src/webhooks/types.ts
@@ -151,6 +151,8 @@ export interface MailWebhookMessage {
 }
 
 export interface MailWebhookPayload {
+  /** Stable per-event id (`evt_...`); idempotency key, stable across replays. */
+  id: string;
   event_type: MailWebhookEventType;
   /** ISO 8601 datetime. */
   timestamp: string;
@@ -231,6 +233,8 @@ export interface TextWebhookMessage {
 }
 
 export interface TextWebhookPayload {
+  /** Stable per-event id (`evt_...`); idempotency key, stable across replays. */
+  id: string;
   event_type: TextWebhookEventType;
   timestamp: string;
   data: {
@@ -382,6 +386,8 @@ export interface IMessageWebhookReaction {
 }
 
 export interface IMessageWebhookPayload {
+  /** Stable per-event id (`evt_...`); idempotency key, stable across replays. */
+  id: string;
   event_type: IMessageWebhookEventType;
   /** ISO 8601 datetime. */
   timestamp: string;


### PR DESCRIPTION
## Webhooks: per-event `id` + delivery log & replay

Two webhook changes to the SDKs (Python / TypeScript / Rust) and CLI, tracking the `servers#webhooks` backend. Shipped lockstep as **0.4.14**.

### 1. Stable per-event `id` (`evt_…`)

Surfaces the new top-level `id` on the mail / text / iMessage webhook payload types so consumers can dedupe on it. Use `id` as the **idempotency key** — it's stable across retries and replays — whereas `X-Inkbox-Request-ID` is per-delivery.

- **Python:** `id: str` on the `MailWebhookPayload` / `TextWebhookPayload` / `IMessageWebhookPayload` TypedDicts.
- **TypeScript:** `id: string` on the corresponding interfaces.
- **Rust:** `id: String` on the corresponding structs, marked `#[serde(default)]` so a missing field deserializes to `""` instead of hard-failing.
- Incoming-call payload types are unchanged (flat, already carry a call `id`).

> **Why `#[serde(default)]` on the Rust field:** unlike the Python `TypedDict` / TS `interface` (compile-time only — `json.loads` / `JSON.parse` don't enforce them), serde's derived `Deserialize` treats a bare `id: String` as **required**, so a consumer would hard-fail parsing any payload without it (an older or mixed-deployment server, or a recorded/mocked fixture predating the field). The `default` keeps the public type `String` (no source break, parity with Python `str` / TS `string`) while tolerating absence.

### 2. Delivery log + manual replay (new)

Every outbound webhook attempt is logged (signed request body, endpoint response or transport error, timing, replay flag). New resource to inspect the log and replay a missed delivery to its subscription's current URL.

- **SDKs:** `inkbox.webhooks.deliveries.list(...)` / `.replay(deliveryId)` (Python `inkbox.webhooks.deliveries`, Rust `inkbox.webhooks().deliveries()`), returning a new `WebhookDelivery` type. `list` filters on subscription / phone number / event type / 2xx success, with `limit` + `offset` paging.
- **CLI:** `inkbox webhook delivery list` (`--subscription-id` / `--phone-number-id` / `--event-type` / `--success` / `--failed` / `--limit` / `--offset`) and `inkbox webhook delivery replay <delivery-id>`.
- **Replay semantics:** reuses the original envelope `event_id`, so a compliant endpoint dedupes a replay it already processed — it recovers a *miss* rather than forcing reprocessing. Incoming-call deliveries are logged but **not replayable**.

### Versioning

- Python / TypeScript / Rust SDKs + CLI bumped to **0.4.14** in lockstep.
- Fixed the CLI's `@inkbox/sdk` dependency pin (was `^0.4.12`, now `^0.4.14`) and brought the stale Rust `Cargo.lock` in line.

### Backward compatibility

**Additive.** Existing code ignores the new `id` field until upgraded; the server already sends it. The new `deliveries` resource is purely additive. With the Rust `#[serde(default)]` fix above, payload deserialization no longer regresses against older or mixed-deployment servers in any of the three SDKs.

### Notes for reviewers

- **Docs** (delivery-log API reference + guide updates) land in the separate **website** repo PR.
- **Verification:** TypeScript SDK builds clean, 759 tests pass; CLI builds + tests pass; Python validated via an isolated round-trip test. The **Rust SDK was not compiled in the authoring environment** (no `cargo` available) — please run `cargo test` before un-drafting.
