### PR TITLE
Correct version 0.4.14 → 0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
-## 0.4.14 — Webhook delivery log
+## 0.4.13 — Webhook delivery log + event id
 
 ### Added
 
@@ -12,16 +12,7 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   - SDKs: `inkbox.webhooks.deliveries.list(...)` / `.replay(deliveryId)` (Python `inkbox.webhooks.deliveries`, Rust `inkbox.webhooks().deliveries()`), returning the new `WebhookDelivery` type. `list` filters on subscription, phone number, event type, and 2xx success, with `limit` / `offset` paging.
   - CLI: `inkbox webhook delivery list` (with `--subscription-id` / `--phone-number-id` / `--event-type` / `--success` / `--failed` / `--limit` / `--offset`) and `inkbox webhook delivery replay <delivery-id>`.
   - Replay reuses the original envelope `event_id`, so a compliant endpoint dedupes a replay it already processed — it recovers a miss rather than forcing reprocessing. Incoming-call deliveries are logged but not replayable.
-
-### Fixed
-
-- **Rust webhook payloads tolerate a missing `id`.** The per-event `id` added to `MailWebhookPayload` / `TextWebhookPayload` / `IMessageWebhookPayload` in 0.4.13 was a required serde field, so a 0.4.13 Rust consumer hard-failed deserializing any payload without it (an older or mixed-deployment server, or a recorded/mocked payload predating the field). The field is now `#[serde(default)]` — an absent `id` parses to `""`. The TypeScript and Python types were already runtime-tolerant (compile-time-only `interface` / `TypedDict`).
-
-## 0.4.13 — Webhook event id
-
-### Added
-
-- **Stable per-event `id` on webhook payloads** in the TypeScript, Python, and Rust SDKs. The mail / text / iMessage webhook envelopes now carry a top-level `id` (`evt_...`) — a stable idempotency key that is the same across the original delivery and any retries or replays. Dedupe on it instead of the per-delivery `X-Inkbox-Request-ID` header. (Incoming-call payloads are flat and keep their own call `id`.)
+- **Stable per-event `id` on webhook payloads** in the TypeScript, Python, and Rust SDKs. The mail / text / iMessage webhook envelopes now carry a top-level `id` (`evt_...`) — a stable idempotency key that is the same across the original delivery and any retries or replays. Dedupe on it instead of the per-delivery `X-Inkbox-Request-ID` header. (Incoming-call payloads are flat and keep their own call `id`.) The Rust field is `#[serde(default)]`, so a payload without `id` parses to `""` rather than failing; the TypeScript and Python types are compile-time-only and already tolerant.
 
 ## 0.4.12 — Tunnel DX
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.14",
+  "version": "0.4.13",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.14",
+    "@inkbox/sdk": "^0.4.13",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.14"
+version = "0.4.13"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.14"
+version = "0.4.13"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.14"
+version = "0.4.13"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.14",
+  "version": "0.4.13",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
#87 bumped the CLI and SDKs `0.4.12 → 0.4.13 → 0.4.14` in two steps within the same PR. Neither was published, so the webhook work should release as a single **0.4.13**, not 0.4.14.

- Set `@inkbox/cli`, `@inkbox/sdk`, `inkbox` (Python), and the Rust crate (+ `Cargo.lock`) back to `0.4.13`; pin the CLI's `@inkbox/sdk` dep to `^0.4.13`.
- Merge the CHANGELOG `0.4.14` section into `0.4.13`. The `0.4.14` "Fixed" note (a missing-`id` serde regression "introduced in 0.4.13") is moot once everything ships as 0.4.13 — folded its `#[serde(default)]` detail into the per-event-`id` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)