### PR TITLE
`0.4.14`: Identity-scoped contact rules + per-identity webhook signing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
-## Unreleased — Identity-scoped contact rules + per-identity signing keys
+## 0.4.14 — Identity-scoped contact rules + per-identity signing keys
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), and `@inkbox/cli`.
 
+## Unreleased — Identity-scoped contact rules + per-identity signing keys
+
+### Added
+
+- **Identity-keyed mail + phone contact rules** in the TypeScript, Python, and Rust SDKs, plus the CLI. Mail and phone contact rules are now addressed by **agent handle** (mirroring iMessage), with the rule shape keyed by `agent_identity_id`.
+  - SDKs: `inkbox.mail_identity_contact_rules` / `inkbox.phone_identity_contact_rules` (TS `mailIdentityContactRules` / `phoneIdentityContactRules`), each with `list/get/create/update/delete` keyed by `agent_handle` and an org-wide `list_all` filtered by `agent_identity_id`. Also surfaced as `identity.list_mail_contact_rules()` / `create_mail_contact_rule()` / … and the phone equivalents on the identity object (phone helpers require the identity to have a phone number). New types `MailIdentityContactRule` / `PhoneIdentityContactRule`.
+  - CLI: `inkbox identity mail-rules [list|list-all|get|create|update|delete]` and `inkbox identity phone-rules [...]`.
+- **Per-identity contact-rule filter mode.** `mail_filter_mode` / `phone_filter_mode` now live on the agent identity (alongside `imessage_filter_mode`) and are set via `identity.update(mail_filter_mode=…, phone_filter_mode=…)` (CLI `inkbox identity update --mail-filter-mode / --phone-filter-mode`). Unlike the deprecated channel update, the identity update does not return a `FilterModeChangeNotice`. `phone_filter_mode` requires the identity to have a phone number.
+- **Per-identity webhook signing keys** in the TypeScript, Python, and Rust SDKs, plus the CLI. Each agent identity has its own signing key.
+  - SDKs: `inkbox.signing_keys.create_or_rotate(agent_handle)` / `get_status(agent_handle)` and `identity.create_signing_key()` / `identity.get_signing_key_status()`, returning `SigningKey` / the new `SigningKeyStatus`.
+  - CLI: `inkbox identity signing-key status <handle>` / `rotate <handle>`.
+  - The **first webhook subscription** created for a keyless identity returns that identity's signing secret **once** — `inkbox.webhooks.subscriptions.create(...)` now returns a `WebhookSubscriptionCreateResponse` carrying an optional once-shown `signing_key`.
+- **`owner_identity_id` on webhook subscriptions** — the resolved owning agent identity for every subscription (mail/phone/iMessage), parsed by the SDKs (optional/back-compatible).
+
+### Deprecated
+
+- The per-mailbox `inkbox.mail_contact_rules` / per-number `inkbox.phone_contact_rules` resources and the CLI `inkbox mailbox rules` / `inkbox number rules` groups — use the identity-keyed surface above. They still work but hit deprecated server routes (Sunset 2026-08-31).
+- The org-level signing key (`inkbox.create_signing_key()` / no-arg `signing_keys.create_or_rotate()`, CLI `inkbox signing-key create`) — use the per-identity surface. With an agent-scoped key the org-level call still rotates that identity's key; with an admin key the server returns 409.
+
 ## 0.4.13 — Webhook delivery log + event id
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.12",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.4.12",
+      "version": "0.4.14",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.4.12",
+        "@inkbox/sdk": "^0.4.14",
         "commander": "^13.0.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.4.12",
+      "version": "0.4.14",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.13",
+    "@inkbox/sdk": "^0.4.14",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -460,6 +460,8 @@ export function registerIdentityCommands(program: Command): void {
             phoneNumber: id.phoneNumber?.number ?? null,
             imessageEnabled: id.imessageEnabled,
             imessageFilterMode: id.imessageFilterMode,
+            mailFilterMode: id.mailFilterMode,
+            phoneFilterMode: id.phoneFilterMode,
             tunnel: id.tunnel
               ? {
                   id: id.tunnel.id,
@@ -701,6 +703,8 @@ export function registerIdentityCommands(program: Command): void {
             phoneNumber: id.phoneNumber?.number ?? null,
             imessageEnabled: id.imessageEnabled,
             imessageFilterMode: id.imessageFilterMode,
+            mailFilterMode: id.mailFilterMode,
+            phoneFilterMode: id.phoneFilterMode,
             tunnel: id.tunnel
               ? {
                   id: id.tunnel.id,

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -462,6 +462,8 @@ export function registerIdentityCommands(program: Command): void {
             imessageFilterMode: id.imessageFilterMode,
             mailFilterMode: id.mailFilterMode,
             phoneFilterMode: id.phoneFilterMode,
+            signingKeyConfigured: id.signingKeyConfigured,
+            signingKeyCreatedAt: id.signingKeyCreatedAt,
             tunnel: id.tunnel
               ? {
                   id: id.tunnel.id,
@@ -705,6 +707,8 @@ export function registerIdentityCommands(program: Command): void {
             imessageFilterMode: id.imessageFilterMode,
             mailFilterMode: id.mailFilterMode,
             phoneFilterMode: id.phoneFilterMode,
+            signingKeyConfigured: id.signingKeyConfigured,
+            signingKeyCreatedAt: id.signingKeyCreatedAt,
             tunnel: id.tunnel
               ? {
                   id: id.tunnel.id,

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -2,8 +2,24 @@ import { Command } from "commander";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
-import type { SecretPayload } from "@inkbox/sdk";
+import type {
+  SecretPayload,
+  MailRuleAction,
+  MailRuleMatchType,
+  PhoneRuleAction,
+  PhoneRuleMatchType,
+  ContactRuleStatus,
+} from "@inkbox/sdk";
 import { parseTotpUri } from "@inkbox/sdk";
+
+const RULE_COLUMNS = [
+  "id",
+  "agentIdentityId",
+  "action",
+  "matchType",
+  "matchTarget",
+  "status",
+];
 
 function registerIdentityAccessCommands(parent: Command): void {
   const access = parent
@@ -96,6 +112,311 @@ function registerIdentityAccessCommands(parent: Command): void {
         await target.revokeAccess(viewer.id);
         console.log(
           `Revoked '${viewerHandle}' visibility on '${targetHandle}'.`,
+        );
+      }),
+    );
+}
+
+function registerIdentityMailRuleCommands(parent: Command): void {
+  const rules = parent
+    .command("mail-rules")
+    .description("Mail contact rules scoped to an agent identity");
+
+  rules
+    .command("list <handle>")
+    .description("List an identity's mail contact rules")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_email or domain")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        cmdOpts: { action?: string; matchType?: string; limit?: number; offset?: number },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.mailIdentityContactRules.list(handle, {
+          action: cmdOpts.action as MailRuleAction | undefined,
+          matchType: cmdOpts.matchType as MailRuleMatchType | undefined,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows, { json: !!opts.json, columns: RULE_COLUMNS });
+      }),
+    );
+
+  rules
+    .command("list-all")
+    .description("List mail contact rules across the org (admin-only)")
+    .option("--agent-identity-id <id>", "Narrow to a single agent identity id")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_email or domain")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          agentIdentityId?: string;
+          action?: string;
+          matchType?: string;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.mailIdentityContactRules.listAll({
+          agentIdentityId: cmdOpts.agentIdentityId,
+          action: cmdOpts.action as MailRuleAction | undefined,
+          matchType: cmdOpts.matchType as MailRuleMatchType | undefined,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows, { json: !!opts.json, columns: RULE_COLUMNS });
+      }),
+    );
+
+  rules
+    .command("get <handle> <rule-id>")
+    .description("Get a single mail contact rule")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string, ruleId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailIdentityContactRules.get(handle, ruleId);
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("create <handle>")
+    .description("Create a mail contact rule (always starts active; use `update` to pause)")
+    .requiredOption("--action <action>", "allow or block")
+    .requiredOption("--match-type <type>", "exact_email or domain")
+    .requiredOption("--match-target <value>", "Address or domain to match")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        cmdOpts: { action: string; matchType: string; matchTarget: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailIdentityContactRules.create(handle, {
+          action: cmdOpts.action as MailRuleAction,
+          matchType: cmdOpts.matchType as MailRuleMatchType,
+          matchTarget: cmdOpts.matchTarget,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("update <handle> <rule-id>")
+    .description("Update action and/or status on a mail rule (admin-only)")
+    .option("--action <action>", "allow or block")
+    .option("--status <status>", "active or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        ruleId: string,
+        cmdOpts: { action?: string; status?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.mailIdentityContactRules.update(handle, ruleId, {
+          action: cmdOpts.action as MailRuleAction | undefined,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("delete <handle> <rule-id>")
+    .description("Delete a mail contact rule (admin-only)")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string, ruleId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.mailIdentityContactRules.delete(handle, ruleId);
+        console.log(`Deleted mail contact rule '${ruleId}' on '${handle}'.`);
+      }),
+    );
+}
+
+function registerIdentityPhoneRuleCommands(parent: Command): void {
+  const rules = parent
+    .command("phone-rules")
+    .description("Phone contact rules scoped to an agent identity (requires a phone number)");
+
+  rules
+    .command("list <handle>")
+    .description("List an identity's phone contact rules (empty if no phone number)")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_number")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        cmdOpts: { action?: string; matchType?: string; limit?: number; offset?: number },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.phoneIdentityContactRules.list(handle, {
+          action: cmdOpts.action as PhoneRuleAction | undefined,
+          matchType: cmdOpts.matchType as PhoneRuleMatchType | undefined,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows, { json: !!opts.json, columns: RULE_COLUMNS });
+      }),
+    );
+
+  rules
+    .command("list-all")
+    .description("List phone contact rules across the org (admin-only)")
+    .option("--agent-identity-id <id>", "Narrow to a single agent identity id")
+    .option("--action <action>", "Filter by action: allow or block")
+    .option("--match-type <type>", "Filter by match_type: exact_number")
+    .option("--limit <n>", "Max rows", (v) => parseInt(v, 10))
+    .option("--offset <n>", "Offset", (v) => parseInt(v, 10))
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        cmdOpts: {
+          agentIdentityId?: string;
+          action?: string;
+          matchType?: string;
+          limit?: number;
+          offset?: number;
+        },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rows = await inkbox.phoneIdentityContactRules.listAll({
+          agentIdentityId: cmdOpts.agentIdentityId,
+          action: cmdOpts.action as PhoneRuleAction | undefined,
+          matchType: cmdOpts.matchType as PhoneRuleMatchType | undefined,
+          limit: cmdOpts.limit,
+          offset: cmdOpts.offset,
+        });
+        output(rows, { json: !!opts.json, columns: RULE_COLUMNS });
+      }),
+    );
+
+  rules
+    .command("get <handle> <rule-id>")
+    .description("Get a single phone contact rule")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string, ruleId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneIdentityContactRules.get(handle, ruleId);
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("create <handle>")
+    .description("Create a phone contact rule (identity must have a phone number)")
+    .requiredOption("--action <action>", "allow or block")
+    .requiredOption("--match-target <value>", "E.164 phone number to match")
+    .option("--match-type <type>", "Match type (default exact_number)", "exact_number")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        cmdOpts: { action: string; matchTarget: string; matchType: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneIdentityContactRules.create(handle, {
+          action: cmdOpts.action as PhoneRuleAction,
+          matchTarget: cmdOpts.matchTarget,
+          matchType: cmdOpts.matchType as PhoneRuleMatchType,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("update <handle> <rule-id>")
+    .description("Update action and/or status on a phone rule (admin-only)")
+    .option("--action <action>", "allow or block")
+    .option("--status <status>", "active or paused")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        handle: string,
+        ruleId: string,
+        cmdOpts: { action?: string; status?: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const rule = await inkbox.phoneIdentityContactRules.update(handle, ruleId, {
+          action: cmdOpts.action as PhoneRuleAction | undefined,
+          status: cmdOpts.status as ContactRuleStatus | undefined,
+        });
+        output(rule as unknown as Record<string, unknown>, { json: !!opts.json });
+      }),
+    );
+
+  rules
+    .command("delete <handle> <rule-id>")
+    .description("Delete a phone contact rule (admin-only)")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string, ruleId: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        await inkbox.phoneIdentityContactRules.delete(handle, ruleId);
+        console.log(`Deleted phone contact rule '${ruleId}' on '${handle}'.`);
+      }),
+    );
+}
+
+function registerIdentitySigningKeyCommands(parent: Command): void {
+  const signingKey = parent
+    .command("signing-key")
+    .description("Per-identity webhook signing key operations");
+
+  signingKey
+    .command("status <handle>")
+    .description("Report whether this identity has a webhook signing key")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const id = await inkbox.getIdentity(handle);
+        const status = await id.getSigningKeyStatus();
+        output(
+          { configured: status.configured, createdAt: status.createdAt },
+          { json: !!opts.json },
+        );
+      }),
+    );
+
+  signingKey
+    .command("rotate <handle>")
+    .description("Create or rotate this identity's webhook signing key")
+    .action(
+      withErrorHandler(async function (this: Command, handle: string) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const id = await inkbox.getIdentity(handle);
+        const key = await id.createSigningKey();
+        output(
+          { signingKey: key.signingKey, createdAt: key.createdAt },
+          { json: !!opts.json },
+        );
+        console.error(
+          "Note: Store this key securely — it cannot be retrieved again.",
         );
       }),
     );
@@ -282,6 +603,8 @@ export function registerIdentityCommands(program: Command): void {
     .option("--clear-description", "Explicitly clear the description (sends null)", false)
     .option("--imessage-enabled <bool>", "Toggle shared-iMessage reachability: true or false")
     .option("--imessage-filter-mode <mode>", "iMessage contact-rule mode: whitelist or blacklist (admin-only)")
+    .option("--mail-filter-mode <mode>", "Mail contact-rule mode: whitelist or blacklist (admin-only)")
+    .option("--phone-filter-mode <mode>", "Phone contact-rule mode: whitelist or blacklist (admin-only; identity must have a phone number)")
     .option("--status <status>", "active or paused")
     .action(
       withErrorHandler(async function (
@@ -294,6 +617,8 @@ export function registerIdentityCommands(program: Command): void {
           clearDescription?: boolean;
           imessageEnabled?: string;
           imessageFilterMode?: string;
+          mailFilterMode?: string;
+          phoneFilterMode?: string;
           status?: string;
         },
       ) {
@@ -303,8 +628,14 @@ export function registerIdentityCommands(program: Command): void {
         if (cmdOpts.imessageEnabled !== undefined && cmdOpts.imessageEnabled !== "true" && cmdOpts.imessageEnabled !== "false") {
           throw new Error("--imessage-enabled must be 'true' or 'false'");
         }
-        if (cmdOpts.imessageFilterMode !== undefined && cmdOpts.imessageFilterMode !== "whitelist" && cmdOpts.imessageFilterMode !== "blacklist") {
-          throw new Error("--imessage-filter-mode must be 'whitelist' or 'blacklist'");
+        for (const [flag, value] of [
+          ["--imessage-filter-mode", cmdOpts.imessageFilterMode],
+          ["--mail-filter-mode", cmdOpts.mailFilterMode],
+          ["--phone-filter-mode", cmdOpts.phoneFilterMode],
+        ] as const) {
+          if (value !== undefined && value !== "whitelist" && value !== "blacklist") {
+            throw new Error(`${flag} must be 'whitelist' or 'blacklist'`);
+          }
         }
         if (cmdOpts.status !== undefined && cmdOpts.status !== "active" && cmdOpts.status !== "paused") {
           throw new Error("--status must be 'active' or 'paused'");
@@ -318,6 +649,8 @@ export function registerIdentityCommands(program: Command): void {
           description?: string | null;
           imessageEnabled?: boolean;
           imessageFilterMode?: "whitelist" | "blacklist";
+          mailFilterMode?: "whitelist" | "blacklist";
+          phoneFilterMode?: "whitelist" | "blacklist";
           status?: "active" | "paused";
         } = {};
         if (cmdOpts.newHandle !== undefined) updateOpts.newHandle = cmdOpts.newHandle;
@@ -334,6 +667,12 @@ export function registerIdentityCommands(program: Command): void {
         }
         if (cmdOpts.imessageFilterMode !== undefined) {
           updateOpts.imessageFilterMode = cmdOpts.imessageFilterMode as "whitelist" | "blacklist";
+        }
+        if (cmdOpts.mailFilterMode !== undefined) {
+          updateOpts.mailFilterMode = cmdOpts.mailFilterMode as "whitelist" | "blacklist";
+        }
+        if (cmdOpts.phoneFilterMode !== undefined) {
+          updateOpts.phoneFilterMode = cmdOpts.phoneFilterMode as "whitelist" | "blacklist";
         }
         if (cmdOpts.status !== undefined) {
           updateOpts.status = cmdOpts.status as "active" | "paused";
@@ -726,4 +1065,7 @@ export function registerIdentityCommands(program: Command): void {
     );
 
   registerIdentityAccessCommands(identity);
+  registerIdentityMailRuleCommands(identity);
+  registerIdentityPhoneRuleCommands(identity);
+  registerIdentitySigningKeyCommands(identity);
 }

--- a/cli/src/commands/mailbox.ts
+++ b/cli/src/commands/mailbox.ts
@@ -44,7 +44,10 @@ function assertFilterMode(raw: string): FilterMode {
 function registerMailboxRulesCommands(parent: Command): void {
   const rules = parent
     .command("rules")
-    .description("Contact rules scoped to a mailbox");
+    .description(
+      "[deprecated] Contact rules scoped to a mailbox. Use " +
+        "'inkbox identity mail-rules ...' instead (keyed by agent handle).",
+    );
 
   rules
     .command("list")

--- a/cli/src/commands/number.ts
+++ b/cli/src/commands/number.ts
@@ -35,7 +35,10 @@ function assertFilterMode(raw: string): FilterMode {
 function registerNumberRulesCommands(parent: Command): void {
   const rules = parent
     .command("rules")
-    .description("Contact rules scoped to a phone number");
+    .description(
+      "[deprecated] Contact rules scoped to a phone number. Use " +
+        "'inkbox identity phone-rules ...' instead (keyed by agent handle).",
+    );
 
   rules
     .command("list")

--- a/cli/src/commands/signing-key.ts
+++ b/cli/src/commands/signing-key.ts
@@ -10,7 +10,12 @@ export function registerSigningKeyCommands(program: Command): void {
 
   signingKey
     .command("create")
-    .description("Create or rotate the webhook signing key")
+    .description(
+      "[deprecated] Create or rotate a webhook signing key via the org-level " +
+        "endpoint. Use 'inkbox identity signing-key rotate <handle>' instead. " +
+        "With an agent-scoped key this rotates that identity's key; with an " +
+        "admin key the server returns 409.",
+    )
     .action(
       withErrorHandler(async function (this: Command) {
         const opts = getGlobalOpts(this);
@@ -25,6 +30,10 @@ export function registerSigningKeyCommands(program: Command): void {
         );
         console.error(
           "Note: Store this key securely — it cannot be retrieved again.",
+        );
+        console.error(
+          "Note: Org-level signing keys are deprecated. Prefer " +
+            "'inkbox identity signing-key rotate <handle>'.",
         );
       }),
     );

--- a/cli/src/commands/webhook.ts
+++ b/cli/src/commands/webhook.ts
@@ -3,7 +3,11 @@ import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
 import { verifyWebhook } from "@inkbox/sdk";
-import type { WebhookSubscription, WebhookDelivery } from "@inkbox/sdk";
+import type {
+  WebhookSubscription,
+  WebhookSubscriptionCreateResponse,
+  WebhookDelivery,
+} from "@inkbox/sdk";
 
 const WEBHOOK_SUBSCRIPTION_LIST_COLUMNS = [
   "id",
@@ -29,6 +33,31 @@ function flattenForOutput(sub: WebhookSubscription): Record<string, unknown> {
     createdAt: sub.createdAt,
     updatedAt: sub.updatedAt,
   };
+}
+
+// Create-only display shape: surfaces the one-time plaintext signingKey and the
+// resolved ownerIdentityId, which flattenForOutput drops. signingKey is shown
+// only on the first create that mints the owning identity's key.
+export function flattenCreateForOutput(
+  row: WebhookSubscriptionCreateResponse,
+): Record<string, unknown> {
+  return {
+    ...flattenForOutput(row),
+    ownerIdentityId: row.ownerIdentityId,
+    signingKey: row.signingKey,
+  };
+}
+
+// --json preserves the SDK response shape (eventTypes stays an array) so the
+// one-time signingKey/ownerIdentityId survive; human output uses the flattened
+// create shape. Either way the plaintext signingKey is never dropped.
+export function buildCreateOutput(
+  row: WebhookSubscriptionCreateResponse,
+  json: boolean,
+): { data: unknown; json: boolean } {
+  return json
+    ? { data: row, json: true }
+    : { data: flattenCreateForOutput(row), json: false };
 }
 
 function registerSubscriptionCommands(parent: Command): void {
@@ -119,7 +148,8 @@ function registerSubscriptionCommands(parent: Command): void {
           url: cmdOpts.url,
           eventTypes: cmdOpts.eventType,
         });
-        output(flattenForOutput(row), { json: !!opts.json });
+        const { data, json } = buildCreateOutput(row, !!opts.json);
+        output(data, { json });
       }),
     );
 

--- a/cli/tests/webhook-command.test.mjs
+++ b/cli/tests/webhook-command.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCreateOutput,
+  flattenCreateForOutput,
+} from "../dist/commands/webhook.js";
+
+// A first-create response: the one-time plaintext signingKey is present.
+const CREATE_ROW = {
+  id: "sub_1",
+  organizationId: "org_x",
+  mailboxId: "mbx_1",
+  phoneNumberId: null,
+  agentIdentityId: null,
+  ownerIdentityId: "id_1",
+  url: "https://example.com/hook",
+  eventTypes: ["message.received", "message.sent"],
+  status: "active",
+  createdAt: new Date("2026-06-02T03:04:05Z"),
+  updatedAt: new Date("2026-06-02T03:04:05Z"),
+  signingKey: "whsec_first_create_plaintext",
+};
+
+test("flattenCreateForOutput keeps the one-time signingKey and ownerIdentityId", () => {
+  const flat = flattenCreateForOutput(CREATE_ROW);
+  assert.equal(flat.signingKey, "whsec_first_create_plaintext");
+  assert.equal(flat.ownerIdentityId, "id_1");
+  // human display joins eventTypes into a string
+  assert.equal(flat.eventTypes, "message.received, message.sent");
+});
+
+test("buildCreateOutput human output includes signingKey", () => {
+  const { data, json } = buildCreateOutput(CREATE_ROW, false);
+  assert.equal(json, false);
+  assert.equal(data.signingKey, "whsec_first_create_plaintext");
+  assert.equal(data.ownerIdentityId, "id_1");
+});
+
+test("buildCreateOutput --json preserves the SDK shape including signingKey", () => {
+  const { data, json } = buildCreateOutput(CREATE_ROW, true);
+  assert.equal(json, true);
+  // raw SDK object: signingKey present and eventTypes stays an array
+  assert.equal(data.signingKey, "whsec_first_create_plaintext");
+  assert.equal(data.ownerIdentityId, "id_1");
+  assert.deepEqual(data.eventTypes, ["message.received", "message.sent"]);
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -664,11 +664,12 @@ print(mailbox.email_address)
 print(mailbox.sending_domain)        # bare domain the mailbox sends from
 print(mailbox.agent_identity_id)     # non-null for live customer mailboxes (1:1 invariant)
 
-# Update filter mode. display_name has moved to the identity — set
-# it via identity.update(display_name=...). The mailbox PATCH
-# endpoint hard-rejects display_name with a 422. To attach a webhook
-# receiver, see "Webhooks" below.
-inkbox.mailboxes.update(mailbox.email_address, filter_mode="whitelist")  # admin-scoped key only
+# Filter mode now lives on the agent identity — set it via
+# identity.update(mail_filter_mode=...). display_name likewise moved to
+# the identity; the mailbox PATCH endpoint hard-rejects display_name
+# with a 422. To attach a webhook receiver, see "Webhooks" below.
+inkbox.get_identity("support-agent").update(mail_filter_mode="whitelist")  # admin-scoped key only
+# (deprecated) inkbox.mailboxes.update(mailbox.email_address, filter_mode="whitelist")
 
 # Full-text search across messages in a mailbox
 results = inkbox.mailboxes.search(mailbox.email_address, q="invoice", limit=20)
@@ -983,10 +984,31 @@ elif isinstance(info, inkbox.WhoamiJwtResponse):
 
 ## Signing Keys
 
+Signing keys are **per agent identity**. Create/rotate or check status via the
+identity (or `inkbox.signing_keys.create_or_rotate(agent_handle)` /
+`get_status(agent_handle)`). The plaintext is returned **once**.
+
 ```python
-# Create or rotate the org-level webhook signing key (plaintext returned once)
-key = inkbox.create_signing_key()
+identity = inkbox.get_identity("support-agent")
+
+# Create or rotate this identity's webhook signing key (plaintext returned once)
+key = identity.create_signing_key()
 print(key.signing_key)  # save this immediately
+
+# Check whether a key is configured
+status = identity.get_signing_key_status()
+print(status.configured, status.created_at)
+
+# The FIRST webhook subscription for a keyless identity returns its secret once:
+created = inkbox.webhooks.subscriptions.create(
+    mailbox_id=identity.mailbox.id,
+    url="https://example.com/hooks/mail",
+    event_types=["message.received"],
+)
+if created.signing_key is not None:
+    print(created.signing_key)  # save this immediately — shown only once
+
+# (deprecated) org-level: inkbox.create_signing_key()
 ```
 
 ---

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -24,6 +24,7 @@ from inkbox.mail.types import (
     FilterModeChangeNotice,
     ForwardMode,
     MailContactRule,
+    MailIdentityContactRule,
     MailRuleAction,
     MailRuleMatchType,
     Mailbox,
@@ -42,6 +43,7 @@ from inkbox.phone.types import (
     PhoneCall,
     PhoneCallWithRateLimit,
     PhoneContactRule,
+    PhoneIdentityContactRule,
     PhoneNumber,
     PhoneRuleAction,
     PhoneRuleMatchType,
@@ -188,7 +190,7 @@ from inkbox.identities.exceptions import (
 )
 
 # Signing key + webhook verification
-from inkbox.signing_keys import SigningKey, verify_webhook
+from inkbox.signing_keys import SigningKey, SigningKeyStatus, verify_webhook
 
 # Receiver-side webhook payload types
 from inkbox.webhooks import (
@@ -237,6 +239,7 @@ from inkbox.webhooks import (
 # Webhook subscription resource (CRUD)
 from inkbox.webhook_subscriptions import (
     WebhookSubscription,
+    WebhookSubscriptionCreateResponse,
     WebhookSubscriptionsResource,
     WebhookSubscriptionStatus,
 )
@@ -269,6 +272,7 @@ __all__ = [
     "FilterModeChangeNotice",
     "ForwardMode",
     "MailContactRule",
+    "MailIdentityContactRule",
     "MailRuleAction",
     "MailRuleMatchType",
     "Mailbox",
@@ -284,6 +288,7 @@ __all__ = [
     "PhoneCall",
     "PhoneCallWithRateLimit",
     "PhoneContactRule",
+    "PhoneIdentityContactRule",
     "PhoneNumber",
     "PhoneRuleAction",
     "PhoneRuleMatchType",
@@ -400,6 +405,7 @@ __all__ = [
     "HandleUnavailableError",
     # Signing key + webhook verification
     "SigningKey",
+    "SigningKeyStatus",
     "verify_webhook",
     # Receiver-side webhook payload types
     "CallDirectionWire",
@@ -444,6 +450,7 @@ __all__ = [
     "WebhookMailContact",
     # Webhook subscriptions
     "WebhookSubscription",
+    "WebhookSubscriptionCreateResponse",
     "WebhookSubscriptionsResource",
     "WebhookSubscriptionStatus",
     # Webhook deliveries

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -63,6 +63,8 @@ from inkbox.phone.types import (
 from inkbox.signing_keys import SigningKey, SigningKeyStatus
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from inkbox.client import Inkbox
 
 # `_UNSET` is imported from inkbox.identities.types above. Identity-based
@@ -148,6 +150,16 @@ class AgentIdentity:
     def phone_filter_mode(self) -> FilterMode:
         """Whitelist/blacklist mode for this identity's phone contact rules."""
         return self._data.phone_filter_mode
+
+    @property
+    def signing_key_configured(self) -> bool:
+        """Whether this identity has a webhook signing key configured (status only)."""
+        return self._data.signing_key_configured
+
+    @property
+    def signing_key_created_at(self) -> datetime | None:
+        """When this identity's signing key was created, or ``None`` if unset."""
+        return self._data.signing_key_created_at
 
     @property
     def mailbox(self) -> IdentityMailbox | None:
@@ -1076,9 +1088,9 @@ class AgentIdentity:
     ) -> list[PhoneIdentityContactRule]:
         """List this identity's phone allow/block rules, newest first.
 
-        Raises ``InkboxError`` if this identity has no phone number.
+        Returns ``[]`` for a phoneless identity; the server requires a phone
+        only for create/get/update/delete, not for list.
         """
-        self._require_phone()
         return self._inkbox._phone_identity_contact_rules.list(
             self.agent_handle,
             action=action,

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -38,8 +38,12 @@ from inkbox.imessage.types import (
     IMessageSendStyle,
 )
 from inkbox.mail.types import (
+    ContactRuleStatus,
     FilterMode,
     ForwardMode,
+    MailIdentityContactRule,
+    MailRuleAction,
+    MailRuleMatchType,
     Message,
     MessageDetail,
     MessageDirection,
@@ -48,11 +52,15 @@ from inkbox.mail.types import (
 from inkbox.phone.types import (
     PhoneCall,
     PhoneCallWithRateLimit,
+    PhoneIdentityContactRule,
+    PhoneRuleAction,
+    PhoneRuleMatchType,
     PhoneTranscript,
     TextConversationSummary,
     TextConversationUpdateResult,
     TextMessage,
 )
+from inkbox.signing_keys import SigningKey, SigningKeyStatus
 
 if TYPE_CHECKING:
     from inkbox.client import Inkbox
@@ -130,6 +138,16 @@ class AgentIdentity:
     def imessage_filter_mode(self) -> FilterMode:
         """Whitelist/blacklist mode for this identity's iMessage contact rules."""
         return self._data.imessage_filter_mode
+
+    @property
+    def mail_filter_mode(self) -> FilterMode:
+        """Whitelist/blacklist mode for this identity's mail contact rules."""
+        return self._data.mail_filter_mode
+
+    @property
+    def phone_filter_mode(self) -> FilterMode:
+        """Whitelist/blacklist mode for this identity's phone contact rules."""
+        return self._data.phone_filter_mode
 
     @property
     def mailbox(self) -> IdentityMailbox | None:
@@ -987,6 +1005,149 @@ class AgentIdentity:
             content_type=content_type,
         )
 
+    ## Mail contact rules
+
+    def list_mail_contact_rules(
+        self,
+        *,
+        action: MailRuleAction | str | None = None,
+        match_type: MailRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[MailIdentityContactRule]:
+        """List this identity's mail allow/block rules, newest first."""
+        return self._inkbox._mail_identity_contact_rules.list(
+            self.agent_handle,
+            action=action,
+            match_type=match_type,
+            limit=limit,
+            offset=offset,
+        )
+
+    def get_mail_contact_rule(self, rule_id: UUID | str) -> MailIdentityContactRule:
+        """Get one of this identity's mail contact rules by id."""
+        return self._inkbox._mail_identity_contact_rules.get(self.agent_handle, rule_id)
+
+    def create_mail_contact_rule(
+        self,
+        *,
+        action: MailRuleAction | str,
+        match_type: MailRuleMatchType | str,
+        match_target: str,
+    ) -> MailIdentityContactRule:
+        """Create a mail allow/block rule for this identity."""
+        return self._inkbox._mail_identity_contact_rules.create(
+            self.agent_handle,
+            action=action,
+            match_type=match_type,
+            match_target=match_target,
+        )
+
+    def update_mail_contact_rule(
+        self,
+        rule_id: UUID | str,
+        *,
+        action: MailRuleAction | str = _UNSET,  # type: ignore[assignment]
+        status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
+    ) -> MailIdentityContactRule:
+        """Update a mail rule's ``action`` or ``status`` (admin-only)."""
+        kwargs: dict[str, Any] = {}
+        if action is not _UNSET:
+            kwargs["action"] = action
+        if status is not _UNSET:
+            kwargs["status"] = status
+        return self._inkbox._mail_identity_contact_rules.update(
+            self.agent_handle, rule_id, **kwargs,
+        )
+
+    def delete_mail_contact_rule(self, rule_id: UUID | str) -> None:
+        """Delete one of this identity's mail contact rules (admin-only)."""
+        self._inkbox._mail_identity_contact_rules.delete(self.agent_handle, rule_id)
+
+    ## Phone contact rules
+
+    def list_phone_contact_rules(
+        self,
+        *,
+        action: PhoneRuleAction | str | None = None,
+        match_type: PhoneRuleMatchType | str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[PhoneIdentityContactRule]:
+        """List this identity's phone allow/block rules, newest first.
+
+        Raises ``InkboxError`` if this identity has no phone number.
+        """
+        self._require_phone()
+        return self._inkbox._phone_identity_contact_rules.list(
+            self.agent_handle,
+            action=action,
+            match_type=match_type,
+            limit=limit,
+            offset=offset,
+        )
+
+    def get_phone_contact_rule(self, rule_id: UUID | str) -> PhoneIdentityContactRule:
+        """Get one of this identity's phone contact rules by id."""
+        self._require_phone()
+        return self._inkbox._phone_identity_contact_rules.get(self.agent_handle, rule_id)
+
+    def create_phone_contact_rule(
+        self,
+        *,
+        action: PhoneRuleAction | str,
+        match_target: str,
+        match_type: PhoneRuleMatchType | str = PhoneRuleMatchType.EXACT_NUMBER,
+    ) -> PhoneIdentityContactRule:
+        """Create a phone allow/block rule for this identity.
+
+        Raises ``InkboxError`` if this identity has no phone number.
+        """
+        self._require_phone()
+        return self._inkbox._phone_identity_contact_rules.create(
+            self.agent_handle,
+            action=action,
+            match_target=match_target,
+            match_type=match_type,
+        )
+
+    def update_phone_contact_rule(
+        self,
+        rule_id: UUID | str,
+        *,
+        action: PhoneRuleAction | str = _UNSET,  # type: ignore[assignment]
+        status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
+    ) -> PhoneIdentityContactRule:
+        """Update a phone rule's ``action`` or ``status`` (admin-only)."""
+        self._require_phone()
+        kwargs: dict[str, Any] = {}
+        if action is not _UNSET:
+            kwargs["action"] = action
+        if status is not _UNSET:
+            kwargs["status"] = status
+        return self._inkbox._phone_identity_contact_rules.update(
+            self.agent_handle, rule_id, **kwargs,
+        )
+
+    def delete_phone_contact_rule(self, rule_id: UUID | str) -> None:
+        """Delete one of this identity's phone contact rules (admin-only)."""
+        self._require_phone()
+        self._inkbox._phone_identity_contact_rules.delete(self.agent_handle, rule_id)
+
+    ## Signing key
+
+    def get_signing_key_status(self) -> SigningKeyStatus:
+        """Report whether this identity has a webhook signing key."""
+        return self._inkbox._signing_keys.get_status(self.agent_handle)
+
+    def create_signing_key(self) -> SigningKey:
+        """Create or rotate this identity's webhook signing key.
+
+        The plaintext ``signing_key`` is returned **once** — store it
+        securely, it cannot be retrieved again.
+        """
+        return self._inkbox._signing_keys.create_or_rotate(self.agent_handle)
+
     ## Identity management
 
     def update(
@@ -997,10 +1158,12 @@ class AgentIdentity:
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
         imessage_filter_mode: FilterMode | str | None = None,
+        mail_filter_mode: FilterMode | str | None = None,
+        phone_filter_mode: FilterMode | str | None = None,
         status: str | None = None,
     ) -> None:
         """Update this identity's handle, display name, description,
-        iMessage reachability, and/or status.
+        iMessage reachability, contact-rule filter modes, and/or status.
 
         Only provided fields are applied; omitted fields are left
         unchanged. For ``display_name`` and ``description``, explicit
@@ -1014,6 +1177,13 @@ class AgentIdentity:
             imessage_enabled: Toggle shared-iMessage reachability.
             imessage_filter_mode: ``"whitelist"`` or ``"blacklist"`` for
                 iMessage contact rules (admin-only).
+            mail_filter_mode: ``"whitelist"`` or ``"blacklist"`` for this
+                identity's mail contact rules (admin-only). Note: unlike the
+                deprecated ``mailboxes.update(filter_mode=...)``, this does
+                not return a ``FilterModeChangeNotice``.
+            phone_filter_mode: ``"whitelist"`` or ``"blacklist"`` for this
+                identity's phone contact rules (admin-only). Rejected with a
+                422 when the identity has no phone number.
             status: ``"active"`` or ``"paused"``. Call :meth:`delete`
                 to remove the identity; ``"deleted"`` is rejected here.
         """
@@ -1032,6 +1202,18 @@ class AgentIdentity:
                 if isinstance(imessage_filter_mode, FilterMode)
                 else imessage_filter_mode
             )
+        if mail_filter_mode is not None:
+            update_kwargs["mail_filter_mode"] = (
+                mail_filter_mode.value
+                if isinstance(mail_filter_mode, FilterMode)
+                else mail_filter_mode
+            )
+        if phone_filter_mode is not None:
+            update_kwargs["phone_filter_mode"] = (
+                phone_filter_mode.value
+                if isinstance(phone_filter_mode, FilterMode)
+                else phone_filter_mode
+            )
         if status is not None:
             update_kwargs["status"] = status
         result = self._inkbox._ids_resource.update(
@@ -1048,6 +1230,8 @@ class AgentIdentity:
             updated_at=result.updated_at,
             imessage_enabled=result.imessage_enabled,
             imessage_filter_mode=result.imessage_filter_mode,
+            mail_filter_mode=result.mail_filter_mode,
+            phone_filter_mode=result.phone_filter_mode,
             mailbox=self._mailbox,
             phone_number=self._phone_number,
             tunnel=self._tunnel,

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -37,12 +37,16 @@ from inkbox.identities.types import (  # noqa: I001
 from inkbox.imessage.resources.contact_rules import IMessageContactRulesResource
 from inkbox.imessage.resources.imessages import IMessagesResource
 from inkbox.mail.resources.contact_rules import MailContactRulesResource
+from inkbox.mail.resources.identity_contact_rules import MailIdentityContactRulesResource
 from inkbox.mail.resources.domains import DomainsResource
 from inkbox.mail.resources.mailboxes import MailboxesResource
 from inkbox.mail.resources.messages import MessagesResource
 from inkbox.mail.resources.threads import ThreadsResource
 from inkbox.phone.resources.calls import CallsResource
 from inkbox.phone.resources.contact_rules import PhoneContactRulesResource
+from inkbox.phone.resources.identity_contact_rules import (
+    PhoneIdentityContactRulesResource,
+)
 from inkbox.phone.resources.numbers import PhoneNumbersResource
 from inkbox.phone.resources.sms_opt_ins import SmsOptInsResource
 from inkbox.phone.resources.texts import TextsResource
@@ -224,6 +228,16 @@ class Inkbox:
         self._phone_contact_rules = PhoneContactRulesResource(self._phone_http)
         self._sms_opt_ins = SmsOptInsResource(self._phone_http)
 
+        # Identity-keyed contact rules ride the api-root transport (base
+        # /api/v1) so they reach both /identities/{handle}/...-contact-rules
+        # and the org-wide /mail|/phone/contact-rules with full paths.
+        self._mail_identity_contact_rules = MailIdentityContactRulesResource(
+            self._api_http
+        )
+        self._phone_identity_contact_rules = PhoneIdentityContactRulesResource(
+            self._api_http
+        )
+
         self._imessages = IMessagesResource(self._imessage_http)
         self._imessage_contact_rules = IMessageContactRulesResource(self._imessage_http)
 
@@ -331,13 +345,31 @@ class Inkbox:
 
     @property
     def mail_contact_rules(self) -> MailContactRulesResource:
-        """Mail per-mailbox allow/block rules (+ org-wide list)."""
+        """Mail per-mailbox allow/block rules (+ org-wide list).
+
+        Deprecated: contact rules are now keyed by agent identity — use
+        :attr:`mail_identity_contact_rules` (or ``identity.*_mail_contact_rule``).
+        """
         return self._mail_contact_rules
 
     @property
     def phone_contact_rules(self) -> PhoneContactRulesResource:
-        """Phone per-number allow/block rules (+ org-wide list)."""
+        """Phone per-number allow/block rules (+ org-wide list).
+
+        Deprecated: contact rules are now keyed by agent identity — use
+        :attr:`phone_identity_contact_rules` (or ``identity.*_phone_contact_rule``).
+        """
         return self._phone_contact_rules
+
+    @property
+    def mail_identity_contact_rules(self) -> MailIdentityContactRulesResource:
+        """Mail per-identity allow/block rules (+ org-wide list), keyed by ``agent_handle``."""
+        return self._mail_identity_contact_rules
+
+    @property
+    def phone_identity_contact_rules(self) -> PhoneIdentityContactRulesResource:
+        """Phone per-identity allow/block rules (+ org-wide list), keyed by ``agent_handle``."""
+        return self._phone_identity_contact_rules
 
     @property
     def sms_opt_ins(self) -> SmsOptInsResource:
@@ -362,6 +394,17 @@ class Inkbox:
     def api_keys(self) -> ApiKeysResource:
         """Org-level API key creation. Admin-scoped API keys can mint identity-scoped keys."""
         return self._api_keys
+
+    @property
+    def signing_keys(self) -> SigningKeysResource:
+        """Per-identity webhook signing keys.
+
+        Use ``create_or_rotate(agent_handle)`` / ``get_status(agent_handle)``
+        (or the ``identity.create_signing_key()`` /
+        ``identity.get_signing_key_status()`` convenience methods). Calling
+        either with no handle hits the deprecated org-level endpoint.
+        """
+        return self._signing_keys
 
     @property
     def webhooks(self) -> "_WebhooksNamespace":
@@ -469,7 +512,14 @@ class Inkbox:
 
     def create_signing_key(self) -> SigningKey:
         """
-        Create or rotate the org-level webhook signing key.
+        Create or rotate a webhook signing key via the deprecated org-level
+        endpoint.
+
+        Deprecated: signing keys are now per agent identity. Prefer
+        ``identity.create_signing_key()`` (or
+        ``inkbox.signing_keys.create_or_rotate(agent_handle)``). With an
+        agent-scoped API key this rotates that key's identity; with an admin
+        key the server returns 409 (``InkboxAPIError``).
 
         The plaintext key is returned once — save it immediately.
         """

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -109,10 +109,12 @@ class IdentitiesResource:
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
         imessage_filter_mode: str | None = None,
+        mail_filter_mode: str | None = None,
+        phone_filter_mode: str | None = None,
         status: str | None = None,
     ) -> AgentIdentitySummary:
         """Update an identity's handle, display name, description,
-        iMessage reachability, and/or status.
+        iMessage reachability, contact-rule filter modes, and/or status.
 
         Only provided fields are applied; omitted fields are left
         unchanged. For ``display_name`` and ``description``, explicit
@@ -127,6 +129,11 @@ class IdentitiesResource:
             imessage_enabled: Toggle shared-iMessage reachability.
             imessage_filter_mode: ``"whitelist"`` or ``"blacklist"`` for
                 iMessage contact rules (admin-only).
+            mail_filter_mode: ``"whitelist"`` or ``"blacklist"`` for this
+                identity's mail contact rules (admin-only).
+            phone_filter_mode: ``"whitelist"`` or ``"blacklist"`` for this
+                identity's phone contact rules (admin-only). The server
+                rejects this with 422 when the identity has no phone number.
             status: ``"active"`` or ``"paused"``. Call :meth:`delete`
                 to remove an identity; ``"deleted"`` is rejected here.
         """
@@ -141,6 +148,10 @@ class IdentitiesResource:
             body["imessage_enabled"] = imessage_enabled
         if imessage_filter_mode is not None:
             body["imessage_filter_mode"] = imessage_filter_mode
+        if mail_filter_mode is not None:
+            body["mail_filter_mode"] = mail_filter_mode
+        if phone_filter_mode is not None:
+            body["phone_filter_mode"] = phone_filter_mode
         if status is not None:
             body["status"] = status
         try:

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -257,9 +257,13 @@ class AgentIdentitySummary:
     imessage_filter_mode: FilterMode = FilterMode.BLACKLIST
     mail_filter_mode: FilterMode = FilterMode.BLACKLIST
     phone_filter_mode: FilterMode = FilterMode.BLACKLIST
+    # Webhook signing-key status (never the secret itself).
+    signing_key_configured: bool = False
+    signing_key_created_at: datetime | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> AgentIdentitySummary:
+        raw_signing_created_at = d.get("signing_key_created_at")
         return cls(
             id=UUID(d["id"]),
             organization_id=d["organization_id"],
@@ -273,6 +277,12 @@ class AgentIdentitySummary:
             imessage_filter_mode=FilterMode(d.get("imessage_filter_mode") or "blacklist"),
             mail_filter_mode=FilterMode(d.get("mail_filter_mode") or "blacklist"),
             phone_filter_mode=FilterMode(d.get("phone_filter_mode") or "blacklist"),
+            signing_key_configured=d.get("signing_key_configured", False),
+            signing_key_created_at=(
+                datetime.fromisoformat(raw_signing_created_at)
+                if raw_signing_created_at
+                else None
+            ),
         )
 
 

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -238,6 +238,11 @@ class AgentIdentitySummary:
     ``imessage_enabled`` / ``imessage_filter_mode`` describe shared-pool
     iMessage reachability — there is no per-identity iMessage number, so
     these live on the identity itself rather than on a channel object.
+
+    ``mail_filter_mode`` / ``phone_filter_mode`` are the whitelist/blacklist
+    modes for this identity's mail and phone contact rules. They live on the
+    identity (set via ``identity.update(...)``); the same field on the mailbox
+    / phone-number objects is the deprecated legacy mirror.
     """
 
     id: UUID
@@ -250,6 +255,8 @@ class AgentIdentitySummary:
     updated_at: datetime
     imessage_enabled: bool = False
     imessage_filter_mode: FilterMode = FilterMode.BLACKLIST
+    mail_filter_mode: FilterMode = FilterMode.BLACKLIST
+    phone_filter_mode: FilterMode = FilterMode.BLACKLIST
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> AgentIdentitySummary:
@@ -264,6 +271,8 @@ class AgentIdentitySummary:
             updated_at=datetime.fromisoformat(d["updated_at"]),
             imessage_enabled=d.get("imessage_enabled", False),
             imessage_filter_mode=FilterMode(d.get("imessage_filter_mode") or "blacklist"),
+            mail_filter_mode=FilterMode(d.get("mail_filter_mode") or "blacklist"),
+            phone_filter_mode=FilterMode(d.get("phone_filter_mode") or "blacklist"),
         )
 
 

--- a/sdk/python/inkbox/mail/resources/identity_contact_rules.py
+++ b/sdk/python/inkbox/mail/resources/identity_contact_rules.py
@@ -1,7 +1,18 @@
 """
-inkbox/mail/resources/contact_rules.py
+inkbox/mail/resources/identity_contact_rules.py
 
-Mail contact rules (per-mailbox allow/block rules + org-wide list).
+Identity-keyed mail contact rules (per-agent-identity allow/block rules
++ org-wide list).
+
+Mail rules live on the **agent identity**, addressed by ``agent_handle``,
+mirroring the iMessage rule shape. The legacy per-mailbox resource
+(``inkbox.mail_contact_rules``) is kept as a deprecated wrapper.
+
+Transport note: this resource rides the api-root transport
+(``{base}/api/v1``) so it can address both the per-identity routes
+(``/identities/{handle}/mail-contact-rules``) and the org-wide list
+(``/mail/contact-rules``) with full paths. It must NOT ride the
+``/mail``-prefixed transport, which would mangle the identity paths.
 """
 
 from __future__ import annotations
@@ -11,7 +22,7 @@ from uuid import UUID
 
 from inkbox.mail.types import (
     ContactRuleStatus,
-    MailContactRule,
+    MailIdentityContactRule,
     MailRuleAction,
     MailRuleMatchType,
 )
@@ -19,40 +30,30 @@ from inkbox.mail.types import (
 if TYPE_CHECKING:
     from inkbox._http import HttpTransport
 
-_BASE = "/mailboxes"
-_ORG_BASE = "/contact-rules"
+_ORG_BASE = "/mail/contact-rules"
 _UNSET = object()
 
 
-def _rule_path(email_address: str, rule_id: UUID | str | None = None) -> str:
-    base = f"{_BASE}/{email_address}/contact-rules"
+def _rule_path(agent_handle: str, rule_id: UUID | str | None = None) -> str:
+    base = f"/identities/{agent_handle}/mail-contact-rules"
     return base if rule_id is None else f"{base}/{rule_id}"
 
 
-class MailContactRulesResource:
-    """Allow/block rules scoped to mail mailboxes.
-
-    .. deprecated::
-        Mail contact rules are now keyed by **agent identity**. Use
-        ``inkbox.mail_identity_contact_rules`` (or
-        ``identity.list_mail_contact_rules()`` etc.) instead. These
-        per-mailbox routes still work but hit the deprecated server
-        endpoints (Sunset 2026-08-31) and return the legacy
-        ``mailbox_id`` shape.
-    """
+class MailIdentityContactRulesResource:
+    """Allow/block mail rules scoped to agent identities."""
 
     def __init__(self, http: HttpTransport) -> None:
         self._http = http
 
     def list(
         self,
-        email_address: str,
+        agent_handle: str,
         *,
         action: MailRuleAction | str | None = None,
         match_type: MailRuleMatchType | str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[MailContactRule]:
+    ) -> list[MailIdentityContactRule]:
         params: dict[str, Any] = {}
         if action is not None:
             params["action"] = action.value if isinstance(action, MailRuleAction) else action
@@ -64,24 +65,24 @@ class MailContactRulesResource:
             params["limit"] = limit
         if offset is not None:
             params["offset"] = offset
-        data = self._http.get(_rule_path(email_address), params=params)
+        data = self._http.get(_rule_path(agent_handle), params=params)
         items = data["items"] if isinstance(data, dict) and "items" in data else data
-        return [MailContactRule._from_dict(r) for r in items]
+        return [MailIdentityContactRule._from_dict(r) for r in items]
 
-    def get(self, email_address: str, rule_id: UUID | str) -> MailContactRule:
-        data = self._http.get(_rule_path(email_address, rule_id))
-        return MailContactRule._from_dict(data)
+    def get(self, agent_handle: str, rule_id: UUID | str) -> MailIdentityContactRule:
+        data = self._http.get(_rule_path(agent_handle, rule_id))
+        return MailIdentityContactRule._from_dict(data)
 
     def create(
         self,
-        email_address: str,
+        agent_handle: str,
         *,
         action: MailRuleAction | str,
         match_type: MailRuleMatchType | str,
         match_target: str,
-    ) -> MailContactRule:
-        """Create a rule. New rules are always ``active``; use
-        :meth:`update` to pause one after creation.
+    ) -> MailIdentityContactRule:
+        """Create a rule for an agent identity. New rules are always
+        ``active``; use :meth:`update` to pause one after creation.
 
         Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
         rule with the same ``(match_type, match_target)`` already exists.
@@ -93,17 +94,17 @@ class MailContactRulesResource:
             ),
             "match_target": match_target,
         }
-        data = self._http.post(_rule_path(email_address), json=body)
-        return MailContactRule._from_dict(data)
+        data = self._http.post(_rule_path(agent_handle), json=body)
+        return MailIdentityContactRule._from_dict(data)
 
     def update(
         self,
-        email_address: str,
+        agent_handle: str,
         rule_id: UUID | str,
         *,
         action: MailRuleAction | str = _UNSET,  # type: ignore[assignment]
         status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
-    ) -> MailContactRule:
+    ) -> MailIdentityContactRule:
         """Update ``action`` or ``status`` (admin-only).
 
         ``match_type`` and ``match_target`` are immutable — delete + re-create
@@ -118,32 +119,32 @@ class MailContactRulesResource:
             body["status"] = (
                 status.value if isinstance(status, ContactRuleStatus) else status
             )
-        data = self._http.patch(_rule_path(email_address, rule_id), json=body)
-        return MailContactRule._from_dict(data)
+        data = self._http.patch(_rule_path(agent_handle, rule_id), json=body)
+        return MailIdentityContactRule._from_dict(data)
 
-    def delete(self, email_address: str, rule_id: UUID | str) -> None:
+    def delete(self, agent_handle: str, rule_id: UUID | str) -> None:
         """Delete a rule (admin-only)."""
-        self._http.delete(_rule_path(email_address, rule_id))
+        self._http.delete(_rule_path(agent_handle, rule_id))
 
     def list_all(
         self,
         *,
-        mailbox_id: UUID | str | None = None,
+        agent_identity_id: UUID | str | None = None,
         action: MailRuleAction | str | None = None,
         match_type: MailRuleMatchType | str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[MailContactRule]:
+    ) -> list[MailIdentityContactRule]:
         """Org-wide list of mail contact rules (admin-only).
 
         Args:
-            mailbox_id: Narrow to a single mailbox by id.
+            agent_identity_id: Narrow to a single agent identity by id.
             action: Filter by ``allow`` or ``block``.
             match_type: Filter by ``exact_email`` or ``domain``.
         """
         params: dict[str, Any] = {}
-        if mailbox_id is not None:
-            params["mailbox_id"] = str(mailbox_id)
+        if agent_identity_id is not None:
+            params["agent_identity_id"] = str(agent_identity_id)
         if action is not None:
             params["action"] = action.value if isinstance(action, MailRuleAction) else action
         if match_type is not None:
@@ -156,4 +157,4 @@ class MailContactRulesResource:
             params["offset"] = offset
         data = self._http.get(_ORG_BASE, params=params)
         items = data["items"] if isinstance(data, dict) and "items" in data else data
-        return [MailContactRule._from_dict(r) for r in items]
+        return [MailIdentityContactRule._from_dict(r) for r in items]

--- a/sdk/python/inkbox/mail/types.py
+++ b/sdk/python/inkbox/mail/types.py
@@ -377,7 +377,12 @@ class ThreadDetail(Thread):
 
 @dataclass
 class MailContactRule:
-    """An inbound/outbound allow/block rule scoped to a mailbox."""
+    """An inbound/outbound allow/block rule scoped to a mailbox.
+
+    Returned by the **legacy** per-mailbox routes
+    (``inkbox.mail_contact_rules``). The forward-looking, identity-keyed
+    shape is :class:`MailIdentityContactRule`.
+    """
 
     id: UUID
     mailbox_id: UUID
@@ -393,6 +398,40 @@ class MailContactRule:
         return cls(
             id=UUID(d["id"]),
             mailbox_id=UUID(d["mailbox_id"]),
+            action=MailRuleAction(d["action"]),
+            match_type=MailRuleMatchType(d["match_type"]),
+            match_target=d["match_target"],
+            status=ContactRuleStatus(d.get("status", "active")),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+        )
+
+
+@dataclass
+class MailIdentityContactRule:
+    """A mail allow/block rule scoped to an **agent identity**.
+
+    Returned by the identity-keyed routes
+    (``inkbox.mail_identity_contact_rules`` /
+    ``identity.list_mail_contact_rules()``). Same shape as
+    :class:`MailContactRule` but keyed by ``agent_identity_id`` instead
+    of ``mailbox_id``.
+    """
+
+    id: UUID
+    agent_identity_id: UUID
+    action: MailRuleAction
+    match_type: MailRuleMatchType
+    match_target: str
+    status: ContactRuleStatus
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> MailIdentityContactRule:
+        return cls(
+            id=UUID(d["id"]),
+            agent_identity_id=UUID(d["agent_identity_id"]),
             action=MailRuleAction(d["action"]),
             match_type=MailRuleMatchType(d["match_type"]),
             match_target=d["match_target"],

--- a/sdk/python/inkbox/phone/resources/identity_contact_rules.py
+++ b/sdk/python/inkbox/phone/resources/identity_contact_rules.py
@@ -1,7 +1,22 @@
 """
-inkbox/phone/resources/contact_rules.py
+inkbox/phone/resources/identity_contact_rules.py
 
-Phone contact rules (per-number allow/block rules + org-wide list).
+Identity-keyed phone contact rules (per-agent-identity allow/block rules
++ org-wide list).
+
+Phone (voice + SMS) rules live on the **agent identity**, addressed by
+``agent_handle``, mirroring the iMessage rule shape. The legacy
+per-number resource (``inkbox.phone_contact_rules``) is kept as a
+deprecated wrapper.
+
+The identity must have a phone number: ``create`` returns 422 and the
+identity helpers guard with ``_require_phone()`` before the request.
+Listing an identity with no number returns an empty list.
+
+Transport note: rides the api-root transport (``{base}/api/v1``) so it
+addresses both ``/identities/{handle}/phone-contact-rules`` and the
+org-wide ``/phone/contact-rules`` with full paths. It must NOT ride the
+``/phone``-prefixed transport.
 """
 
 from __future__ import annotations
@@ -11,7 +26,7 @@ from uuid import UUID
 
 from inkbox.mail.types import ContactRuleStatus
 from inkbox.phone.types import (
-    PhoneContactRule,
+    PhoneIdentityContactRule,
     PhoneRuleAction,
     PhoneRuleMatchType,
 )
@@ -19,40 +34,32 @@ from inkbox.phone.types import (
 if TYPE_CHECKING:
     from inkbox._http import HttpTransport
 
-_BASE = "/numbers"
-_ORG_BASE = "/contact-rules"
+_ORG_BASE = "/phone/contact-rules"
 _UNSET = object()
 
 
-def _rule_path(phone_number_id: UUID | str, rule_id: UUID | str | None = None) -> str:
-    base = f"{_BASE}/{phone_number_id}/contact-rules"
+def _rule_path(agent_handle: str, rule_id: UUID | str | None = None) -> str:
+    base = f"/identities/{agent_handle}/phone-contact-rules"
     return base if rule_id is None else f"{base}/{rule_id}"
 
 
-class PhoneContactRulesResource:
-    """Allow/block rules scoped to phone numbers (voice + SMS).
-
-    .. deprecated::
-        Phone contact rules are now keyed by **agent identity**. Use
-        ``inkbox.phone_identity_contact_rules`` (or
-        ``identity.list_phone_contact_rules()`` etc.) instead. These
-        per-number routes still work but hit the deprecated server
-        endpoints (Sunset 2026-08-31) and return the legacy
-        ``phone_number_id`` shape.
-    """
+class PhoneIdentityContactRulesResource:
+    """Allow/block phone rules scoped to agent identities (voice + SMS)."""
 
     def __init__(self, http: HttpTransport) -> None:
         self._http = http
 
     def list(
         self,
-        phone_number_id: UUID | str,
+        agent_handle: str,
         *,
         action: PhoneRuleAction | str | None = None,
         match_type: PhoneRuleMatchType | str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[PhoneContactRule]:
+    ) -> list[PhoneIdentityContactRule]:
+        """List rules for an identity. Returns an empty list when the
+        identity has no phone number."""
         params: dict[str, Any] = {}
         if action is not None:
             params["action"] = action.value if isinstance(action, PhoneRuleAction) else action
@@ -64,24 +71,27 @@ class PhoneContactRulesResource:
             params["limit"] = limit
         if offset is not None:
             params["offset"] = offset
-        data = self._http.get(_rule_path(phone_number_id), params=params)
+        data = self._http.get(_rule_path(agent_handle), params=params)
         items = data["items"] if isinstance(data, dict) and "items" in data else data
-        return [PhoneContactRule._from_dict(r) for r in items]
+        return [PhoneIdentityContactRule._from_dict(r) for r in items]
 
-    def get(self, phone_number_id: UUID | str, rule_id: UUID | str) -> PhoneContactRule:
-        data = self._http.get(_rule_path(phone_number_id, rule_id))
-        return PhoneContactRule._from_dict(data)
+    def get(self, agent_handle: str, rule_id: UUID | str) -> PhoneIdentityContactRule:
+        data = self._http.get(_rule_path(agent_handle, rule_id))
+        return PhoneIdentityContactRule._from_dict(data)
 
     def create(
         self,
-        phone_number_id: UUID | str,
+        agent_handle: str,
         *,
         action: PhoneRuleAction | str,
         match_target: str,
         match_type: PhoneRuleMatchType | str = PhoneRuleMatchType.EXACT_NUMBER,
-    ) -> PhoneContactRule:
-        """Create a rule. New rules are always ``active``; use
-        :meth:`update` to pause one after creation.
+    ) -> PhoneIdentityContactRule:
+        """Create a rule for an agent identity. New rules are always
+        ``active``; use :meth:`update` to pause one after creation.
+
+        The identity must have a phone number — otherwise the server
+        returns 422.
 
         Raises :class:`DuplicateContactRuleError` on 409 when a non-deleted
         rule with the same ``(match_type, match_target)`` already exists.
@@ -93,17 +103,17 @@ class PhoneContactRulesResource:
             ),
             "match_target": match_target,
         }
-        data = self._http.post(_rule_path(phone_number_id), json=body)
-        return PhoneContactRule._from_dict(data)
+        data = self._http.post(_rule_path(agent_handle), json=body)
+        return PhoneIdentityContactRule._from_dict(data)
 
     def update(
         self,
-        phone_number_id: UUID | str,
+        agent_handle: str,
         rule_id: UUID | str,
         *,
         action: PhoneRuleAction | str = _UNSET,  # type: ignore[assignment]
         status: ContactRuleStatus | str = _UNSET,  # type: ignore[assignment]
-    ) -> PhoneContactRule:
+    ) -> PhoneIdentityContactRule:
         """Update ``action`` or ``status`` (admin-only)."""
         body: dict[str, Any] = {}
         if action is not _UNSET:
@@ -114,32 +124,32 @@ class PhoneContactRulesResource:
             body["status"] = (
                 status.value if isinstance(status, ContactRuleStatus) else status
             )
-        data = self._http.patch(_rule_path(phone_number_id, rule_id), json=body)
-        return PhoneContactRule._from_dict(data)
+        data = self._http.patch(_rule_path(agent_handle, rule_id), json=body)
+        return PhoneIdentityContactRule._from_dict(data)
 
-    def delete(self, phone_number_id: UUID | str, rule_id: UUID | str) -> None:
+    def delete(self, agent_handle: str, rule_id: UUID | str) -> None:
         """Delete a rule (admin-only)."""
-        self._http.delete(_rule_path(phone_number_id, rule_id))
+        self._http.delete(_rule_path(agent_handle, rule_id))
 
     def list_all(
         self,
         *,
-        phone_number_id: UUID | str | None = None,
+        agent_identity_id: UUID | str | None = None,
         action: PhoneRuleAction | str | None = None,
         match_type: PhoneRuleMatchType | str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[PhoneContactRule]:
+    ) -> list[PhoneIdentityContactRule]:
         """Org-wide list of phone contact rules (admin-only).
 
         Args:
-            phone_number_id: Narrow to a single phone number by id.
+            agent_identity_id: Narrow to a single agent identity by id.
             action: Filter by ``allow`` or ``block``.
             match_type: Filter by ``exact_number``.
         """
         params: dict[str, Any] = {}
-        if phone_number_id is not None:
-            params["phone_number_id"] = str(phone_number_id)
+        if agent_identity_id is not None:
+            params["agent_identity_id"] = str(agent_identity_id)
         if action is not None:
             params["action"] = action.value if isinstance(action, PhoneRuleAction) else action
         if match_type is not None:
@@ -152,4 +162,4 @@ class PhoneContactRulesResource:
             params["offset"] = offset
         data = self._http.get(_ORG_BASE, params=params)
         items = data["items"] if isinstance(data, dict) and "items" in data else data
-        return [PhoneContactRule._from_dict(r) for r in items]
+        return [PhoneIdentityContactRule._from_dict(r) for r in items]

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -498,7 +498,12 @@ class SmsOptIn:
 
 @dataclass
 class PhoneContactRule:
-    """An inbound/outbound allow/block rule scoped to a phone number."""
+    """An inbound/outbound allow/block rule scoped to a phone number.
+
+    Returned by the **legacy** per-number routes
+    (``inkbox.phone_contact_rules``). The forward-looking, identity-keyed
+    shape is :class:`PhoneIdentityContactRule`.
+    """
 
     id: UUID
     phone_number_id: UUID
@@ -514,6 +519,40 @@ class PhoneContactRule:
         return cls(
             id=UUID(d["id"]),
             phone_number_id=UUID(d["phone_number_id"]),
+            action=PhoneRuleAction(d["action"]),
+            match_type=PhoneRuleMatchType(d["match_type"]),
+            match_target=d["match_target"],
+            status=ContactRuleStatus(d.get("status", "active")),
+            created_at=datetime.fromisoformat(d["created_at"]),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+        )
+
+
+@dataclass
+class PhoneIdentityContactRule:
+    """A phone allow/block rule scoped to an **agent identity**.
+
+    Returned by the identity-keyed routes
+    (``inkbox.phone_identity_contact_rules`` /
+    ``identity.list_phone_contact_rules()``). Same shape as
+    :class:`PhoneContactRule` but keyed by ``agent_identity_id`` instead
+    of ``phone_number_id``.
+    """
+
+    id: UUID
+    agent_identity_id: UUID
+    action: PhoneRuleAction
+    match_type: PhoneRuleMatchType
+    match_target: str
+    status: ContactRuleStatus
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> PhoneIdentityContactRule:
+        return cls(
+            id=UUID(d["id"]),
+            agent_identity_id=UUID(d["agent_identity_id"]),
             action=PhoneRuleAction(d["action"]),
             match_type=PhoneRuleMatchType(d["match_type"]),
             match_target=d["match_target"],

--- a/sdk/python/inkbox/signing_keys.py
+++ b/sdk/python/inkbox/signing_keys.py
@@ -1,7 +1,15 @@
 """
 inkbox/signing_keys.py
 
-Org-level webhook signing key management, shared across all Inkbox clients.
+Per-identity webhook signing key management.
+
+Each agent identity has its own signing key used to verify the webhooks
+(and WebSocket upgrades) for that identity's mail / phone / iMessage
+traffic. Manage it via ``inkbox.signing_keys.create_or_rotate(handle)`` /
+``get_status(handle)``, or the ``identity.create_signing_key()`` /
+``identity.get_signing_key_status()`` convenience methods.
+
+The legacy no-arg / org-level calls are kept as deprecated bridges.
 """
 
 from __future__ import annotations
@@ -16,7 +24,7 @@ from typing import Any, Mapping
 @dataclass
 class SigningKey:
     """
-    Org-level webhook signing key.
+    A webhook signing key.
 
     Returned once on creation/rotation — store ``signing_key`` securely.
     """
@@ -29,6 +37,27 @@ class SigningKey:
         return cls(
             signing_key=d["signing_key"],
             created_at=datetime.fromisoformat(d["created_at"]),
+        )
+
+
+@dataclass
+class SigningKeyStatus:
+    """
+    Status of an identity's webhook signing key.
+
+    ``configured`` is ``True`` once a key exists; ``created_at`` is when
+    it was created or last rotated (``None`` when not configured).
+    """
+
+    configured: bool
+    created_at: datetime | None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> SigningKeyStatus:
+        created_at = d.get("created_at")
+        return cls(
+            configured=bool(d.get("configured", False)),
+            created_at=datetime.fromisoformat(created_at) if created_at else None,
         )
 
 
@@ -66,18 +95,39 @@ def verify_webhook(
     return hmac.compare_digest(expected, received)
 
 
+def _identity_path(agent_handle: str) -> str:
+    return f"/identities/{agent_handle}/signing-key"
+
+
 class SigningKeysResource:
+    """Webhook signing key management.
+
+    Rides the api-root transport (``{base}/api/v1``) so it can address
+    both the per-identity routes (``/identities/{handle}/signing-key``)
+    and the deprecated org-level route (``/signing-keys``).
+    """
 
     def __init__(self, http: Any) -> None:
         self._http = http
 
-    def create_or_rotate(self) -> SigningKey:
+    def create_or_rotate(self, agent_handle: str | None = None) -> SigningKey:
         """
-        Create or rotate the webhook signing key for your organisation.
+        Create or rotate a webhook signing key.
 
-        The first call creates a new key; subsequent calls rotate (replace) the
-        existing key. The plaintext ``signing_key`` is returned **once** —
-        store it securely as it cannot be retrieved again.
+        Pass ``agent_handle`` to create/rotate **that identity's** key
+        (the forward-looking surface). The first call mints a key;
+        subsequent calls rotate (replace) it. The plaintext
+        ``signing_key`` is returned **once** — store it securely, it
+        cannot be retrieved again.
+
+        .. deprecated::
+            Calling with no ``agent_handle`` hits the deprecated org-level
+            ``/signing-keys`` route (Sunset 2026-08-31). With an
+            agent-scoped API key the server rotates that key's identity;
+            with an admin key it returns 409 (``InkboxAPIError``) pointing
+            at the per-identity route. Prefer
+            ``create_or_rotate(agent_handle)`` or
+            ``identity.create_signing_key()``.
 
         Use the returned key to verify ``X-Inkbox-Signature`` headers on
         incoming webhook requests.
@@ -85,5 +135,26 @@ class SigningKeysResource:
         Returns:
             The newly created/rotated signing key with its creation timestamp.
         """
-        data = self._http.post("/signing-keys", json={})
+        path = "/signing-keys" if agent_handle is None else _identity_path(agent_handle)
+        data = self._http.post(path, json={})
         return SigningKey._from_dict(data)
+
+    def get_status(self, agent_handle: str | None = None) -> SigningKeyStatus:
+        """
+        Report whether a signing key is configured.
+
+        Pass ``agent_handle`` for that identity's status (the
+        forward-looking surface).
+
+        .. deprecated::
+            Calling with no ``agent_handle`` hits the deprecated org-level
+            ``/signing-keys`` route (Sunset 2026-08-31): with an
+            agent-scoped key it reports that identity's status; with an
+            admin key it reports an org-aggregate status (``configured``
+            true if any identity in the org has a key). Prefer
+            ``get_status(agent_handle)`` or
+            ``identity.get_signing_key_status()``.
+        """
+        path = "/signing-keys" if agent_handle is None else _identity_path(agent_handle)
+        data = self._http.get(path)
+        return SigningKeyStatus._from_dict(data)

--- a/sdk/python/inkbox/webhook_subscriptions.py
+++ b/sdk/python/inkbox/webhook_subscriptions.py
@@ -42,7 +42,12 @@ class WebhookSubscription:
     """A webhook subscription row returned by the API.
 
     Exactly one of ``mailbox_id`` / ``phone_number_id`` /
-    ``agent_identity_id`` is populated.
+    ``agent_identity_id`` (the raw owner FK) is populated.
+    ``owner_identity_id`` is the **resolved** owning agent identity for
+    every subscription regardless of channel — mail/phone subs resolve
+    it server-side through the mailbox / phone number, while iMessage
+    subs carry it directly. (Optional for forward-compatibility: ``None``
+    on servers that predate the field.)
     ``organization_id`` is an ``"org_..."`` token string, not a UUID.
     ``status`` is always ``"active"`` for subscriptions callers can
     observe; deleted subscriptions are not returned by ``list`` /
@@ -59,6 +64,7 @@ class WebhookSubscription:
     status: WebhookSubscriptionStatus
     created_at: datetime
     updated_at: datetime
+    owner_identity_id: UUID | None = None
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> WebhookSubscription:
@@ -75,7 +81,28 @@ class WebhookSubscription:
             status=d["status"],
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
+            owner_identity_id=(
+                UUID(d["owner_identity_id"]) if d.get("owner_identity_id") else None
+            ),
         )
+
+
+@dataclass
+class WebhookSubscriptionCreateResponse(WebhookSubscription):
+    """The response from creating a webhook subscription.
+
+    Extends :class:`WebhookSubscription` with a one-time ``signing_key``.
+    It is populated **only** on the request that first mints the owning
+    identity's signing key (returned once — store it securely); on every
+    other create it is ``None``. List/get/update never return it.
+    """
+
+    signing_key: str | None = None
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> WebhookSubscriptionCreateResponse:
+        base = WebhookSubscription._from_dict(d)
+        return cls(**base.__dict__, signing_key=d.get("signing_key"))
 
 
 def _assert_url_not_none(url: Any) -> None:
@@ -191,7 +218,7 @@ class WebhookSubscriptionsResource:
         mailbox_id: UUID | str | None = None,
         phone_number_id: UUID | str | None = None,
         agent_identity_id: UUID | str | None = None,
-    ) -> WebhookSubscription:
+    ) -> WebhookSubscriptionCreateResponse:
         """Create a webhook subscription.
 
         Exactly one of ``mailbox_id`` / ``phone_number_id`` /
@@ -199,6 +226,12 @@ class WebhookSubscriptionsResource:
         non-empty list of distinct values belonging to the owner's
         channel (mailbox -> ``message.*``, phone number -> ``text.*``,
         agent identity -> ``imessage.*``).
+
+        Returns a :class:`WebhookSubscriptionCreateResponse`. Its
+        ``signing_key`` is populated **once** when this is the first
+        subscription for an identity that had no signing key yet — store
+        it securely; it is the only time the plaintext secret is shown.
+        Otherwise ``signing_key`` is ``None``.
         """
         owners: dict[str, UUID | str | None] = {
             "mailbox": mailbox_id,
@@ -227,7 +260,7 @@ class WebhookSubscriptionsResource:
             f"{owner}_id": _uuid_str(owners[owner]),  # type: ignore[arg-type]
         }
         data = self._http.post(_BASE, json=body)
-        return WebhookSubscription._from_dict(data)
+        return WebhookSubscriptionCreateResponse._from_dict(data)
 
     def update(
         self,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.14"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_identities_types.py
+++ b/sdk/python/tests/test_identities_types.py
@@ -4,7 +4,7 @@ sdk/python/tests/test_identities_types.py
 Tests for identities type parsing.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from sample_data_identities import (
@@ -159,3 +159,39 @@ class TestIdentityIMessageFields:
         summary = AgentIdentitySummary._from_dict(d)
         assert summary.imessage_enabled is False
         assert summary.imessage_filter_mode is FilterMode.BLACKLIST
+
+
+class TestIdentitySigningKeyStatusFields:
+    def test_summary_parses_signing_key_status(self):
+        d = {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "organization_id": "org_x",
+            "agent_handle": "support-bot",
+            "display_name": None,
+            "description": None,
+            "email_address": None,
+            "created_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+            "signing_key_configured": True,
+            "signing_key_created_at": "2026-06-02T03:04:05+00:00",
+        }
+        summary = AgentIdentitySummary._from_dict(d)
+        assert summary.signing_key_configured is True
+        assert summary.signing_key_created_at == datetime(
+            2026, 6, 2, 3, 4, 5, tzinfo=timezone.utc,
+        )
+
+    def test_summary_defaults_signing_key_status_when_absent(self):
+        d = {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "organization_id": "org_x",
+            "agent_handle": "support-bot",
+            "display_name": None,
+            "description": None,
+            "email_address": None,
+            "created_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+        }
+        summary = AgentIdentitySummary._from_dict(d)
+        assert summary.signing_key_configured is False
+        assert summary.signing_key_created_at is None

--- a/sdk/python/tests/test_identity_scoped_features.py
+++ b/sdk/python/tests/test_identity_scoped_features.py
@@ -1,0 +1,387 @@
+"""
+sdk/python/tests/test_identity_scoped_features.py
+
+Tests for the identity-scoped contact rules + per-identity signing keys:
+- MailIdentityContactRulesResource / PhoneIdentityContactRulesResource
+- SigningKeysResource per-identity status/rotate (+ deprecated org-level)
+- WebhookSubscriptionsResource.create -> WebhookSubscriptionCreateResponse
+- AgentIdentity convenience methods + identity.update filter modes
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from sample_data_identities import IDENTITY_DETAIL_DICT
+
+from inkbox.agent_identity import AgentIdentity
+from inkbox.identities.types import AgentIdentitySummary, _AgentIdentityData
+from inkbox.mail.exceptions import InkboxError
+from inkbox.mail.resources.identity_contact_rules import (
+    MailIdentityContactRulesResource,
+)
+from inkbox.mail.types import FilterMode, MailIdentityContactRule
+from inkbox.phone.resources.identity_contact_rules import (
+    PhoneIdentityContactRulesResource,
+)
+from inkbox.phone.types import PhoneIdentityContactRule
+from inkbox.signing_keys import SigningKey, SigningKeysResource, SigningKeyStatus
+from inkbox.webhook_subscriptions import (
+    WebhookSubscription,
+    WebhookSubscriptionCreateResponse,
+    WebhookSubscriptionsResource,
+)
+
+
+_AGENT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+MAIL_RULE_DICT = {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "agent_identity_id": _AGENT_ID,
+    "action": "block",
+    "match_type": "exact_email",
+    "match_target": "spam@example.com",
+    "status": "active",
+    "created_at": "2026-06-09T12:30:00Z",
+    "updated_at": "2026-06-09T12:30:00Z",
+}
+
+PHONE_RULE_DICT = {
+    "id": "22222222-2222-2222-2222-222222222222",
+    "agent_identity_id": _AGENT_ID,
+    "action": "block",
+    "match_type": "exact_number",
+    "match_target": "+14155550199",
+    "status": "active",
+    "created_at": "2026-06-09T12:30:00Z",
+    "updated_at": "2026-06-09T12:30:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Mail identity contact-rule resource
+# ---------------------------------------------------------------------------
+
+
+class TestMailIdentityContactRulesResource:
+    def _res(self):
+        http = MagicMock()
+        return MailIdentityContactRulesResource(http), http
+
+    def test_list_path_and_parse(self):
+        res, http = self._res()
+        http.get.return_value = [MAIL_RULE_DICT]
+        rows = res.list("my-agent", action="block")
+        http.get.assert_called_once_with(
+            "/identities/my-agent/mail-contact-rules", params={"action": "block"}
+        )
+        assert len(rows) == 1
+        assert isinstance(rows[0], MailIdentityContactRule)
+        assert rows[0].agent_identity_id == UUID(_AGENT_ID)
+
+    def test_create_path_and_body(self):
+        res, http = self._res()
+        http.post.return_value = MAIL_RULE_DICT
+        res.create(
+            "my-agent", action="block", match_type="exact_email",
+            match_target="spam@example.com",
+        )
+        http.post.assert_called_once_with(
+            "/identities/my-agent/mail-contact-rules",
+            json={
+                "action": "block",
+                "match_type": "exact_email",
+                "match_target": "spam@example.com",
+            },
+        )
+
+    def test_get_update_delete_paths(self):
+        res, http = self._res()
+        http.get.return_value = MAIL_RULE_DICT
+        http.patch.return_value = MAIL_RULE_DICT
+        rid = MAIL_RULE_DICT["id"]
+        res.get("my-agent", rid)
+        http.get.assert_called_with(f"/identities/my-agent/mail-contact-rules/{rid}")
+        res.update("my-agent", rid, status="paused")
+        http.patch.assert_called_once_with(
+            f"/identities/my-agent/mail-contact-rules/{rid}", json={"status": "paused"}
+        )
+        res.delete("my-agent", rid)
+        http.delete.assert_called_once_with(
+            f"/identities/my-agent/mail-contact-rules/{rid}"
+        )
+
+    def test_list_all_filters_by_agent_identity_id(self):
+        res, http = self._res()
+        http.get.return_value = [MAIL_RULE_DICT]
+        res.list_all(agent_identity_id=_AGENT_ID)
+        http.get.assert_called_once_with(
+            "/mail/contact-rules", params={"agent_identity_id": _AGENT_ID}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phone identity contact-rule resource
+# ---------------------------------------------------------------------------
+
+
+class TestPhoneIdentityContactRulesResource:
+    def _res(self):
+        http = MagicMock()
+        return PhoneIdentityContactRulesResource(http), http
+
+    def test_list_path_and_parse(self):
+        res, http = self._res()
+        http.get.return_value = [PHONE_RULE_DICT]
+        rows = res.list("my-agent")
+        http.get.assert_called_once_with(
+            "/identities/my-agent/phone-contact-rules", params={}
+        )
+        assert isinstance(rows[0], PhoneIdentityContactRule)
+        assert rows[0].agent_identity_id == UUID(_AGENT_ID)
+
+    def test_create_defaults_match_type_exact_number(self):
+        res, http = self._res()
+        http.post.return_value = PHONE_RULE_DICT
+        res.create("my-agent", action="block", match_target="+14155550199")
+        http.post.assert_called_once_with(
+            "/identities/my-agent/phone-contact-rules",
+            json={
+                "action": "block",
+                "match_type": "exact_number",
+                "match_target": "+14155550199",
+            },
+        )
+
+    def test_list_all_filters_by_agent_identity_id(self):
+        res, http = self._res()
+        http.get.return_value = [PHONE_RULE_DICT]
+        res.list_all(agent_identity_id=_AGENT_ID, action="block")
+        http.get.assert_called_once_with(
+            "/phone/contact-rules",
+            params={"agent_identity_id": _AGENT_ID, "action": "block"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Signing keys (per-identity + deprecated org-level)
+# ---------------------------------------------------------------------------
+
+
+class TestSigningKeysPerIdentity:
+    def _res(self):
+        http = MagicMock()
+        return SigningKeysResource(http), http
+
+    def test_create_or_rotate_with_handle_hits_identity_path(self):
+        res, http = self._res()
+        http.post.return_value = {
+            "signing_key": "sk-fresh", "created_at": "2026-06-09T00:00:00Z",
+        }
+        key = res.create_or_rotate("my-agent")
+        http.post.assert_called_once_with(
+            "/identities/my-agent/signing-key", json={}
+        )
+        assert isinstance(key, SigningKey)
+        assert key.signing_key == "sk-fresh"
+
+    def test_create_or_rotate_no_handle_hits_org_path(self):
+        res, http = self._res()
+        http.post.return_value = {
+            "signing_key": "sk-org", "created_at": "2026-06-09T00:00:00Z",
+        }
+        res.create_or_rotate()
+        http.post.assert_called_once_with("/signing-keys", json={})
+
+    def test_get_status_with_handle(self):
+        res, http = self._res()
+        http.get.return_value = {
+            "configured": True, "created_at": "2026-06-09T00:00:00Z",
+        }
+        status = res.get_status("my-agent")
+        http.get.assert_called_once_with("/identities/my-agent/signing-key")
+        assert isinstance(status, SigningKeyStatus)
+        assert status.configured is True
+        assert status.created_at == datetime(2026, 6, 9, tzinfo=timezone.utc)
+
+    def test_get_status_not_configured(self):
+        res, http = self._res()
+        http.get.return_value = {"configured": False, "created_at": None}
+        status = res.get_status("my-agent")
+        assert status.configured is False
+        assert status.created_at is None
+
+    def test_get_status_no_handle_hits_org_path(self):
+        res, http = self._res()
+        http.get.return_value = {"configured": True, "created_at": None}
+        res.get_status()
+        http.get.assert_called_once_with("/signing-keys")
+
+
+# ---------------------------------------------------------------------------
+# Webhook subscription create-response (signing_key + owner_identity_id)
+# ---------------------------------------------------------------------------
+
+
+def _sub_dict(**overrides):
+    base = {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "organization_id": "org_abc",
+        "mailbox_id": "44444444-4444-4444-4444-444444444444",
+        "phone_number_id": None,
+        "agent_identity_id": None,
+        "owner_identity_id": _AGENT_ID,
+        "url": "https://example.com/hook",
+        "event_types": ["message.received"],
+        "status": "active",
+        "created_at": "2026-06-09T00:00:00Z",
+        "updated_at": "2026-06-09T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestWebhookSubscriptionCreateResponse:
+    def _res(self):
+        http = MagicMock()
+        return WebhookSubscriptionsResource(http), http
+
+    def test_create_returns_create_response_with_signing_key(self):
+        res, http = self._res()
+        http.post.return_value = _sub_dict(signing_key="sk-once")
+        result = res.create(
+            url="https://example.com/hook",
+            event_types=["message.received"],
+            mailbox_id="44444444-4444-4444-4444-444444444444",
+        )
+        assert isinstance(result, WebhookSubscriptionCreateResponse)
+        assert result.signing_key == "sk-once"
+        assert result.owner_identity_id == UUID(_AGENT_ID)
+
+    def test_create_signing_key_absent_is_none(self):
+        res, http = self._res()
+        http.post.return_value = _sub_dict()  # no signing_key key
+        result = res.create(
+            url="https://example.com/hook",
+            event_types=["message.received"],
+            mailbox_id="44444444-4444-4444-4444-444444444444",
+        )
+        assert result.signing_key is None
+
+    def test_owner_identity_id_optional_back_compat(self):
+        # A server response that predates owner_identity_id must still parse.
+        d = _sub_dict()
+        del d["owner_identity_id"]
+        sub = WebhookSubscription._from_dict(d)
+        assert sub.owner_identity_id is None
+
+
+# ---------------------------------------------------------------------------
+# AgentIdentity convenience methods + filter-mode update
+# ---------------------------------------------------------------------------
+
+
+def _identity():
+    data = _AgentIdentityData._from_dict(IDENTITY_DETAIL_DICT)
+    inkbox = MagicMock()
+    return AgentIdentity(data, inkbox), inkbox
+
+
+def _identity_without_phone():
+    detail = {**IDENTITY_DETAIL_DICT, "phone_number": None}
+    data = _AgentIdentityData._from_dict(detail)
+    inkbox = MagicMock()
+    return AgentIdentity(data, inkbox), inkbox
+
+
+class TestAgentIdentityContactRuleDelegation:
+    def test_create_mail_contact_rule_delegates(self):
+        identity, inkbox = _identity()
+        inkbox._mail_identity_contact_rules.create.return_value = (
+            MailIdentityContactRule._from_dict(MAIL_RULE_DICT)
+        )
+        identity.create_mail_contact_rule(
+            action="block", match_type="exact_email", match_target="spam@example.com",
+        )
+        inkbox._mail_identity_contact_rules.create.assert_called_once_with(
+            identity.agent_handle,
+            action="block",
+            match_type="exact_email",
+            match_target="spam@example.com",
+        )
+
+    def test_update_mail_contact_rule_only_forwards_set_kwargs(self):
+        identity, inkbox = _identity()
+        identity.update_mail_contact_rule("rid", status="paused")
+        inkbox._mail_identity_contact_rules.update.assert_called_once_with(
+            identity.agent_handle, "rid", status="paused",
+        )
+
+    def test_phone_rule_requires_phone_number(self):
+        identity, _ = _identity_without_phone()
+        with pytest.raises(InkboxError, match="no phone number"):
+            identity.list_phone_contact_rules()
+
+    def test_create_phone_contact_rule_delegates(self):
+        identity, inkbox = _identity()
+        inkbox._phone_identity_contact_rules.create.return_value = (
+            PhoneIdentityContactRule._from_dict(PHONE_RULE_DICT)
+        )
+        identity.create_phone_contact_rule(action="block", match_target="+14155550199")
+        inkbox._phone_identity_contact_rules.create.assert_called_once_with(
+            identity.agent_handle,
+            action="block",
+            match_target="+14155550199",
+            match_type="exact_number",
+        )
+
+
+class TestAgentIdentitySigningKeyDelegation:
+    def test_create_signing_key_delegates(self):
+        identity, inkbox = _identity()
+        identity.create_signing_key()
+        inkbox._signing_keys.create_or_rotate.assert_called_once_with(
+            identity.agent_handle
+        )
+
+    def test_get_signing_key_status_delegates(self):
+        identity, inkbox = _identity()
+        identity.get_signing_key_status()
+        inkbox._signing_keys.get_status.assert_called_once_with(identity.agent_handle)
+
+
+class TestAgentIdentityFilterModeUpdate:
+    def test_update_sends_filter_modes_and_refreshes_cache(self):
+        identity, inkbox = _identity()
+        # The server (mirrored) returns the updated summary including the
+        # new filter modes; the cache rebuild must carry them.
+        updated = AgentIdentitySummary._from_dict(
+            {
+                "id": str(identity.id),
+                "organization_id": identity._data.organization_id,
+                "agent_handle": identity.agent_handle,
+                "display_name": None,
+                "description": None,
+                "email_address": None,
+                "created_at": "2026-06-09T00:00:00Z",
+                "updated_at": "2026-06-09T00:00:00Z",
+                "imessage_enabled": False,
+                "imessage_filter_mode": "blacklist",
+                "mail_filter_mode": "whitelist",
+                "phone_filter_mode": "whitelist",
+            }
+        )
+        inkbox._ids_resource.update.return_value = updated
+
+        identity.update(mail_filter_mode="whitelist", phone_filter_mode="whitelist")
+
+        inkbox._ids_resource.update.assert_called_once_with(
+            identity.agent_handle,
+            mail_filter_mode="whitelist",
+            phone_filter_mode="whitelist",
+        )
+        # Regression: rebuild must not reset the cached modes to default.
+        assert identity.mail_filter_mode == FilterMode.WHITELIST
+        assert identity.phone_filter_mode == FilterMode.WHITELIST

--- a/sdk/python/tests/test_identity_scoped_features.py
+++ b/sdk/python/tests/test_identity_scoped_features.py
@@ -319,10 +319,24 @@ class TestAgentIdentityContactRuleDelegation:
             identity.agent_handle, "rid", status="paused",
         )
 
-    def test_phone_rule_requires_phone_number(self):
+    def test_list_phone_contact_rules_without_phone_returns_empty(self):
+        identity, inkbox = _identity_without_phone()
+        inkbox._phone_identity_contact_rules.list.return_value = []
+        # List must not prethrow on a phoneless identity: the server requires a
+        # phone only for create/get/update/delete, not for list.
+        assert identity.list_phone_contact_rules() == []
+        inkbox._phone_identity_contact_rules.list.assert_called_once()
+
+    def test_phone_rule_cgud_requires_phone_number(self):
         identity, _ = _identity_without_phone()
         with pytest.raises(InkboxError, match="no phone number"):
-            identity.list_phone_contact_rules()
+            identity.get_phone_contact_rule("rid")
+        with pytest.raises(InkboxError, match="no phone number"):
+            identity.create_phone_contact_rule(action="block", match_target="+14155550199")
+        with pytest.raises(InkboxError, match="no phone number"):
+            identity.update_phone_contact_rule("rid", status="paused")
+        with pytest.raises(InkboxError, match="no phone number"):
+            identity.delete_phone_contact_rule("rid")
 
     def test_create_phone_contact_rule_delegates(self):
         identity, inkbox = _identity()

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -91,16 +91,27 @@ Org-level accessors on `Inkbox` mirror the Python `@property` names:
 
 | Domain | Accessor |
 |---|---|
-| Mail | `mailboxes()`, `messages()`, `threads()`, `mail_contact_rules()`, `domains()` |
-| Phone | `calls()`, `phone_numbers()`, `texts()`, `transcripts()`, `phone_contact_rules()`, `sms_opt_ins()` |
+| Mail | `mailboxes()`, `messages()`, `threads()`, `mail_identity_contact_rules()`, `mail_contact_rules()` *(deprecated)*, `domains()` |
+| Phone | `calls()`, `phone_numbers()`, `texts()`, `transcripts()`, `phone_identity_contact_rules()`, `phone_contact_rules()` *(deprecated)*, `sms_opt_ins()` |
 | iMessage | `imessages()`, `imessage_contact_rules()` |
 | Vault / data | `vault()`, `contacts()`, `notes()` |
-| Org | `api_keys()`, `identities()`, `tunnels()`, `webhooks()` |
+| Org | `api_keys()`, `identities()`, `signing_keys()`, `tunnels()`, `webhooks()` |
+
+Contact rules and webhook signing keys are keyed by **agent identity**, addressed
+by `agent_handle`. Use `mail_identity_contact_rules()` /
+`phone_identity_contact_rules()` (per-identity `list`/`get`/`create`/`update`/
+`delete` plus an org-wide `list_all`) and `signing_keys()`
+(`create_or_rotate(handle)` / `get_status(handle)`). The legacy per-mailbox /
+per-number `mail_contact_rules()` / `phone_contact_rules()` accessors and the
+org-level `create_signing_key()` are deprecated bridges that remain for
+back-compat.
 
 The per-identity facade `AgentIdentity` (from `create_identity` / `get_identity`)
 exposes channel-scoped convenience methods: `send_email`, `forward_email`,
 `iter_emails`, `place_call`, `send_text`, `send_imessage`, `credentials`,
-`create_secret`, `set_totp`, and more.
+`create_secret`, `set_totp`, the identity-keyed contact-rule helpers
+(`list_mail_contact_rules`, `create_phone_contact_rule`, ...), `create_signing_key`,
+and more.
 
 Static (no-client) helpers for the public agent-signup flow live on `Inkbox`:
 `Inkbox::signup`, `verify_signup`, `resend_signup_verification`,

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -798,7 +798,8 @@ impl AgentIdentity {
 
     /// List this identity's phone allow/block rules, newest first.
     ///
-    /// Errors if this identity has no phone number.
+    /// Returns `[]` for a phoneless identity; the server requires a phone only
+    /// for create/get/update/delete, not for list.
     pub fn list_phone_contact_rules(
         &self,
         action: Option<PhoneRuleAction>,
@@ -806,7 +807,6 @@ impl AgentIdentity {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<Vec<PhoneIdentityContactRule>> {
-        self.require_phone()?;
         self.inkbox.phone_identity_contact_rules().list(
             &self.agent_handle(),
             action,
@@ -1131,5 +1131,68 @@ impl std::fmt::Debug for AgentIdentity {
             .field("mailbox", &mailbox)
             .field("phone", &phone)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identities::types::AgentIdentityData;
+
+    /// Build a phoneless identity backed by a client pointed at an unreachable
+    /// localhost port, so any real request fails fast instead of hanging.
+    fn phoneless_identity() -> AgentIdentity {
+        let data: AgentIdentityData = serde_json::from_value(serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "organization_id": "org_x",
+            "agent_handle": "support-bot",
+            "created_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+        }))
+        .unwrap();
+        let inkbox = Inkbox::builder("test-key")
+            .base_url("http://127.0.0.1:1")
+            .build()
+            .unwrap();
+        AgentIdentity::new(data, inkbox)
+    }
+
+    #[test]
+    fn list_phone_contact_rules_does_not_prethrow_without_phone() {
+        let identity = phoneless_identity();
+        // List must not prethrow the phone guard: with no server it surfaces a
+        // transport error, never InvalidArgument("no phone number").
+        if let Err(InkboxError::InvalidArgument(m)) =
+            identity.list_phone_contact_rules(None, None, None, None)
+        {
+            panic!("list prethrew the phone guard: {m}");
+        }
+    }
+
+    #[test]
+    fn phone_rule_cgud_still_requires_phone_number() {
+        let identity = phoneless_identity();
+        let results = [
+            identity.get_phone_contact_rule("rid").err(),
+            identity
+                .create_phone_contact_rule(
+                    PhoneRuleAction::Block,
+                    "+14155550199",
+                    PhoneRuleMatchType::ExactNumber,
+                )
+                .err(),
+            identity
+                .update_phone_contact_rule("rid", Some(PhoneRuleAction::Block), None)
+                .err(),
+            identity.delete_phone_contact_rule("rid").err(),
+        ];
+        for res in results {
+            match res {
+                Some(InkboxError::InvalidArgument(m)) => {
+                    assert!(m.contains("no phone number"), "unexpected message: {m}");
+                }
+                other => panic!("expected phone-required error, got {other:?}"),
+            }
+        }
     }
 }

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -48,13 +48,16 @@ use crate::imessage::types::{
     IMessageSendStyle,
 };
 use crate::mail::types::{
-    FilterMode, ForwardMode, Message, MessageDetail, MessageDirection, ThreadDetail,
+    ContactRuleStatus as MailContactRuleStatus, FilterMode, ForwardMode, MailIdentityContactRule,
+    MailRuleAction, MailRuleMatchType, Message, MessageDetail, MessageDirection, ThreadDetail,
 };
 use crate::phone::resources::texts::TextRecipients;
 use crate::phone::types::{
-    PhoneCall, PhoneCallWithRateLimit, PhoneTranscript, TextConversationSummary,
-    TextConversationUpdateResult, TextMessage,
+    ContactRuleStatus as PhoneContactRuleStatus, PhoneCall, PhoneCallWithRateLimit,
+    PhoneIdentityContactRule, PhoneRuleAction, PhoneRuleMatchType, PhoneTranscript,
+    TextConversationSummary, TextConversationUpdateResult, TextMessage,
 };
+use crate::signing_keys::{SigningKey, SigningKeyStatus};
 use crate::tunnels::types::Tunnel;
 use crate::vault::resources::vault::UnlockedVault;
 use crate::vault::totp::{TOTPCode, TOTPConfig};
@@ -141,6 +144,16 @@ impl AgentIdentity {
     /// Whitelist/blacklist mode for this identity's iMessage contact rules.
     pub fn imessage_filter_mode(&self) -> FilterMode {
         self.data.borrow().summary.imessage_filter_mode
+    }
+
+    /// Whitelist/blacklist mode for this identity's mail contact rules.
+    pub fn mail_filter_mode(&self) -> FilterMode {
+        self.data.borrow().summary.mail_filter_mode
+    }
+
+    /// Whitelist/blacklist mode for this identity's phone contact rules.
+    pub fn phone_filter_mode(&self) -> FilterMode {
+        self.data.borrow().summary.phone_filter_mode
     }
 
     /// Mailbox linked to this identity. Non-null for live identities (1:1 invariant).
@@ -714,11 +727,175 @@ impl AgentIdentity {
     }
 
     // -----------------------------------------------------------------------
+    // Mail contact rules (identity-keyed)
+    // -----------------------------------------------------------------------
+
+    /// List this identity's mail allow/block rules, newest first.
+    pub fn list_mail_contact_rules(
+        &self,
+        action: Option<MailRuleAction>,
+        match_type: Option<MailRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<MailIdentityContactRule>> {
+        self.inkbox.mail_identity_contact_rules().list(
+            &self.agent_handle(),
+            action,
+            match_type,
+            limit,
+            offset,
+        )
+    }
+
+    /// Get one of this identity's mail contact rules by id.
+    pub fn get_mail_contact_rule(&self, rule_id: &str) -> Result<MailIdentityContactRule> {
+        self.inkbox
+            .mail_identity_contact_rules()
+            .get(&self.agent_handle(), rule_id)
+    }
+
+    /// Create a mail allow/block rule for this identity.
+    pub fn create_mail_contact_rule(
+        &self,
+        action: MailRuleAction,
+        match_type: MailRuleMatchType,
+        match_target: &str,
+    ) -> Result<MailIdentityContactRule> {
+        self.inkbox.mail_identity_contact_rules().create(
+            &self.agent_handle(),
+            action,
+            match_type,
+            match_target,
+        )
+    }
+
+    /// Update a mail rule's `action` or `status` (admin-only). `None` arguments
+    /// are left unchanged.
+    pub fn update_mail_contact_rule(
+        &self,
+        rule_id: &str,
+        action: Option<MailRuleAction>,
+        status: Option<MailContactRuleStatus>,
+    ) -> Result<MailIdentityContactRule> {
+        self.inkbox.mail_identity_contact_rules().update(
+            &self.agent_handle(),
+            rule_id,
+            action,
+            status,
+        )
+    }
+
+    /// Delete one of this identity's mail contact rules (admin-only).
+    pub fn delete_mail_contact_rule(&self, rule_id: &str) -> Result<()> {
+        self.inkbox
+            .mail_identity_contact_rules()
+            .delete(&self.agent_handle(), rule_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Phone contact rules (identity-keyed)
+    // -----------------------------------------------------------------------
+
+    /// List this identity's phone allow/block rules, newest first.
+    ///
+    /// Errors if this identity has no phone number.
+    pub fn list_phone_contact_rules(
+        &self,
+        action: Option<PhoneRuleAction>,
+        match_type: Option<PhoneRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<PhoneIdentityContactRule>> {
+        self.require_phone()?;
+        self.inkbox.phone_identity_contact_rules().list(
+            &self.agent_handle(),
+            action,
+            match_type,
+            limit,
+            offset,
+        )
+    }
+
+    /// Get one of this identity's phone contact rules by id.
+    ///
+    /// Errors if this identity has no phone number.
+    pub fn get_phone_contact_rule(&self, rule_id: &str) -> Result<PhoneIdentityContactRule> {
+        self.require_phone()?;
+        self.inkbox
+            .phone_identity_contact_rules()
+            .get(&self.agent_handle(), rule_id)
+    }
+
+    /// Create a phone allow/block rule for this identity.
+    ///
+    /// Errors if this identity has no phone number.
+    pub fn create_phone_contact_rule(
+        &self,
+        action: PhoneRuleAction,
+        match_target: &str,
+        match_type: PhoneRuleMatchType,
+    ) -> Result<PhoneIdentityContactRule> {
+        self.require_phone()?;
+        self.inkbox.phone_identity_contact_rules().create(
+            &self.agent_handle(),
+            action,
+            match_target,
+            match_type,
+        )
+    }
+
+    /// Update a phone rule's `action` or `status` (admin-only). `None`
+    /// arguments are left unchanged. Errors if this identity has no phone number.
+    pub fn update_phone_contact_rule(
+        &self,
+        rule_id: &str,
+        action: Option<PhoneRuleAction>,
+        status: Option<PhoneContactRuleStatus>,
+    ) -> Result<PhoneIdentityContactRule> {
+        self.require_phone()?;
+        self.inkbox.phone_identity_contact_rules().update(
+            &self.agent_handle(),
+            rule_id,
+            action,
+            status,
+        )
+    }
+
+    /// Delete one of this identity's phone contact rules (admin-only).
+    ///
+    /// Errors if this identity has no phone number.
+    pub fn delete_phone_contact_rule(&self, rule_id: &str) -> Result<()> {
+        self.require_phone()?;
+        self.inkbox
+            .phone_identity_contact_rules()
+            .delete(&self.agent_handle(), rule_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Signing key (identity-keyed)
+    // -----------------------------------------------------------------------
+
+    /// Report whether this identity has a webhook signing key.
+    pub fn get_signing_key_status(&self) -> Result<SigningKeyStatus> {
+        self.inkbox.signing_keys().get_status(&self.agent_handle())
+    }
+
+    /// Create or rotate this identity's webhook signing key.
+    ///
+    /// The plaintext `signing_key` is returned **once** — store it securely, it
+    /// cannot be retrieved again.
+    pub fn create_signing_key(&self) -> Result<SigningKey> {
+        self.inkbox
+            .signing_keys()
+            .create_or_rotate(&self.agent_handle())
+    }
+
+    // -----------------------------------------------------------------------
     // Identity management
     // -----------------------------------------------------------------------
 
     /// Update this identity's handle, display name, description, iMessage
-    /// reachability, and/or status.
+    /// reachability, contact-rule filter modes, and/or status.
     ///
     /// Only provided fields are applied; omitted fields are left unchanged. For
     /// `display_name` and `description`, `Unset::Value(None)` clears the column;
@@ -730,8 +907,14 @@ impl AgentIdentity {
     /// * `description` - New description, or `Unset::Value(None)` to clear.
     /// * `imessage_enabled` - Toggle shared-iMessage reachability.
     /// * `imessage_filter_mode` - `"whitelist"` or `"blacklist"` (admin-only).
+    /// * `mail_filter_mode` - `"whitelist"` or `"blacklist"` for this identity's
+    ///   mail contact rules (admin-only).
+    /// * `phone_filter_mode` - `"whitelist"` or `"blacklist"` for this identity's
+    ///   phone contact rules (admin-only). Rejected with 422 when the identity
+    ///   has no phone number.
     /// * `status` - `"active"` or `"paused"`. Call [`Self::delete`] to remove the
     ///   identity; `"deleted"` is rejected here.
+    #[allow(clippy::too_many_arguments)]
     pub fn update(
         &self,
         new_handle: Option<&str>,
@@ -739,6 +922,8 @@ impl AgentIdentity {
         description: crate::identities::types::Unset<String>,
         imessage_enabled: Option<bool>,
         imessage_filter_mode: Option<&str>,
+        mail_filter_mode: Option<&str>,
+        phone_filter_mode: Option<&str>,
         status: Option<&str>,
     ) -> Result<()> {
         let result = self.inkbox.identities().update(
@@ -748,6 +933,8 @@ impl AgentIdentity {
             description,
             imessage_enabled,
             imessage_filter_mode,
+            mail_filter_mode,
+            phone_filter_mode,
             status,
         )?;
 

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -31,12 +31,14 @@ use crate::imessage::resources::contact_rules::IMessageContactRulesResource;
 use crate::imessage::resources::imessages::IMessagesResource;
 use crate::mail::resources::contact_rules::MailContactRulesResource;
 use crate::mail::resources::domains::DomainsResource;
+use crate::mail::resources::identity_contact_rules::MailIdentityContactRulesResource;
 use crate::mail::resources::mailboxes::MailboxesResource;
 use crate::mail::resources::messages::MessagesResource;
 use crate::mail::resources::threads::ThreadsResource;
 use crate::notes::resources::notes::NotesResource;
 use crate::phone::resources::calls::CallsResource;
 use crate::phone::resources::contact_rules::PhoneContactRulesResource;
+use crate::phone::resources::identity_contact_rules::PhoneIdentityContactRulesResource;
 use crate::phone::resources::numbers::PhoneNumbersResource;
 use crate::phone::resources::sms_opt_ins::SmsOptInsResource;
 use crate::phone::resources::texts::TextsResource;
@@ -122,6 +124,10 @@ pub struct Inkbox {
     transcripts: TranscriptsResource,
     phone_contact_rules: PhoneContactRulesResource,
     sms_opt_ins: SmsOptInsResource,
+
+    // Identity-keyed contact rules (forward-looking; ride the api-root transport).
+    mail_identity_contact_rules: MailIdentityContactRulesResource,
+    phone_identity_contact_rules: PhoneIdentityContactRulesResource,
 
     // iMessage
     imessages: IMessagesResource,
@@ -240,6 +246,12 @@ impl Inkbox {
             phone_contact_rules: PhoneContactRulesResource::new(phone_http.clone()),
             sms_opt_ins: SmsOptInsResource::new(phone_http.clone()),
 
+            // Identity-keyed contact rules ride the api-root transport (base
+            // /api/v1) so they reach both /identities/{handle}/...-contact-rules
+            // and the org-wide /mail|/phone/contact-rules with full paths.
+            mail_identity_contact_rules: MailIdentityContactRulesResource::new(api_http.clone()),
+            phone_identity_contact_rules: PhoneIdentityContactRulesResource::new(api_http.clone()),
+
             imessages: IMessagesResource::new(imessage_http.clone()),
             imessage_contact_rules: IMessageContactRulesResource::new(imessage_http.clone()),
 
@@ -283,6 +295,15 @@ impl Inkbox {
     pub fn threads(&self) -> &ThreadsResource {
         &self.threads
     }
+    /// Mail per-mailbox allow/block rules (+ org-wide list).
+    ///
+    /// Deprecated: contact rules are now keyed by agent identity — use
+    /// [`Self::mail_identity_contact_rules`] (or the `identity.*_mail_contact_rule`
+    /// helpers).
+    #[deprecated(
+        note = "Contact rules are now keyed by agent identity. Use \
+                mail_identity_contact_rules() or identity.*_mail_contact_rule()."
+    )]
     pub fn mail_contact_rules(&self) -> &MailContactRulesResource {
         &self.mail_contact_rules
     }
@@ -302,11 +323,36 @@ impl Inkbox {
     pub fn transcripts(&self) -> &TranscriptsResource {
         &self.transcripts
     }
+    /// Phone per-number allow/block rules (+ org-wide list).
+    ///
+    /// Deprecated: contact rules are now keyed by agent identity — use
+    /// [`Self::phone_identity_contact_rules`] (or the
+    /// `identity.*_phone_contact_rule` helpers).
+    #[deprecated(
+        note = "Contact rules are now keyed by agent identity. Use \
+                phone_identity_contact_rules() or identity.*_phone_contact_rule()."
+    )]
     pub fn phone_contact_rules(&self) -> &PhoneContactRulesResource {
         &self.phone_contact_rules
     }
     pub fn sms_opt_ins(&self) -> &SmsOptInsResource {
         &self.sms_opt_ins
+    }
+
+    /// Mail per-identity allow/block rules (+ org-wide list), keyed by
+    /// `agent_handle`.
+    pub fn mail_identity_contact_rules(&self) -> &MailIdentityContactRulesResource {
+        &self.mail_identity_contact_rules
+    }
+    /// Phone per-identity allow/block rules (+ org-wide list), keyed by
+    /// `agent_handle`.
+    pub fn phone_identity_contact_rules(&self) -> &PhoneIdentityContactRulesResource {
+        &self.phone_identity_contact_rules
+    }
+
+    /// Webhook signing key management (per-identity create/rotate/status).
+    pub fn signing_keys(&self) -> &SigningKeysResource {
+        &self.signing_keys
     }
 
     pub fn imessages(&self) -> &IMessagesResource {
@@ -422,10 +468,22 @@ impl Inkbox {
         parse_whoami(data)
     }
 
-    /// Create or rotate the org-level webhook signing key. The plaintext key is
-    /// returned once — save it immediately.
+    /// Create or rotate a webhook signing key via the deprecated org-level
+    /// endpoint. The plaintext key is returned once — save it immediately.
+    ///
+    /// Deprecated: signing keys are now per agent identity. Prefer
+    /// `identity.create_signing_key()` (or
+    /// `inkbox.signing_keys().create_or_rotate(agent_handle)`). With an
+    /// agent-scoped API key this rotates that key's identity; with an admin key
+    /// the server returns 409 ([`InkboxError::Api`]).
+    #[deprecated(
+        note = "Signing keys are now per agent identity. Use \
+                identity.create_signing_key() or \
+                signing_keys().create_or_rotate(agent_handle)."
+    )]
     pub fn create_signing_key(&self) -> Result<SigningKey> {
-        self.signing_keys.create_or_rotate()
+        #[allow(deprecated)]
+        self.signing_keys.create_or_rotate_org()
     }
 
     // ----- Agent signup (associated functions — no client instance needed) ---

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -300,10 +300,8 @@ impl Inkbox {
     /// Deprecated: contact rules are now keyed by agent identity — use
     /// [`Self::mail_identity_contact_rules`] (or the `identity.*_mail_contact_rule`
     /// helpers).
-    #[deprecated(
-        note = "Contact rules are now keyed by agent identity. Use \
-                mail_identity_contact_rules() or identity.*_mail_contact_rule()."
-    )]
+    #[deprecated(note = "Contact rules are now keyed by agent identity. Use \
+                mail_identity_contact_rules() or identity.*_mail_contact_rule().")]
     pub fn mail_contact_rules(&self) -> &MailContactRulesResource {
         &self.mail_contact_rules
     }
@@ -328,10 +326,8 @@ impl Inkbox {
     /// Deprecated: contact rules are now keyed by agent identity — use
     /// [`Self::phone_identity_contact_rules`] (or the
     /// `identity.*_phone_contact_rule` helpers).
-    #[deprecated(
-        note = "Contact rules are now keyed by agent identity. Use \
-                phone_identity_contact_rules() or identity.*_phone_contact_rule()."
-    )]
+    #[deprecated(note = "Contact rules are now keyed by agent identity. Use \
+                phone_identity_contact_rules() or identity.*_phone_contact_rule().")]
     pub fn phone_contact_rules(&self) -> &PhoneContactRulesResource {
         &self.phone_contact_rules
     }
@@ -476,11 +472,9 @@ impl Inkbox {
     /// `inkbox.signing_keys().create_or_rotate(agent_handle)`). With an
     /// agent-scoped API key this rotates that key's identity; with an admin key
     /// the server returns 409 ([`InkboxError::Api`]).
-    #[deprecated(
-        note = "Signing keys are now per agent identity. Use \
+    #[deprecated(note = "Signing keys are now per agent identity. Use \
                 identity.create_signing_key() or \
-                signing_keys().create_or_rotate(agent_handle)."
-    )]
+                signing_keys().create_or_rotate(agent_handle).")]
     pub fn create_signing_key(&self) -> Result<SigningKey> {
         #[allow(deprecated)]
         self.signing_keys.create_or_rotate_org()

--- a/sdk/rust/src/identities/resources/identities.rs
+++ b/sdk/rust/src/identities/resources/identities.rs
@@ -133,6 +133,11 @@ impl IdentitiesResource {
     /// * `description` - New description, or `Unset::Value(None)` to clear.
     /// * `imessage_enabled` - Toggle shared-iMessage reachability.
     /// * `imessage_filter_mode` - `"whitelist"` or `"blacklist"` (admin-only).
+    /// * `mail_filter_mode` - `"whitelist"` or `"blacklist"` for this identity's
+    ///   mail contact rules (admin-only).
+    /// * `phone_filter_mode` - `"whitelist"` or `"blacklist"` for this identity's
+    ///   phone contact rules (admin-only). The server rejects this with 422 when
+    ///   the identity has no phone number.
     /// * `status` - `"active"` or `"paused"`. Call [`Self::delete`] to remove an
     ///   identity; `"deleted"` is rejected here.
     #[allow(clippy::too_many_arguments)]
@@ -144,6 +149,8 @@ impl IdentitiesResource {
         description: Unset<String>,
         imessage_enabled: Option<bool>,
         imessage_filter_mode: Option<&str>,
+        mail_filter_mode: Option<&str>,
+        phone_filter_mode: Option<&str>,
         status: Option<&str>,
     ) -> Result<AgentIdentitySummary> {
         let mut body = Map::new();
@@ -177,6 +184,12 @@ impl IdentitiesResource {
                 "imessage_filter_mode".into(),
                 Value::String(mode.to_string()),
             );
+        }
+        if let Some(mode) = mail_filter_mode {
+            body.insert("mail_filter_mode".into(), Value::String(mode.to_string()));
+        }
+        if let Some(mode) = phone_filter_mode {
+            body.insert("phone_filter_mode".into(), Value::String(mode.to_string()));
         }
         if let Some(s) = status {
             body.insert("status".into(), Value::String(s.to_string()));

--- a/sdk/rust/src/identities/types.rs
+++ b/sdk/rust/src/identities/types.rs
@@ -337,6 +337,11 @@ pub struct IdentityPhoneNumber {
 /// `imessage_enabled` / `imessage_filter_mode` describe shared-pool iMessage
 /// reachability — there is no per-identity iMessage number, so these live on
 /// the identity itself rather than on a channel object.
+///
+/// `mail_filter_mode` / `phone_filter_mode` are the whitelist/blacklist modes
+/// for this identity's mail and phone contact rules. They live on the identity
+/// (set via `identity.update(...)`); the same field on the mailbox /
+/// phone-number objects is the deprecated legacy mirror.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentIdentitySummary {
     pub id: Uuid,
@@ -356,6 +361,14 @@ pub struct AgentIdentitySummary {
     /// Defaults to `blacklist` when absent.
     #[serde(default = "default_filter_mode_blacklist")]
     pub imessage_filter_mode: FilterMode,
+    /// Whitelist/blacklist mode for this identity's mail contact rules.
+    /// Defaults to `blacklist` when absent.
+    #[serde(default = "default_filter_mode_blacklist")]
+    pub mail_filter_mode: FilterMode,
+    /// Whitelist/blacklist mode for this identity's phone contact rules.
+    /// Defaults to `blacklist` when absent.
+    #[serde(default = "default_filter_mode_blacklist")]
+    pub phone_filter_mode: FilterMode,
 }
 
 /// Agent identity with linked communication channels and tunnel.

--- a/sdk/rust/src/identities/types.rs
+++ b/sdk/rust/src/identities/types.rs
@@ -369,6 +369,13 @@ pub struct AgentIdentitySummary {
     /// Defaults to `blacklist` when absent.
     #[serde(default = "default_filter_mode_blacklist")]
     pub phone_filter_mode: FilterMode,
+    /// Whether this identity has a webhook signing key configured. Status only,
+    /// never the secret. Defaults to `false` when the server omits the field.
+    #[serde(default)]
+    pub signing_key_configured: bool,
+    /// When the signing key was created, or `None` if none is configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_key_created_at: Option<String>,
 }
 
 /// Agent identity with linked communication channels and tunnel.

--- a/sdk/rust/src/mail/mod.rs
+++ b/sdk/rust/src/mail/mod.rs
@@ -12,12 +12,12 @@ pub mod types;
 // Re-export the public types.
 pub use types::{
     ContactRuleStatus, Domain, FilterMode, FilterModeChangeNotice, ForwardMode, MailContactRule,
-    MailRuleAction, MailRuleMatchType, Mailbox, Message, MessageDetail, MessageDirection,
-    ReplyAllRecipients, SendingDomainStatus, Thread, ThreadDetail, ThreadFolder,
+    MailIdentityContactRule, MailRuleAction, MailRuleMatchType, Mailbox, Message, MessageDetail,
+    MessageDirection, ReplyAllRecipients, SendingDomainStatus, Thread, ThreadDetail, ThreadFolder,
 };
 
 // Re-export the resources.
 pub use resources::{
-    Attachment, DomainsResource, MailContactRulesResource, MailboxesResource, MessagesResource,
-    ThreadsResource,
+    Attachment, DomainsResource, MailContactRulesResource, MailIdentityContactRulesResource,
+    MailboxesResource, MessagesResource, ThreadsResource,
 };

--- a/sdk/rust/src/mail/resources/identity_contact_rules.rs
+++ b/sdk/rust/src/mail/resources/identity_contact_rules.rs
@@ -1,0 +1,190 @@
+//! Identity-keyed mail contact rules (per-agent-identity allow/block rules +
+//! org-wide list).
+//!
+//! Mail rules live on the **agent identity**, addressed by `agent_handle`,
+//! mirroring the iMessage rule shape. The legacy per-mailbox resource
+//! ([`crate::mail::resources::contact_rules::MailContactRulesResource`]) is kept
+//! as a deprecated wrapper.
+//!
+//! Transport note: this resource rides the api-root transport (`{base}/api/v1`)
+//! so it can address both the per-identity routes
+//! (`/identities/{handle}/mail-contact-rules`) and the org-wide list
+//! (`/mail/contact-rules`) with full paths. It must NOT ride the
+//! `/mail`-prefixed transport, which would mangle the identity paths.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::http::HttpTransport;
+use crate::mail::types::{
+    ContactRuleStatus, MailIdentityContactRule, MailRuleAction, MailRuleMatchType,
+};
+
+const ORG_BASE: &str = "/mail/contact-rules";
+
+/// Build the per-identity contact-rule path, optionally addressing one rule.
+fn rule_path(agent_handle: &str, rule_id: Option<&str>) -> String {
+    let base = format!("/identities/{agent_handle}/mail-contact-rules");
+    match rule_id {
+        None => base,
+        Some(id) => format!("{base}/{id}"),
+    }
+}
+
+/// Decode a rule list that may be either a bare array or an `{"items": [...]}`
+/// envelope (mirrors the Python `data["items"] if ... else data`).
+fn parse_rule_list(data: Value) -> Result<Vec<MailIdentityContactRule>> {
+    let items = match data {
+        Value::Object(mut map) if map.contains_key("items") => {
+            map.remove("items").unwrap_or(Value::Array(vec![]))
+        }
+        other => other,
+    };
+    Ok(serde_json::from_value(items)?)
+}
+
+/// Allow/block mail rules scoped to agent identities.
+pub struct MailIdentityContactRulesResource {
+    http: Arc<HttpTransport>,
+}
+
+impl MailIdentityContactRulesResource {
+    pub fn new(http: Arc<HttpTransport>) -> Self {
+        Self { http }
+    }
+
+    /// List the mail contact rules for one agent identity, optionally filtered.
+    ///
+    /// # Arguments
+    /// * `agent_handle` - Handle of the agent identity owning the rules.
+    /// * `action` - Filter by `allow` or `block`.
+    /// * `match_type` - Filter by `exact_email` or `domain`.
+    /// * `limit` / `offset` - Pagination controls.
+    pub fn list(
+        &self,
+        agent_handle: &str,
+        action: Option<MailRuleAction>,
+        match_type: Option<MailRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<MailIdentityContactRule>> {
+        // Push only present params (Python omits None keys).
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(a) = action {
+            params.push(("action", a.as_str().to_string()));
+        }
+        if let Some(m) = match_type {
+            params.push(("match_type", m.as_str().to_string()));
+        }
+        if let Some(l) = limit {
+            params.push(("limit", l.to_string()));
+        }
+        if let Some(o) = offset {
+            params.push(("offset", o.to_string()));
+        }
+        let data = self.http.get(&rule_path(agent_handle, None), &params)?;
+        parse_rule_list(data)
+    }
+
+    /// Get a single contact rule by id.
+    pub fn get(&self, agent_handle: &str, rule_id: &str) -> Result<MailIdentityContactRule> {
+        let data = self.http.get(
+            &rule_path(agent_handle, Some(rule_id)),
+            crate::http::NO_QUERY,
+        )?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Create a rule for an agent identity. New rules are always `active`; use
+    /// [`Self::update`] to pause one after creation.
+    ///
+    /// Returns [`crate::error::InkboxError::DuplicateContactRule`] on 409 when a
+    /// non-deleted rule with the same `(match_type, match_target)` already exists.
+    pub fn create(
+        &self,
+        agent_handle: &str,
+        action: MailRuleAction,
+        match_type: MailRuleMatchType,
+        match_target: &str,
+    ) -> Result<MailIdentityContactRule> {
+        let body = json!({
+            "action": action.as_str(),
+            "match_type": match_type.as_str(),
+            "match_target": match_target,
+        });
+        let data = self.http.post(
+            &rule_path(agent_handle, None),
+            Some(&body),
+            crate::http::NO_QUERY,
+        )?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Update `action` or `status` (admin-only).
+    ///
+    /// `match_type` and `match_target` are immutable — delete + re-create to
+    /// change them. `None` arguments are omitted from the body, mirroring the
+    /// Python `_UNSET` sentinel.
+    pub fn update(
+        &self,
+        agent_handle: &str,
+        rule_id: &str,
+        action: Option<MailRuleAction>,
+        status: Option<ContactRuleStatus>,
+    ) -> Result<MailIdentityContactRule> {
+        let mut body = serde_json::Map::new();
+        if let Some(a) = action {
+            body.insert("action".into(), Value::String(a.as_str().to_string()));
+        }
+        if let Some(s) = status {
+            body.insert("status".into(), Value::String(s.as_str().to_string()));
+        }
+        let data = self
+            .http
+            .patch(&rule_path(agent_handle, Some(rule_id)), &Value::Object(body))?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Delete a rule (admin-only).
+    pub fn delete(&self, agent_handle: &str, rule_id: &str) -> Result<()> {
+        self.http.delete(&rule_path(agent_handle, Some(rule_id)))
+    }
+
+    /// Org-wide list of mail contact rules (admin-only).
+    ///
+    /// # Arguments
+    /// * `agent_identity_id` - Narrow to a single agent identity by id.
+    /// * `action` - Filter by `allow` or `block`.
+    /// * `match_type` - Filter by `exact_email` or `domain`.
+    /// * `limit` / `offset` - Pagination controls.
+    pub fn list_all(
+        &self,
+        agent_identity_id: Option<&Uuid>,
+        action: Option<MailRuleAction>,
+        match_type: Option<MailRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<MailIdentityContactRule>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(id) = agent_identity_id {
+            params.push(("agent_identity_id", id.to_string()));
+        }
+        if let Some(a) = action {
+            params.push(("action", a.as_str().to_string()));
+        }
+        if let Some(m) = match_type {
+            params.push(("match_type", m.as_str().to_string()));
+        }
+        if let Some(l) = limit {
+            params.push(("limit", l.to_string()));
+        }
+        if let Some(o) = offset {
+            params.push(("offset", o.to_string()));
+        }
+        let data = self.http.get(ORG_BASE, &params)?;
+        parse_rule_list(data)
+    }
+}

--- a/sdk/rust/src/mail/resources/identity_contact_rules.rs
+++ b/sdk/rust/src/mail/resources/identity_contact_rules.rs
@@ -142,9 +142,10 @@ impl MailIdentityContactRulesResource {
         if let Some(s) = status {
             body.insert("status".into(), Value::String(s.as_str().to_string()));
         }
-        let data = self
-            .http
-            .patch(&rule_path(agent_handle, Some(rule_id)), &Value::Object(body))?;
+        let data = self.http.patch(
+            &rule_path(agent_handle, Some(rule_id)),
+            &Value::Object(body),
+        )?;
         Ok(serde_json::from_value(data)?)
     }
 

--- a/sdk/rust/src/mail/resources/mod.rs
+++ b/sdk/rust/src/mail/resources/mod.rs
@@ -2,12 +2,14 @@
 
 pub mod contact_rules;
 pub mod domains;
+pub mod identity_contact_rules;
 pub mod mailboxes;
 pub mod messages;
 pub mod threads;
 
 pub use contact_rules::MailContactRulesResource;
 pub use domains::DomainsResource;
+pub use identity_contact_rules::MailIdentityContactRulesResource;
 pub use mailboxes::MailboxesResource;
 pub use messages::{Attachment, MessagesResource};
 pub use threads::ThreadsResource;

--- a/sdk/rust/src/mail/types.rs
+++ b/sdk/rust/src/mail/types.rs
@@ -373,10 +373,34 @@ pub struct ThreadDetail {
 }
 
 /// An inbound/outbound allow/block rule scoped to a mailbox.
+///
+/// Returned by the **legacy** per-mailbox routes
+/// ([`crate::mail::resources::contact_rules::MailContactRulesResource`]). The
+/// forward-looking, identity-keyed shape is [`MailIdentityContactRule`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MailContactRule {
     pub id: Uuid,
     pub mailbox_id: Uuid,
+    pub action: MailRuleAction,
+    pub match_type: MailRuleMatchType,
+    pub match_target: String,
+    /// Defaults to `Active` when the server omits the field.
+    #[serde(default = "default_contact_rule_status")]
+    pub status: ContactRuleStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A mail allow/block rule scoped to an **agent identity**.
+///
+/// Returned by the identity-keyed routes
+/// ([`crate::mail::resources::identity_contact_rules::MailIdentityContactRulesResource`]
+/// / `identity.list_mail_contact_rules()`). Same shape as [`MailContactRule`]
+/// but keyed by `agent_identity_id` instead of `mailbox_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MailIdentityContactRule {
+    pub id: Uuid,
+    pub agent_identity_id: Uuid,
     pub action: MailRuleAction,
     pub match_type: MailRuleMatchType,
     pub match_target: String,

--- a/sdk/rust/src/phone/mod.rs
+++ b/sdk/rust/src/phone/mod.rs
@@ -12,6 +12,7 @@ pub use types::*;
 
 pub use resources::calls::CallsResource;
 pub use resources::contact_rules::PhoneContactRulesResource;
+pub use resources::identity_contact_rules::PhoneIdentityContactRulesResource;
 pub use resources::numbers::PhoneNumbersResource;
 pub use resources::sms_opt_ins::SmsOptInsResource;
 pub use resources::texts::TextsResource;

--- a/sdk/rust/src/phone/resources/identity_contact_rules.rs
+++ b/sdk/rust/src/phone/resources/identity_contact_rules.rs
@@ -1,0 +1,189 @@
+//! Identity-keyed phone contact rules (per-agent-identity allow/block rules +
+//! org-wide list).
+//!
+//! Phone (voice + SMS) rules live on the **agent identity**, addressed by
+//! `agent_handle`, mirroring the iMessage rule shape. The legacy per-number
+//! resource ([`crate::phone::resources::contact_rules::PhoneContactRulesResource`])
+//! is kept as a deprecated wrapper.
+//!
+//! The identity must have a phone number: `create` returns 422 otherwise and
+//! the identity helpers guard with a phone-presence check before the request.
+//! Listing an identity with no number returns an empty list.
+//!
+//! Transport note: rides the api-root transport (`{base}/api/v1`) so it
+//! addresses both `/identities/{handle}/phone-contact-rules` and the org-wide
+//! `/phone/contact-rules` with full paths. It must NOT ride the
+//! `/phone`-prefixed transport.
+
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+
+use crate::error::Result;
+use crate::http::HttpTransport;
+use crate::phone::types::{
+    ContactRuleStatus, PhoneIdentityContactRule, PhoneRuleAction, PhoneRuleMatchType,
+};
+
+const ORG_BASE: &str = "/phone/contact-rules";
+
+/// Build the per-identity contact-rule path, optionally addressing one rule.
+fn rule_path(agent_handle: &str, rule_id: Option<&str>) -> String {
+    let base = format!("/identities/{agent_handle}/phone-contact-rules");
+    match rule_id {
+        None => base,
+        Some(id) => format!("{base}/{id}"),
+    }
+}
+
+/// Unwrap a list response that is either `{"items": [...]}` or a bare array,
+/// matching the Python `data["items"] if ... else data` fallback.
+fn extract_items(data: Value) -> Result<Vec<PhoneIdentityContactRule>> {
+    let items = match data {
+        Value::Object(mut map) => match map.remove("items") {
+            Some(items) => items,
+            None => Value::Object(map),
+        },
+        other => other,
+    };
+    Ok(serde_json::from_value(items)?)
+}
+
+/// Allow/block phone rules scoped to agent identities (voice + SMS).
+pub struct PhoneIdentityContactRulesResource {
+    http: Arc<HttpTransport>,
+}
+
+impl PhoneIdentityContactRulesResource {
+    pub fn new(http: Arc<HttpTransport>) -> Self {
+        Self { http }
+    }
+
+    /// List rules for an identity. Returns an empty list when the identity has
+    /// no phone number.
+    pub fn list(
+        &self,
+        agent_handle: &str,
+        action: Option<PhoneRuleAction>,
+        match_type: Option<PhoneRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<PhoneIdentityContactRule>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(a) = action {
+            params.push(("action", a.as_str().to_string()));
+        }
+        if let Some(m) = match_type {
+            params.push(("match_type", m.as_str().to_string()));
+        }
+        if let Some(l) = limit {
+            params.push(("limit", l.to_string()));
+        }
+        if let Some(o) = offset {
+            params.push(("offset", o.to_string()));
+        }
+        let data = self.http.get(&rule_path(agent_handle, None), &params)?;
+        extract_items(data)
+    }
+
+    /// Get a single rule by id.
+    pub fn get(&self, agent_handle: &str, rule_id: &str) -> Result<PhoneIdentityContactRule> {
+        let data = self.http.get(
+            &rule_path(agent_handle, Some(rule_id)),
+            crate::http::NO_QUERY,
+        )?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Create a rule for an agent identity. New rules are always `active`; use
+    /// [`Self::update`] to pause one after creation.
+    ///
+    /// The identity must have a phone number — otherwise the server returns 422.
+    ///
+    /// Returns [`crate::error::InkboxError::DuplicateContactRule`] on 409 when a
+    /// non-deleted rule with the same `(match_type, match_target)` already exists.
+    pub fn create(
+        &self,
+        agent_handle: &str,
+        action: PhoneRuleAction,
+        match_target: &str,
+        match_type: PhoneRuleMatchType,
+    ) -> Result<PhoneIdentityContactRule> {
+        let mut body = Map::new();
+        body.insert("action".into(), action.as_str().into());
+        body.insert("match_type".into(), match_type.as_str().into());
+        body.insert("match_target".into(), match_target.into());
+        let data = self.http.post(
+            &rule_path(agent_handle, None),
+            Some(&body),
+            crate::http::NO_QUERY,
+        )?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Update `action` or `status` (admin-only). Omitted (`None`) fields are
+    /// left unchanged, matching the Python `_UNSET` sentinel.
+    pub fn update(
+        &self,
+        agent_handle: &str,
+        rule_id: &str,
+        action: Option<PhoneRuleAction>,
+        status: Option<ContactRuleStatus>,
+    ) -> Result<PhoneIdentityContactRule> {
+        let mut body = Map::new();
+        if let Some(a) = action {
+            body.insert("action".into(), a.as_str().into());
+        }
+        if let Some(s) = status {
+            let s = match s {
+                ContactRuleStatus::Active => "active",
+                ContactRuleStatus::Paused => "paused",
+            };
+            body.insert("status".into(), s.into());
+        }
+        let data = self
+            .http
+            .patch(&rule_path(agent_handle, Some(rule_id)), &body)?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Delete a rule (admin-only).
+    pub fn delete(&self, agent_handle: &str, rule_id: &str) -> Result<()> {
+        self.http.delete(&rule_path(agent_handle, Some(rule_id)))
+    }
+
+    /// Org-wide list of phone contact rules (admin-only).
+    ///
+    /// # Arguments
+    /// * `agent_identity_id` - Narrow to a single agent identity by id.
+    /// * `action` - Filter by `allow` or `block`.
+    /// * `match_type` - Filter by `exact_number`.
+    /// * `limit` / `offset` - Pagination controls.
+    pub fn list_all(
+        &self,
+        agent_identity_id: Option<&str>,
+        action: Option<PhoneRuleAction>,
+        match_type: Option<PhoneRuleMatchType>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<PhoneIdentityContactRule>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(id) = agent_identity_id {
+            params.push(("agent_identity_id", id.to_string()));
+        }
+        if let Some(a) = action {
+            params.push(("action", a.as_str().to_string()));
+        }
+        if let Some(m) = match_type {
+            params.push(("match_type", m.as_str().to_string()));
+        }
+        if let Some(l) = limit {
+            params.push(("limit", l.to_string()));
+        }
+        if let Some(o) = offset {
+            params.push(("offset", o.to_string()));
+        }
+        let data = self.http.get(ORG_BASE, &params)?;
+        extract_items(data)
+    }
+}

--- a/sdk/rust/src/phone/resources/mod.rs
+++ b/sdk/rust/src/phone/resources/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod calls;
 pub mod contact_rules;
+pub mod identity_contact_rules;
 pub mod numbers;
 pub mod sms_opt_ins;
 pub mod texts;

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -417,10 +417,34 @@ pub struct SmsOptIn {
 }
 
 /// An inbound/outbound allow/block rule scoped to a phone number.
+///
+/// Returned by the **legacy** per-number routes
+/// ([`crate::phone::resources::contact_rules::PhoneContactRulesResource`]). The
+/// forward-looking, identity-keyed shape is [`PhoneIdentityContactRule`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PhoneContactRule {
     pub id: Uuid,
     pub phone_number_id: Uuid,
+    pub action: PhoneRuleAction,
+    pub match_type: PhoneRuleMatchType,
+    pub match_target: String,
+    /// Defaults to `active` when absent.
+    #[serde(default = "default_contact_rule_status_active")]
+    pub status: ContactRuleStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A phone allow/block rule scoped to an **agent identity** (voice + SMS).
+///
+/// Returned by the identity-keyed routes
+/// ([`crate::phone::resources::identity_contact_rules::PhoneIdentityContactRulesResource`]
+/// / `identity.list_phone_contact_rules()`). Same shape as [`PhoneContactRule`]
+/// but keyed by `agent_identity_id` instead of `phone_number_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhoneIdentityContactRule {
+    pub id: Uuid,
+    pub agent_identity_id: Uuid,
     pub action: PhoneRuleAction,
     pub match_type: PhoneRuleMatchType,
     pub match_target: String,

--- a/sdk/rust/src/signing_keys.rs
+++ b/sdk/rust/src/signing_keys.rs
@@ -1,25 +1,39 @@
-//! Org-level webhook signing key management, shared across all Inkbox clients.
+//! Per-identity webhook signing key management.
 //!
-//! Faithful port of `inkbox/signing_keys.py`: the `SigningKey` row, the
-//! `SigningKeysResource` create/rotate endpoint, and the free `verify_webhook`
-//! function used by receivers to authenticate inbound webhook requests.
+//! Faithful port of `inkbox/signing_keys.py`. Each agent identity has its own
+//! signing key used to verify the webhooks (and WebSocket upgrades) for that
+//! identity's mail / phone / iMessage traffic. Manage it via
+//! [`SigningKeysResource::create_or_rotate`] / [`SigningKeysResource::get_status`]
+//! (both keyed by `agent_handle`), or the `identity.create_signing_key()` /
+//! `identity.get_signing_key_status()` convenience methods. The legacy
+//! org-level calls are kept as deprecated bridges.
+//!
+//! The free [`verify_webhook`] function used by receivers to authenticate
+//! inbound webhook requests is unchanged.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
 use crate::error::Result;
-use crate::http::HttpTransport;
+use crate::http::{HttpTransport, NO_QUERY};
 
 type HmacSha256 = Hmac<Sha256>;
 
-const PATH: &str = "/signing-keys";
+/// Deprecated org-level route. Per-identity routes use [`identity_path`].
+const ORG_PATH: &str = "/signing-keys";
 
-/// Org-level webhook signing key.
+/// Per-identity signing-key route.
+fn identity_path(agent_handle: &str) -> String {
+    format!("/identities/{agent_handle}/signing-key")
+}
+
+/// A webhook signing key.
 ///
 /// Returned once on creation/rotation -- store `signing_key` securely.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,6 +42,19 @@ pub struct SigningKey {
     // ISO 8601 timestamp string (Python parses to `datetime`; the contract
     // keeps ISO strings as `String`).
     pub created_at: String,
+}
+
+/// Status of an identity's webhook signing key.
+///
+/// `configured` is `true` once a key exists; `created_at` is when it was
+/// created or last rotated (`None` when not configured). The timestamp is kept
+/// as a raw ISO 8601 `String` per the porting contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SigningKeyStatus {
+    #[serde(default)]
+    pub configured: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 /// Verify that an incoming webhook request was sent by Inkbox.
@@ -86,7 +113,11 @@ pub fn verify_webhook(
     Ok(expected_bytes.ct_eq(received_bytes).into())
 }
 
-/// Org-level webhook signing key resource.
+/// Webhook signing key management.
+///
+/// Rides the api-root transport (`{base}/api/v1`) so it can address both the
+/// per-identity routes (`/identities/{handle}/signing-key`) and the deprecated
+/// org-level route (`/signing-keys`).
 pub struct SigningKeysResource {
     http: Arc<HttpTransport>,
 }
@@ -96,21 +127,60 @@ impl SigningKeysResource {
         Self { http }
     }
 
-    /// Create or rotate the webhook signing key for your organisation.
+    /// Create or rotate an agent identity's webhook signing key.
     ///
-    /// The first call creates a new key; subsequent calls rotate (replace) the
-    /// existing key. The plaintext `signing_key` is returned **once** -- store
-    /// it securely as it cannot be retrieved again.
+    /// The first call mints a key; subsequent calls rotate (replace) it. The
+    /// plaintext `signing_key` is returned **once** -- store it securely as it
+    /// cannot be retrieved again.
     ///
     /// Use the returned key to verify `X-Inkbox-Signature` headers on incoming
-    /// webhook requests.
+    /// webhook requests for this identity.
     ///
     /// # Returns
     /// The newly created/rotated signing key with its creation timestamp.
-    pub fn create_or_rotate(&self) -> Result<SigningKey> {
+    pub fn create_or_rotate(&self, agent_handle: &str) -> Result<SigningKey> {
         // POST an empty JSON object, matching `json={}`.
-        let body = serde_json::json!({});
-        let data = self.http.post(PATH, Some(&body), crate::http::NO_QUERY)?;
+        let body = json!({});
+        let data = self
+            .http
+            .post(&identity_path(agent_handle), Some(&body), NO_QUERY)?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Report whether an agent identity has a webhook signing key configured.
+    pub fn get_status(&self, agent_handle: &str) -> Result<SigningKeyStatus> {
+        let data = self.http.get(&identity_path(agent_handle), NO_QUERY)?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Create or rotate the signing key via the deprecated org-level route.
+    ///
+    /// With an agent-scoped API key the server rotates that key's identity;
+    /// with an admin key it returns 409 ([`crate::error::InkboxError::Api`])
+    /// pointing at the per-identity route (Sunset 2026-08-31). Prefer
+    /// [`Self::create_or_rotate`] or `identity.create_signing_key()`.
+    #[deprecated(
+        note = "Signing keys are now per agent identity. Use create_or_rotate(agent_handle) \
+                or identity.create_signing_key()."
+    )]
+    pub fn create_or_rotate_org(&self) -> Result<SigningKey> {
+        let body = json!({});
+        let data = self.http.post(ORG_PATH, Some(&body), NO_QUERY)?;
+        Ok(serde_json::from_value(data)?)
+    }
+
+    /// Report signing-key status via the deprecated org-level route.
+    ///
+    /// With an agent-scoped key it reports that identity's status; with an admin
+    /// key it reports an org-aggregate status (`configured` true if any identity
+    /// in the org has a key) (Sunset 2026-08-31). Prefer [`Self::get_status`] or
+    /// `identity.get_signing_key_status()`.
+    #[deprecated(
+        note = "Signing keys are now per agent identity. Use get_status(agent_handle) \
+                or identity.get_signing_key_status()."
+    )]
+    pub fn get_status_org(&self) -> Result<SigningKeyStatus> {
+        let data = self.http.get(ORG_PATH, NO_QUERY)?;
         Ok(serde_json::from_value(data)?)
     }
 }

--- a/sdk/rust/src/webhooks/mod.rs
+++ b/sdk/rust/src/webhooks/mod.rs
@@ -15,6 +15,7 @@ pub mod types;
 
 pub use deliveries::{WebhookDeliveriesResource, WebhookDelivery};
 pub use subscriptions::{
-    WebhookSubscription, WebhookSubscriptionStatus, WebhookSubscriptionsResource,
+    WebhookSubscription, WebhookSubscriptionCreateResponse, WebhookSubscriptionStatus,
+    WebhookSubscriptionsResource,
 };
 pub use types::*;

--- a/sdk/rust/src/webhooks/subscriptions.rs
+++ b/sdk/rust/src/webhooks/subscriptions.rs
@@ -34,10 +34,15 @@ pub enum WebhookSubscriptionStatus {
 
 /// A webhook subscription row returned by the API.
 ///
-/// Exactly one of `mailbox_id` / `phone_number_id` / `agent_identity_id` is
-/// populated. `organization_id` is an `"org_..."` token string, not a UUID.
-/// `status` is always `"active"` for subscriptions callers can observe;
-/// deleted subscriptions are not returned by `list` / `get`.
+/// Exactly one of `mailbox_id` / `phone_number_id` / `agent_identity_id` (the
+/// raw owner FK) is populated. `owner_identity_id` is the **resolved** owning
+/// agent identity for every subscription regardless of channel — mail/phone
+/// subs resolve it server-side through the mailbox / phone number, while
+/// iMessage subs carry it directly. (Optional for forward-compatibility: `None`
+/// on servers that predate the field.) `organization_id` is an `"org_..."`
+/// token string, not a UUID. `status` is always `"active"` for subscriptions
+/// callers can observe; deleted subscriptions are not returned by `list` /
+/// `get`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookSubscription {
     pub id: Uuid,
@@ -55,6 +60,23 @@ pub struct WebhookSubscription {
     // keeps ISO strings as `String`).
     pub created_at: String,
     pub updated_at: String,
+    // Resolved owning identity; absent on servers that predate the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_identity_id: Option<Uuid>,
+}
+
+/// The response from creating a webhook subscription.
+///
+/// Extends [`WebhookSubscription`] with a one-time `signing_key`. It is
+/// populated **only** on the request that first mints the owning identity's
+/// signing key (returned once — store it securely); on every other create it is
+/// `None`. `list` / `get` / `update` never return it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookSubscriptionCreateResponse {
+    #[serde(flatten)]
+    pub subscription: WebhookSubscription,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_key: Option<String>,
 }
 
 /// Envelope for the `list` response.
@@ -204,7 +226,10 @@ impl WebhookSubscriptionsResource {
     /// * `mailbox_id` / `phone_number_id` / `agent_identity_id` - exactly one.
     ///
     /// # Returns
-    /// The created subscription.
+    /// A [`WebhookSubscriptionCreateResponse`]. Its `signing_key` is populated
+    /// **once** when this is the first subscription for an identity that had no
+    /// signing key yet — store it securely; it is the only time the plaintext
+    /// secret is shown. Otherwise `signing_key` is `None`.
     pub fn create(
         &self,
         url: &str,
@@ -212,7 +237,7 @@ impl WebhookSubscriptionsResource {
         mailbox_id: Option<Uuid>,
         phone_number_id: Option<Uuid>,
         agent_identity_id: Option<Uuid>,
-    ) -> Result<WebhookSubscription> {
+    ) -> Result<WebhookSubscriptionCreateResponse> {
         // Exactly one owner FK must be set.
         let owners: [(&str, Option<Uuid>); 3] = [
             ("mailbox", mailbox_id),

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -703,11 +703,13 @@ console.log(mb.emailAddress);
 console.log(mb.sendingDomain);  // bare domain the mailbox sends from
 console.log(mb.agentIdentityId); // non-null for live customer mailboxes (1:1 invariant)
 
-// Update filter mode. Note: display_name has moved to the agent
-// identity — set it via identity.update({ displayName: ... }). The
-// mailbox PATCH endpoint hard-rejects display_name with a 422. To
-// attach a webhook receiver, see "Webhooks" below.
-await inkbox.mailboxes.update(mb.emailAddress, { filterMode: "whitelist" }); // admin-scoped key only
+// Filter mode now lives on the agent identity — set it via
+// identity.update({ mailFilterMode: ... }). display_name likewise moved
+// to the identity; the mailbox PATCH endpoint hard-rejects display_name
+// with a 422. To attach a webhook receiver, see "Webhooks" below.
+const supportAgent = await inkbox.getIdentity("support-agent");
+await supportAgent.update({ mailFilterMode: "whitelist" }); // admin-scoped key only
+// (deprecated) await inkbox.mailboxes.update(mb.emailAddress, { filterMode: "whitelist" });
 
 // Full-text search across messages in a mailbox
 const results = await inkbox.mailboxes.search(mb.emailAddress, { q: "invoice", limit: 20 });
@@ -972,10 +974,32 @@ if (info.authType === "api_key") {
 
 ## Signing Keys
 
+Signing keys are **per agent identity**. Create/rotate or check status via the
+identity (or `inkbox.signingKeys.createOrRotate(agentHandle)` /
+`getStatus(agentHandle)`). The plaintext is returned **once**.
+
 ```ts
-// Create or rotate the org-level webhook signing key (plaintext returned once)
-const key = await inkbox.createSigningKey();
+const identity = await inkbox.getIdentity("support-agent");
+
+// Create or rotate this identity's webhook signing key (plaintext returned once)
+const key = await identity.createSigningKey();
 console.log(key.signingKey); // save this immediately
+
+// Check whether a key is configured
+const status = await identity.getSigningKeyStatus();
+console.log(status.configured, status.createdAt);
+
+// The FIRST webhook subscription for a keyless identity returns its secret once:
+const created = await inkbox.webhooks.subscriptions.create({
+  mailboxId: identity.mailbox!.id,
+  url: "https://example.com/hooks/mail",
+  eventTypes: ["message.received"],
+});
+if (created.signingKey != null) {
+  console.log(created.signingKey); // save this immediately — shown only once
+}
+
+// (deprecated) org-level: await inkbox.createSigningKey();
 ```
 
 ---

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.12",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.4.12",
+      "version": "0.4.14",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -14,7 +14,25 @@ import { Credentials } from "./credentials.js";
 import type { TOTPCode, TOTPConfig } from "./vault/totp.js";
 import type { DecryptedVaultSecret, SecretPayload, VaultSecret } from "./vault/types.js";
 import { ForwardMode, MessageDirection } from "./mail/types.js";
-import type { FilterMode, Message, MessageDetail, ThreadDetail } from "./mail/types.js";
+import type {
+  FilterMode,
+  MailIdentityContactRule,
+  Message,
+  MessageDetail,
+  ThreadDetail,
+} from "./mail/types.js";
+import type { PhoneIdentityContactRule } from "./phone/types.js";
+import type {
+  CreateMailIdentityContactRuleOptions,
+  ListMailIdentityContactRulesOptions,
+  UpdateMailIdentityContactRuleOptions,
+} from "./mail/resources/identityContactRules.js";
+import type {
+  CreatePhoneIdentityContactRuleOptions,
+  ListPhoneIdentityContactRulesOptions,
+  UpdatePhoneIdentityContactRuleOptions,
+} from "./phone/resources/identityContactRules.js";
+import type { SigningKey, SigningKeyStatus } from "./signing_keys.js";
 import type {
   IMessage,
   IMessageAssignment,
@@ -81,6 +99,12 @@ export class AgentIdentity {
 
   /** Whitelist/blacklist mode for this identity's iMessage contact rules. */
   get imessageFilterMode(): FilterMode { return this._data.imessageFilterMode; }
+
+  /** Whitelist/blacklist mode for this identity's mail contact rules. */
+  get mailFilterMode(): FilterMode { return this._data.mailFilterMode; }
+
+  /** Whitelist/blacklist mode for this identity's phone contact rules. */
+  get phoneFilterMode(): FilterMode { return this._data.phoneFilterMode; }
 
   /** The mailbox currently assigned to this identity. Non-null for live identities (1:1 invariant). */
   get mailbox(): IdentityMailbox | null { return this._mailbox; }
@@ -830,6 +854,110 @@ export class AgentIdentity {
   }
 
   // ------------------------------------------------------------------
+  // Mail contact rules
+  // ------------------------------------------------------------------
+
+  /** List this identity's mail allow/block rules, newest first. */
+  async listMailContactRules(
+    options: ListMailIdentityContactRulesOptions = {},
+  ): Promise<MailIdentityContactRule[]> {
+    return this._inkbox._mailIdentityContactRules.list(this.agentHandle, options);
+  }
+
+  /** Get one of this identity's mail contact rules by id. */
+  async getMailContactRule(ruleId: string): Promise<MailIdentityContactRule> {
+    return this._inkbox._mailIdentityContactRules.get(this.agentHandle, ruleId);
+  }
+
+  /** Create a mail allow/block rule for this identity. */
+  async createMailContactRule(
+    options: CreateMailIdentityContactRuleOptions,
+  ): Promise<MailIdentityContactRule> {
+    return this._inkbox._mailIdentityContactRules.create(this.agentHandle, options);
+  }
+
+  /** Update a mail rule's `action` or `status` (admin-only). */
+  async updateMailContactRule(
+    ruleId: string,
+    options: UpdateMailIdentityContactRuleOptions,
+  ): Promise<MailIdentityContactRule> {
+    return this._inkbox._mailIdentityContactRules.update(this.agentHandle, ruleId, options);
+  }
+
+  /** Delete one of this identity's mail contact rules (admin-only). */
+  async deleteMailContactRule(ruleId: string): Promise<void> {
+    await this._inkbox._mailIdentityContactRules.delete(this.agentHandle, ruleId);
+  }
+
+  // ------------------------------------------------------------------
+  // Phone contact rules
+  // ------------------------------------------------------------------
+
+  /**
+   * List this identity's phone allow/block rules, newest first.
+   *
+   * @throws {InkboxError} if this identity has no phone number.
+   */
+  async listPhoneContactRules(
+    options: ListPhoneIdentityContactRulesOptions = {},
+  ): Promise<PhoneIdentityContactRule[]> {
+    this._requirePhone();
+    return this._inkbox._phoneIdentityContactRules.list(this.agentHandle, options);
+  }
+
+  /** Get one of this identity's phone contact rules by id. */
+  async getPhoneContactRule(ruleId: string): Promise<PhoneIdentityContactRule> {
+    this._requirePhone();
+    return this._inkbox._phoneIdentityContactRules.get(this.agentHandle, ruleId);
+  }
+
+  /**
+   * Create a phone allow/block rule for this identity.
+   *
+   * @throws {InkboxError} if this identity has no phone number.
+   */
+  async createPhoneContactRule(
+    options: CreatePhoneIdentityContactRuleOptions,
+  ): Promise<PhoneIdentityContactRule> {
+    this._requirePhone();
+    return this._inkbox._phoneIdentityContactRules.create(this.agentHandle, options);
+  }
+
+  /** Update a phone rule's `action` or `status` (admin-only). */
+  async updatePhoneContactRule(
+    ruleId: string,
+    options: UpdatePhoneIdentityContactRuleOptions,
+  ): Promise<PhoneIdentityContactRule> {
+    this._requirePhone();
+    return this._inkbox._phoneIdentityContactRules.update(this.agentHandle, ruleId, options);
+  }
+
+  /** Delete one of this identity's phone contact rules (admin-only). */
+  async deletePhoneContactRule(ruleId: string): Promise<void> {
+    this._requirePhone();
+    await this._inkbox._phoneIdentityContactRules.delete(this.agentHandle, ruleId);
+  }
+
+  // ------------------------------------------------------------------
+  // Signing key
+  // ------------------------------------------------------------------
+
+  /** Report whether this identity has a webhook signing key. */
+  async getSigningKeyStatus(): Promise<SigningKeyStatus> {
+    return this._inkbox._signingKeys.getStatus(this.agentHandle);
+  }
+
+  /**
+   * Create or rotate this identity's webhook signing key.
+   *
+   * The plaintext `signingKey` is returned **once** — store it securely,
+   * it cannot be retrieved again.
+   */
+  async createSigningKey(): Promise<SigningKey> {
+    return this._inkbox._signingKeys.createOrRotate(this.agentHandle);
+  }
+
+  // ------------------------------------------------------------------
   // Identity management
   // ------------------------------------------------------------------
 
@@ -847,6 +975,13 @@ export class AgentIdentity {
    * @param options.imessageEnabled - Toggle shared-iMessage reachability.
    * @param options.imessageFilterMode - `"whitelist"` or `"blacklist"`
    *   for iMessage contact rules (admin-only).
+   * @param options.mailFilterMode - `"whitelist"` or `"blacklist"` for this
+   *   identity's mail contact rules (admin-only). Unlike the deprecated
+   *   `mailboxes.update({ filterMode })`, this does not return a
+   *   `FilterModeChangeNotice`.
+   * @param options.phoneFilterMode - `"whitelist"` or `"blacklist"` for this
+   *   identity's phone contact rules (admin-only). Rejected with a 422 when
+   *   the identity has no phone number.
    * @param options.status - `"active"` or `"paused"`. Call `delete()`
    *   to remove the identity; `"deleted"` is rejected here.
    */
@@ -856,6 +991,8 @@ export class AgentIdentity {
     description?: string | null;
     imessageEnabled?: boolean;
     imessageFilterMode?: "whitelist" | "blacklist";
+    mailFilterMode?: "whitelist" | "blacklist";
+    phoneFilterMode?: "whitelist" | "blacklist";
     status?: "active" | "paused";
   }): Promise<void> {
     const result = await this._inkbox._idsResource.update(this.agentHandle, options);

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -106,6 +106,12 @@ export class AgentIdentity {
   /** Whitelist/blacklist mode for this identity's phone contact rules. */
   get phoneFilterMode(): FilterMode { return this._data.phoneFilterMode; }
 
+  /** Whether this identity has a webhook signing key configured. Status only — never the secret. */
+  get signingKeyConfigured(): boolean { return this._data.signingKeyConfigured; }
+
+  /** When this identity's signing key was created, or `null` if none is configured. */
+  get signingKeyCreatedAt(): Date | null { return this._data.signingKeyCreatedAt; }
+
   /** The mailbox currently assigned to this identity. Non-null for live identities (1:1 invariant). */
   get mailbox(): IdentityMailbox | null { return this._mailbox; }
 
@@ -896,12 +902,12 @@ export class AgentIdentity {
   /**
    * List this identity's phone allow/block rules, newest first.
    *
-   * @throws {InkboxError} if this identity has no phone number.
+   * Returns `[]` for a phoneless identity; the server requires a phone only
+   * for create/get/update/delete, not for list.
    */
   async listPhoneContactRules(
     options: ListPhoneIdentityContactRulesOptions = {},
   ): Promise<PhoneIdentityContactRule[]> {
-    this._requirePhone();
     return this._inkbox._phoneIdentityContactRules.list(this.agentHandle, options);
   }
 

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -110,6 +110,11 @@ export class IdentitiesResource {
    * @param options.imessageEnabled - Toggle shared-iMessage reachability.
    * @param options.imessageFilterMode - `"whitelist"` or `"blacklist"`
    *   for iMessage contact rules (admin-only).
+   * @param options.mailFilterMode - `"whitelist"` or `"blacklist"` for this
+   *   identity's mail contact rules (admin-only).
+   * @param options.phoneFilterMode - `"whitelist"` or `"blacklist"` for this
+   *   identity's phone contact rules (admin-only). The server rejects this
+   *   with 422 when the identity has no phone number.
    * @param options.status - `"active"` or `"paused"`. Call `delete()` to
    *   remove an identity; `"deleted"` is rejected here.
    */
@@ -121,6 +126,8 @@ export class IdentitiesResource {
       description?: string | null;
       imessageEnabled?: boolean;
       imessageFilterMode?: "whitelist" | "blacklist";
+      mailFilterMode?: "whitelist" | "blacklist";
+      phoneFilterMode?: "whitelist" | "blacklist";
       status?: "active" | "paused";
     },
   ): Promise<AgentIdentitySummary> {
@@ -130,6 +137,8 @@ export class IdentitiesResource {
     if (options.description !== undefined) body["description"] = options.description;
     if (options.imessageEnabled !== undefined) body["imessage_enabled"] = options.imessageEnabled;
     if (options.imessageFilterMode !== undefined) body["imessage_filter_mode"] = options.imessageFilterMode;
+    if (options.mailFilterMode !== undefined) body["mail_filter_mode"] = options.mailFilterMode;
+    if (options.phoneFilterMode !== undefined) body["phone_filter_mode"] = options.phoneFilterMode;
     if (options.status !== undefined) body["status"] = options.status;
     try {
       const data = await this.http.patch<RawAgentIdentitySummary>(`/${agentHandle}`, body);

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -146,6 +146,10 @@ export interface AgentIdentitySummary {
   phoneFilterMode: FilterMode;
   createdAt: Date;
   updatedAt: Date;
+  /** Whether this identity has a webhook signing key configured. Status only — never the secret. */
+  signingKeyConfigured: boolean;
+  /** When the signing key was created, or `null` if none is configured. */
+  signingKeyCreatedAt: Date | null;
 }
 
 /** @internal Full identity data with channels — users interact with AgentIdentity (the class) instead. */
@@ -218,6 +222,8 @@ export interface RawAgentIdentitySummary {
   imessage_filter_mode?: string | null;
   mail_filter_mode?: string | null;
   phone_filter_mode?: string | null;
+  signing_key_configured?: boolean;
+  signing_key_created_at?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -290,6 +296,8 @@ export function parseAgentIdentitySummary(r: RawAgentIdentitySummary): AgentIden
     phoneFilterMode: (r.phone_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
+    signingKeyConfigured: r.signing_key_configured ?? false,
+    signingKeyCreatedAt: r.signing_key_created_at ? new Date(r.signing_key_created_at) : null,
   };
 }
 

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -132,6 +132,18 @@ export interface AgentIdentitySummary {
   imessageEnabled: boolean;
   /** Whitelist/blacklist mode for this identity's iMessage contact rules. */
   imessageFilterMode: FilterMode;
+  /**
+   * Whitelist/blacklist mode for this identity's mail contact rules. Lives
+   * on the identity (set via `identity.update(...)`); the same field on the
+   * mailbox object is the deprecated legacy mirror.
+   */
+  mailFilterMode: FilterMode;
+  /**
+   * Whitelist/blacklist mode for this identity's phone contact rules. Lives
+   * on the identity (set via `identity.update(...)`); the same field on the
+   * phone-number object is the deprecated legacy mirror.
+   */
+  phoneFilterMode: FilterMode;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -204,6 +216,8 @@ export interface RawAgentIdentitySummary {
   email_address: string | null;
   imessage_enabled?: boolean;
   imessage_filter_mode?: string | null;
+  mail_filter_mode?: string | null;
+  phone_filter_mode?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -272,6 +286,8 @@ export function parseAgentIdentitySummary(r: RawAgentIdentitySummary): AgentIden
     emailAddress: r.email_address,
     imessageEnabled: r.imessage_enabled ?? false,
     imessageFilterMode: (r.imessage_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    mailFilterMode: (r.mail_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
+    phoneFilterMode: (r.phone_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
   };

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -30,7 +30,7 @@ export {
   AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_CLAIMED,
   AUTH_SUBTYPE_API_KEY_AGENT_SCOPED_UNCLAIMED,
 } from "./whoami/types.js";
-export type { SigningKey } from "./signing_keys.js";
+export type { SigningKey, SigningKeyStatus } from "./signing_keys.js";
 export { verifyWebhook } from "./signing_keys.js";
 export type {
   WebhookContact,
@@ -70,6 +70,7 @@ export type {
 } from "./webhooks/types.js";
 export type {
   WebhookSubscription,
+  WebhookSubscriptionCreateResponse,
   WebhookSubscriptionStatus,
   CreateWebhookSubscriptionOptions,
   UpdateWebhookSubscriptionOptions,
@@ -105,12 +106,20 @@ export type {
   FilterModeChangeNotice,
   Mailbox,
   MailContactRule,
+  MailIdentityContactRule,
   Message,
   MessageDetail,
   ReplyAllRecipients,
   Thread,
   ThreadDetail,
 } from "./mail/types.js";
+export type {
+  MailIdentityContactRulesResource,
+  CreateMailIdentityContactRuleOptions,
+  ListMailIdentityContactRulesOptions,
+  ListAllMailIdentityContactRulesOptions,
+  UpdateMailIdentityContactRuleOptions,
+} from "./mail/resources/identityContactRules.js";
 export {
   PhoneRuleAction,
   PhoneRuleMatchType,
@@ -125,6 +134,7 @@ export type {
   PhoneCall,
   PhoneCallWithRateLimit,
   PhoneContactRule,
+  PhoneIdentityContactRule,
   RateLimitInfo,
   PhoneTranscript,
   SmsOptIn,
@@ -134,6 +144,13 @@ export type {
   TextConversationSummary,
   TextConversationUpdateResult,
 } from "./phone/types.js";
+export type {
+  PhoneIdentityContactRulesResource,
+  CreatePhoneIdentityContactRuleOptions,
+  ListPhoneIdentityContactRulesOptions,
+  ListAllPhoneIdentityContactRulesOptions,
+  UpdatePhoneIdentityContactRuleOptions,
+} from "./phone/resources/identityContactRules.js";
 export {
   IMessageAssignmentStatus,
   IMessageDeliveryStatus,

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -12,6 +12,7 @@ import { MailboxesResource } from "./mail/resources/mailboxes.js";
 import { MessagesResource } from "./mail/resources/messages.js";
 import { ThreadsResource } from "./mail/resources/threads.js";
 import { MailContactRulesResource } from "./mail/resources/contactRules.js";
+import { MailIdentityContactRulesResource } from "./mail/resources/identityContactRules.js";
 import { DomainsResource } from "./mail/resources/domains.js";
 import { SigningKeysResource } from "./signing_keys.js";
 import type { SigningKey } from "./signing_keys.js";
@@ -24,6 +25,7 @@ import { CallsResource } from "./phone/resources/calls.js";
 import { TextsResource } from "./phone/resources/texts.js";
 import { TranscriptsResource } from "./phone/resources/transcripts.js";
 import { PhoneContactRulesResource } from "./phone/resources/contactRules.js";
+import { PhoneIdentityContactRulesResource } from "./phone/resources/identityContactRules.js";
 import { SmsOptInsResource } from "./phone/resources/smsOptIns.js";
 import { IdentitiesResource } from "./identities/resources/identities.js";
 import { VaultResource } from "./vault/resources/vault.js";
@@ -126,6 +128,7 @@ export class Inkbox {
   readonly _messages: MessagesResource;
   readonly _threads: ThreadsResource;
   readonly _mailContactRules: MailContactRulesResource;
+  readonly _mailIdentityContactRules: MailIdentityContactRulesResource;
   readonly _domains: DomainsResource;
   readonly _signingKeys: SigningKeysResource;
   readonly _webhookSubscriptions: WebhookSubscriptionsResource;
@@ -141,6 +144,7 @@ export class Inkbox {
   readonly _imessageContactRules: IMessageContactRulesResource;
   readonly _transcripts: TranscriptsResource;
   readonly _phoneContactRules: PhoneContactRulesResource;
+  readonly _phoneIdentityContactRules: PhoneIdentityContactRulesResource;
   readonly _smsOptIns: SmsOptInsResource;
   readonly _idsResource: IdentitiesResource;
   readonly _vaultResource: VaultResource;
@@ -198,6 +202,11 @@ export class Inkbox {
     this._threads          = new ThreadsResource(mailHttp);
     this._mailContactRules = new MailContactRulesResource(mailHttp);
     this._domains          = new DomainsResource(domainsHttp);
+    // Identity-keyed contact rules ride the api-root transport (base
+    // /api/v1) so they reach both /identities/{handle}/...-contact-rules
+    // and the org-wide /mail|/phone/contact-rules with full paths.
+    this._mailIdentityContactRules = new MailIdentityContactRulesResource(apiHttp);
+    this._phoneIdentityContactRules = new PhoneIdentityContactRulesResource(apiHttp);
     this._signingKeys      = new SigningKeysResource(apiHttp);
     this._webhookSubscriptions = new WebhookSubscriptionsResource(apiHttp);
     this._webhookDeliveries = new WebhookDeliveriesResource(apiHttp);
@@ -298,11 +307,27 @@ export class Inkbox {
   /** Org-scoped notes with per-identity access grants. */
   get notes(): NotesResource { return this._notes; }
 
-  /** Mail per-mailbox allow/block rules (+ org-wide list). */
+  /**
+   * Mail per-mailbox allow/block rules (+ org-wide list).
+   *
+   * @deprecated Contact rules are now keyed by agent identity — use
+   *   {@link mailIdentityContactRules} (or `identity.*MailContactRule(...)`).
+   */
   get mailContactRules(): MailContactRulesResource { return this._mailContactRules; }
 
-  /** Phone per-number allow/block rules (+ org-wide list). */
+  /**
+   * Phone per-number allow/block rules (+ org-wide list).
+   *
+   * @deprecated Contact rules are now keyed by agent identity — use
+   *   {@link phoneIdentityContactRules} (or `identity.*PhoneContactRule(...)`).
+   */
   get phoneContactRules(): PhoneContactRulesResource { return this._phoneContactRules; }
+
+  /** Mail per-identity allow/block rules (+ org-wide list), keyed by `agentHandle`. */
+  get mailIdentityContactRules(): MailIdentityContactRulesResource { return this._mailIdentityContactRules; }
+
+  /** Phone per-identity allow/block rules (+ org-wide list), keyed by `agentHandle`. */
+  get phoneIdentityContactRules(): PhoneIdentityContactRulesResource { return this._phoneIdentityContactRules; }
 
   /**
    * SMS opt-in / opt-out registry (per-(org, receiver) consent).
@@ -319,6 +344,14 @@ export class Inkbox {
 
   /** Org-level API key creation. Admin-scoped API keys can mint identity-scoped keys. */
   get apiKeys(): ApiKeysResource { return this._apiKeys; }
+
+  /**
+   * Per-identity webhook signing keys. Use `createOrRotate(agentHandle)` /
+   * `getStatus(agentHandle)` (or `identity.createSigningKey()` /
+   * `identity.getSigningKeyStatus()`). Calling either with no handle hits the
+   * deprecated org-level endpoint.
+   */
+  get signingKeys(): SigningKeysResource { return this._signingKeys; }
 
   /**
    * Webhook subscription management and delivery log. Use
@@ -408,9 +441,16 @@ export class Inkbox {
   }
 
   /**
-   * Create or rotate the org-level webhook signing key.
+   * Create or rotate a webhook signing key via the deprecated org-level
+   * endpoint.
    *
    * The plaintext key is returned once — save it immediately.
+   *
+   * @deprecated Signing keys are now per agent identity. Prefer
+   *   `identity.createSigningKey()` (or
+   *   `inkbox.signingKeys.createOrRotate(agentHandle)`). With an agent-scoped
+   *   API key this rotates that key's identity; with an admin key the server
+   *   returns 409 (`InkboxAPIError`).
    *
    * @returns The new {@link SigningKey}.
    */

--- a/sdk/typescript/src/mail/resources/contactRules.ts
+++ b/sdk/typescript/src/mail/resources/contactRules.ts
@@ -2,6 +2,11 @@
  * inkbox-mail/resources/contactRules.ts
  *
  * Per-mailbox mail contact rules (allow/block) + org-wide list.
+ *
+ * @deprecated Contact rules are now keyed by agent identity. Use
+ *   {@link MailIdentityContactRulesResource} (`inkbox.mailIdentityContactRules`
+ *   or `identity.*MailContactRule(...)`) instead. These per-mailbox routes
+ *   keep working unchanged.
  */
 
 import { HttpTransport } from "../../_http.js";

--- a/sdk/typescript/src/mail/resources/identityContactRules.ts
+++ b/sdk/typescript/src/mail/resources/identityContactRules.ts
@@ -1,0 +1,153 @@
+/**
+ * inkbox-mail/resources/identityContactRules.ts
+ *
+ * Identity-keyed mail contact rules (per-agent-identity allow/block rules
+ * + org-wide list).
+ *
+ * Mail rules live on the **agent identity**, addressed by `agentHandle`,
+ * mirroring the iMessage rule shape. The legacy per-mailbox resource
+ * (`inkbox.mailContactRules`) is kept as a deprecated wrapper.
+ *
+ * Transport note: this resource rides the api-root transport
+ * (`{base}/api/v1`) so it can address both the per-identity routes
+ * (`/identities/{handle}/mail-contact-rules`) and the org-wide list
+ * (`/mail/contact-rules`) with full paths. It must NOT ride the
+ * `/mail`-prefixed transport, which would mangle the identity paths.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import {
+  ContactRuleStatus,
+  MailIdentityContactRule,
+  MailRuleAction,
+  MailRuleMatchType,
+  RawMailIdentityContactRule,
+  parseMailIdentityContactRule,
+} from "../types.js";
+
+const ORG_BASE = "/mail/contact-rules";
+
+function rulePath(agentHandle: string, ruleId?: string): string {
+  const base = `/identities/${agentHandle}/mail-contact-rules`;
+  return ruleId ? `${base}/${ruleId}` : base;
+}
+
+export interface ListMailIdentityContactRulesOptions {
+  action?: MailRuleAction;
+  matchType?: MailRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateMailIdentityContactRuleOptions {
+  action: MailRuleAction;
+  matchType: MailRuleMatchType;
+  matchTarget: string;
+}
+
+export interface UpdateMailIdentityContactRuleOptions {
+  action?: MailRuleAction;
+  status?: ContactRuleStatus;
+}
+
+export interface ListAllMailIdentityContactRulesOptions {
+  agentIdentityId?: string;
+  action?: MailRuleAction;
+  matchType?: MailRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+/** Allow/block mail rules scoped to agent identities. */
+export class MailIdentityContactRulesResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async list(
+    agentHandle: string,
+    options: ListMailIdentityContactRulesOptions = {},
+  ): Promise<MailIdentityContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawMailIdentityContactRule[] } | RawMailIdentityContactRule[]
+    >(rulePath(agentHandle), params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseMailIdentityContactRule);
+  }
+
+  async get(agentHandle: string, ruleId: string): Promise<MailIdentityContactRule> {
+    const data = await this.http.get<RawMailIdentityContactRule>(
+      rulePath(agentHandle, ruleId),
+    );
+    return parseMailIdentityContactRule(data);
+  }
+
+  /**
+   * Create a rule for an agent identity. New rules are always `active`;
+   * use {@link update} to pause one after creation.
+   *
+   * @throws {DuplicateContactRuleError} 409 when a non-deleted rule with
+   *   the same `(matchType, matchTarget)` already exists.
+   */
+  async create(
+    agentHandle: string,
+    options: CreateMailIdentityContactRuleOptions,
+  ): Promise<MailIdentityContactRule> {
+    const body: Record<string, unknown> = {
+      action: options.action,
+      match_type: options.matchType,
+      match_target: options.matchTarget,
+    };
+    const data = await this.http.post<RawMailIdentityContactRule>(
+      rulePath(agentHandle),
+      body,
+    );
+    return parseMailIdentityContactRule(data);
+  }
+
+  /**
+   * Update `action` or `status` (admin-only).
+   *
+   * `matchType` and `matchTarget` are immutable — delete + re-create to
+   * change them.
+   */
+  async update(
+    agentHandle: string,
+    ruleId: string,
+    options: UpdateMailIdentityContactRuleOptions,
+  ): Promise<MailIdentityContactRule> {
+    const body: Record<string, unknown> = {};
+    if (options.action !== undefined) body.action = options.action;
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.patch<RawMailIdentityContactRule>(
+      rulePath(agentHandle, ruleId),
+      body,
+    );
+    return parseMailIdentityContactRule(data);
+  }
+
+  /** Delete a rule (admin-only). */
+  async delete(agentHandle: string, ruleId: string): Promise<void> {
+    await this.http.delete(rulePath(agentHandle, ruleId));
+  }
+
+  /** Org-wide list of mail contact rules (admin-only). */
+  async listAll(
+    options: ListAllMailIdentityContactRulesOptions = {},
+  ): Promise<MailIdentityContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.agentIdentityId !== undefined) params.agent_identity_id = options.agentIdentityId;
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawMailIdentityContactRule[] } | RawMailIdentityContactRule[]
+    >(ORG_BASE, params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parseMailIdentityContactRule);
+  }
+}

--- a/sdk/typescript/src/mail/types.ts
+++ b/sdk/typescript/src/mail/types.ts
@@ -202,9 +202,35 @@ export interface ThreadDetail extends Thread {
   messages: Message[];
 }
 
+/**
+ * A mail allow/block rule scoped to a mailbox.
+ *
+ * @deprecated Returned by the legacy per-mailbox routes
+ *   (`inkbox.mailContactRules`). The forward-looking, identity-keyed
+ *   shape is {@link MailIdentityContactRule}.
+ */
 export interface MailContactRule {
   id: string;
   mailboxId: string;
+  action: MailRuleAction;
+  matchType: MailRuleMatchType;
+  matchTarget: string;
+  status: ContactRuleStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * A mail allow/block rule scoped to an **agent identity**.
+ *
+ * Returned by the identity-keyed routes
+ * (`inkbox.mailIdentityContactRules` / `identity.listMailContactRules()`).
+ * Same shape as {@link MailContactRule} but keyed by `agentIdentityId`
+ * instead of `mailboxId`.
+ */
+export interface MailIdentityContactRule {
+  id: string;
+  agentIdentityId: string;
   action: MailRuleAction;
   matchType: MailRuleMatchType;
   matchTarget: string;
@@ -286,6 +312,17 @@ export interface RawThread {
 export interface RawMailContactRule {
   id: string;
   mailbox_id: string;
+  action: string;
+  match_type: string;
+  match_target: string;
+  status?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RawMailIdentityContactRule {
+  id: string;
+  agent_identity_id: string;
   action: string;
   match_type: string;
   match_target: string;
@@ -400,6 +437,21 @@ export function parseMailContactRule(r: RawMailContactRule): MailContactRule {
   return {
     id: r.id,
     mailboxId: r.mailbox_id,
+    action: r.action as MailRuleAction,
+    matchType: r.match_type as MailRuleMatchType,
+    matchTarget: r.match_target,
+    status: (r.status as ContactRuleStatus) ?? ContactRuleStatus.ACTIVE,
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
+  };
+}
+
+export function parseMailIdentityContactRule(
+  r: RawMailIdentityContactRule,
+): MailIdentityContactRule {
+  return {
+    id: r.id,
+    agentIdentityId: r.agent_identity_id,
     action: r.action as MailRuleAction,
     matchType: r.match_type as MailRuleMatchType,
     matchTarget: r.match_target,

--- a/sdk/typescript/src/phone/resources/contactRules.ts
+++ b/sdk/typescript/src/phone/resources/contactRules.ts
@@ -2,6 +2,11 @@
  * inkbox-phone/resources/contactRules.ts
  *
  * Per-number phone contact rules (allow/block) + org-wide list.
+ *
+ * @deprecated Contact rules are now keyed by agent identity. Use
+ *   {@link PhoneIdentityContactRulesResource}
+ *   (`inkbox.phoneIdentityContactRules` or `identity.*PhoneContactRule(...)`)
+ *   instead. These per-number routes keep working unchanged.
  */
 
 import { HttpTransport } from "../../_http.js";

--- a/sdk/typescript/src/phone/resources/identityContactRules.ts
+++ b/sdk/typescript/src/phone/resources/identityContactRules.ts
@@ -1,0 +1,156 @@
+/**
+ * inkbox-phone/resources/identityContactRules.ts
+ *
+ * Identity-keyed phone contact rules (per-agent-identity allow/block rules
+ * + org-wide list).
+ *
+ * Phone (voice + SMS) rules live on the **agent identity**, addressed by
+ * `agentHandle`, mirroring the iMessage rule shape. The legacy per-number
+ * resource (`inkbox.phoneContactRules`) is kept as a deprecated wrapper.
+ *
+ * The identity must have a phone number: `create` returns 422 and the
+ * identity helpers guard with a require-phone check before the request.
+ * Listing an identity with no number returns an empty list.
+ *
+ * Transport note: rides the api-root transport (`{base}/api/v1`) so it
+ * addresses both `/identities/{handle}/phone-contact-rules` and the
+ * org-wide `/phone/contact-rules` with full paths. It must NOT ride the
+ * `/phone`-prefixed transport.
+ */
+
+import { HttpTransport } from "../../_http.js";
+import { ContactRuleStatus } from "../../mail/types.js";
+import {
+  PhoneIdentityContactRule,
+  PhoneRuleAction,
+  PhoneRuleMatchType,
+  RawPhoneIdentityContactRule,
+  parsePhoneIdentityContactRule,
+} from "../types.js";
+
+const ORG_BASE = "/phone/contact-rules";
+
+function rulePath(agentHandle: string, ruleId?: string): string {
+  const base = `/identities/${agentHandle}/phone-contact-rules`;
+  return ruleId ? `${base}/${ruleId}` : base;
+}
+
+export interface ListPhoneIdentityContactRulesOptions {
+  action?: PhoneRuleAction;
+  matchType?: PhoneRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreatePhoneIdentityContactRuleOptions {
+  action: PhoneRuleAction;
+  matchTarget: string;
+  matchType?: PhoneRuleMatchType;
+}
+
+export interface UpdatePhoneIdentityContactRuleOptions {
+  action?: PhoneRuleAction;
+  status?: ContactRuleStatus;
+}
+
+export interface ListAllPhoneIdentityContactRulesOptions {
+  agentIdentityId?: string;
+  action?: PhoneRuleAction;
+  matchType?: PhoneRuleMatchType;
+  limit?: number;
+  offset?: number;
+}
+
+/** Allow/block phone rules scoped to agent identities (voice + SMS). */
+export class PhoneIdentityContactRulesResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  /**
+   * List rules for an identity. Returns an empty list when the identity
+   * has no phone number.
+   */
+  async list(
+    agentHandle: string,
+    options: ListPhoneIdentityContactRulesOptions = {},
+  ): Promise<PhoneIdentityContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawPhoneIdentityContactRule[] } | RawPhoneIdentityContactRule[]
+    >(rulePath(agentHandle), params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parsePhoneIdentityContactRule);
+  }
+
+  async get(agentHandle: string, ruleId: string): Promise<PhoneIdentityContactRule> {
+    const data = await this.http.get<RawPhoneIdentityContactRule>(
+      rulePath(agentHandle, ruleId),
+    );
+    return parsePhoneIdentityContactRule(data);
+  }
+
+  /**
+   * Create a rule for an agent identity. New rules are always `active`;
+   * use {@link update} to pause one after creation. The identity must have
+   * a phone number — otherwise the server returns 422.
+   *
+   * @throws {DuplicateContactRuleError} 409 when a non-deleted rule with
+   *   the same `(matchType, matchTarget)` already exists.
+   */
+  async create(
+    agentHandle: string,
+    options: CreatePhoneIdentityContactRuleOptions,
+  ): Promise<PhoneIdentityContactRule> {
+    const body: Record<string, unknown> = {
+      action: options.action,
+      match_type: options.matchType ?? PhoneRuleMatchType.EXACT_NUMBER,
+      match_target: options.matchTarget,
+    };
+    const data = await this.http.post<RawPhoneIdentityContactRule>(
+      rulePath(agentHandle),
+      body,
+    );
+    return parsePhoneIdentityContactRule(data);
+  }
+
+  /** Update `action` or `status` (admin-only). */
+  async update(
+    agentHandle: string,
+    ruleId: string,
+    options: UpdatePhoneIdentityContactRuleOptions,
+  ): Promise<PhoneIdentityContactRule> {
+    const body: Record<string, unknown> = {};
+    if (options.action !== undefined) body.action = options.action;
+    if (options.status !== undefined) body.status = options.status;
+    const data = await this.http.patch<RawPhoneIdentityContactRule>(
+      rulePath(agentHandle, ruleId),
+      body,
+    );
+    return parsePhoneIdentityContactRule(data);
+  }
+
+  /** Delete a rule (admin-only). */
+  async delete(agentHandle: string, ruleId: string): Promise<void> {
+    await this.http.delete(rulePath(agentHandle, ruleId));
+  }
+
+  /** Org-wide list of phone contact rules (admin-only). */
+  async listAll(
+    options: ListAllPhoneIdentityContactRulesOptions = {},
+  ): Promise<PhoneIdentityContactRule[]> {
+    const params: Record<string, string | number | undefined> = {};
+    if (options.agentIdentityId !== undefined) params.agent_identity_id = options.agentIdentityId;
+    if (options.action !== undefined) params.action = options.action;
+    if (options.matchType !== undefined) params.match_type = options.matchType;
+    if (options.limit !== undefined) params.limit = options.limit;
+    if (options.offset !== undefined) params.offset = options.offset;
+    const data = await this.http.get<
+      { items: RawPhoneIdentityContactRule[] } | RawPhoneIdentityContactRule[]
+    >(ORG_BASE, params);
+    const items = Array.isArray(data) ? data : data.items;
+    return items.map(parsePhoneIdentityContactRule);
+  }
+}

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -103,9 +103,36 @@ export interface PhoneNumber {
   filterModeChangeNotice: FilterModeChangeNotice | null;
 }
 
+/**
+ * A phone allow/block rule scoped to a phone number.
+ *
+ * @deprecated Returned by the legacy per-number routes
+ *   (`inkbox.phoneContactRules`). The forward-looking, identity-keyed
+ *   shape is {@link PhoneIdentityContactRule}.
+ */
 export interface PhoneContactRule {
   id: string;
   phoneNumberId: string;
+  action: PhoneRuleAction;
+  matchType: PhoneRuleMatchType;
+  matchTarget: string;
+  status: ContactRuleStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * A phone allow/block rule scoped to an **agent identity**.
+ *
+ * Returned by the identity-keyed routes
+ * (`inkbox.phoneIdentityContactRules` /
+ * `identity.listPhoneContactRules()`). Same shape as
+ * {@link PhoneContactRule} but keyed by `agentIdentityId` instead of
+ * `phoneNumberId`.
+ */
+export interface PhoneIdentityContactRule {
+  id: string;
+  agentIdentityId: string;
   action: PhoneRuleAction;
   matchType: PhoneRuleMatchType;
   matchTarget: string;
@@ -303,6 +330,17 @@ export interface RawPhoneContactRule {
   updated_at: string;
 }
 
+export interface RawPhoneIdentityContactRule {
+  id: string;
+  agent_identity_id: string;
+  action: string;
+  match_type: string;
+  match_target: string;
+  status?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface RawSmsOptIn {
   id: string;
   organization_id: string;
@@ -447,6 +485,21 @@ export function parsePhoneContactRule(r: RawPhoneContactRule): PhoneContactRule 
   return {
     id: r.id,
     phoneNumberId: r.phone_number_id,
+    action: r.action as PhoneRuleAction,
+    matchType: r.match_type as PhoneRuleMatchType,
+    matchTarget: r.match_target,
+    status: (r.status as ContactRuleStatus) ?? ("active" as ContactRuleStatus),
+    createdAt: new Date(r.created_at),
+    updatedAt: new Date(r.updated_at),
+  };
+}
+
+export function parsePhoneIdentityContactRule(
+  r: RawPhoneIdentityContactRule,
+): PhoneIdentityContactRule {
+  return {
+    id: r.id,
+    agentIdentityId: r.agent_identity_id,
     action: r.action as PhoneRuleAction,
     matchType: r.match_type as PhoneRuleMatchType,
     matchTarget: r.match_target,

--- a/sdk/typescript/src/signing_keys.ts
+++ b/sdk/typescript/src/signing_keys.ts
@@ -1,13 +1,23 @@
 /**
- * Org-level webhook signing key management.
+ * Per-identity webhook signing key management.
  *
- * Shared across all Inkbox clients (mail, phone, etc.).
+ * Each agent identity has its own signing key used to verify the webhooks
+ * (and WebSocket upgrades) for that identity's mail / phone / iMessage
+ * traffic. Manage it via `inkbox.signingKeys.createOrRotate(handle)` /
+ * `getStatus(handle)`, or the `identity.createSigningKey()` /
+ * `identity.getSigningKeyStatus()` convenience methods.
+ *
+ * The legacy no-arg / org-level calls are kept as deprecated bridges.
  */
 
 import { createHmac, timingSafeEqual } from "crypto";
 import { HttpTransport } from "./_http.js";
 
-const PATH = "/signing-keys";
+const ORG_PATH = "/signing-keys";
+
+function identityPath(agentHandle: string): string {
+  return `/identities/${agentHandle}/signing-key`;
+}
 
 export interface SigningKey {
   /** Plaintext signing key — returned once on creation/rotation. Store securely. */
@@ -15,15 +25,38 @@ export interface SigningKey {
   createdAt: Date;
 }
 
+/**
+ * Status of an identity's webhook signing key.
+ *
+ * `configured` is `true` once a key exists; `createdAt` is when it was
+ * created or last rotated (`null` when not configured).
+ */
+export interface SigningKeyStatus {
+  configured: boolean;
+  createdAt: Date | null;
+}
+
 interface RawSigningKey {
   signing_key: string;
   created_at: string;
+}
+
+interface RawSigningKeyStatus {
+  configured?: boolean;
+  created_at?: string | null;
 }
 
 function parseSigningKey(r: RawSigningKey): SigningKey {
   return {
     signingKey: r.signing_key,
     createdAt: new Date(r.created_at),
+  };
+}
+
+function parseSigningKeyStatus(r: RawSigningKeyStatus): SigningKeyStatus {
+  return {
+    configured: r.configured ?? false,
+    createdAt: r.created_at ? new Date(r.created_at) : null,
   };
 }
 
@@ -60,21 +93,54 @@ export function verifyWebhook({
   return timingSafeEqual(Buffer.from(expected), Buffer.from(received));
 }
 
+/**
+ * Webhook signing key management.
+ *
+ * Rides the api-root transport (`{base}/api/v1`) so it can address both
+ * the per-identity routes (`/identities/{handle}/signing-key`) and the
+ * deprecated org-level route (`/signing-keys`).
+ */
 export class SigningKeysResource {
   constructor(private readonly http: HttpTransport) {}
 
   /**
-   * Create or rotate the webhook signing key for your organisation.
+   * Create or rotate a webhook signing key.
    *
-   * The first call creates a new key; subsequent calls rotate (replace) the
-   * existing key. The plaintext `signingKey` is returned **once** —
-   * store it securely as it cannot be retrieved again.
+   * Pass `agentHandle` to create/rotate **that identity's** key (the
+   * forward-looking surface). The first call mints a key; subsequent calls
+   * rotate (replace) it. The plaintext `signingKey` is returned **once** —
+   * store it securely, it cannot be retrieved again.
    *
    * Use the returned key to verify `X-Inkbox-Signature` headers on
    * incoming webhook requests.
+   *
+   * @deprecated Calling with no `agentHandle` hits the deprecated org-level
+   *   `/signing-keys` route. With an agent-scoped API key the server rotates
+   *   that key's identity; with an admin key it returns 409
+   *   (`InkboxAPIError`) pointing at the per-identity route. Prefer
+   *   `createOrRotate(agentHandle)` or `identity.createSigningKey()`.
    */
-  async createOrRotate(): Promise<SigningKey> {
-    const data = await this.http.post<RawSigningKey>(PATH, {});
+  async createOrRotate(agentHandle?: string): Promise<SigningKey> {
+    const path = agentHandle === undefined ? ORG_PATH : identityPath(agentHandle);
+    const data = await this.http.post<RawSigningKey>(path, {});
     return parseSigningKey(data);
+  }
+
+  /**
+   * Report whether a signing key is configured.
+   *
+   * Pass `agentHandle` for that identity's status (the forward-looking
+   * surface).
+   *
+   * @deprecated Calling with no `agentHandle` hits the deprecated org-level
+   *   `/signing-keys` route: with an agent-scoped key it reports that
+   *   identity's status; with an admin key it reports an org-aggregate
+   *   status (`configured` true if any identity in the org has a key).
+   *   Prefer `getStatus(agentHandle)` or `identity.getSigningKeyStatus()`.
+   */
+  async getStatus(agentHandle?: string): Promise<SigningKeyStatus> {
+    const path = agentHandle === undefined ? ORG_PATH : identityPath(agentHandle);
+    const data = await this.http.get<RawSigningKeyStatus>(path);
+    return parseSigningKeyStatus(data);
   }
 }

--- a/sdk/typescript/src/webhooks/subscriptions.ts
+++ b/sdk/typescript/src/webhooks/subscriptions.ts
@@ -30,6 +30,13 @@ export interface WebhookSubscription {
   phoneNumberId: string | null;
   /** Owning agent identity, for identity-owned iMessage subscriptions. */
   agentIdentityId: string | null;
+  /**
+   * Resolved owning agent identity for every subscription regardless of
+   * channel — mail/phone subs resolve it server-side through the mailbox /
+   * phone number, while iMessage subs carry it directly. `null` on servers
+   * that predate the field.
+   */
+  ownerIdentityId: string | null;
   url: string;
   /** Wire event-type strings (e.g. `"message.received"`, `"text.sent"`). Not narrowed to a literal union — the catalog is the source of truth. */
   eventTypes: string[];
@@ -38,17 +45,34 @@ export interface WebhookSubscription {
   updatedAt: Date;
 }
 
+/**
+ * The response from creating a webhook subscription.
+ *
+ * Extends {@link WebhookSubscription} with a one-time `signingKey`. It is
+ * populated **only** on the request that first mints the owning identity's
+ * signing key (returned once — store it securely); on every other create it
+ * is `null`. List/get/update never return it.
+ */
+export interface WebhookSubscriptionCreateResponse extends WebhookSubscription {
+  signingKey: string | null;
+}
+
 export interface RawWebhookSubscription {
   id: string;
   organization_id: string;
   mailbox_id: string | null;
   phone_number_id: string | null;
   agent_identity_id?: string | null;
+  owner_identity_id?: string | null;
   url: string;
   event_types: string[];
   status: WebhookSubscriptionStatus;
   created_at: string;
   updated_at: string;
+}
+
+export interface RawWebhookSubscriptionCreateResponse extends RawWebhookSubscription {
+  signing_key?: string | null;
 }
 
 interface RawListWebhookSubscriptionsResponse {
@@ -64,11 +88,21 @@ export function parseWebhookSubscription(
     mailboxId: r.mailbox_id,
     phoneNumberId: r.phone_number_id,
     agentIdentityId: r.agent_identity_id ?? null,
+    ownerIdentityId: r.owner_identity_id ?? null,
     url: r.url,
     eventTypes: r.event_types,
     status: r.status,
     createdAt: new Date(r.created_at),
     updatedAt: new Date(r.updated_at),
+  };
+}
+
+export function parseWebhookSubscriptionCreateResponse(
+  r: RawWebhookSubscriptionCreateResponse,
+): WebhookSubscriptionCreateResponse {
+  return {
+    ...parseWebhookSubscription(r),
+    signingKey: r.signing_key ?? null,
   };
 }
 
@@ -193,10 +227,16 @@ export class WebhookSubscriptionsResource {
    * be a non-empty list of distinct values belonging to the owner's
    * channel (mailbox → `message.*`, phone number → `text.*`, agent
    * identity → `imessage.*`).
+   *
+   * Returns a {@link WebhookSubscriptionCreateResponse}. Its `signingKey`
+   * is populated **once** when this is the first subscription for an
+   * identity that had no signing key yet — store it securely; it is the
+   * only time the plaintext secret is shown. Otherwise `signingKey` is
+   * `null`.
    */
   async create(
     options: CreateWebhookSubscriptionOptions,
-  ): Promise<WebhookSubscription> {
+  ): Promise<WebhookSubscriptionCreateResponse> {
     const owners: Record<string, string | undefined | null> = {
       mailbox: options.mailboxId,
       phone_number: options.phoneNumberId,
@@ -221,8 +261,8 @@ export class WebhookSubscriptionsResource {
       event_types: options.eventTypes,
       [`${owner}_id`]: ownerId,
     };
-    const data = await this.http.post<RawWebhookSubscription>(PATH, body);
-    return parseWebhookSubscription(data);
+    const data = await this.http.post<RawWebhookSubscriptionCreateResponse>(PATH, body);
+    return parseWebhookSubscriptionCreateResponse(data);
   }
 
   /**

--- a/sdk/typescript/tests/identities/types.test.ts
+++ b/sdk/typescript/tests/identities/types.test.ts
@@ -24,6 +24,23 @@ describe("parseAgentIdentitySummary", () => {
     expect(i.createdAt).toBeInstanceOf(Date);
     expect(i.updatedAt).toBeInstanceOf(Date);
   });
+
+  it("parses signing-key status fields", () => {
+    const i = parseAgentIdentitySummary({
+      ...RAW_IDENTITY,
+      signing_key_configured: true,
+      signing_key_created_at: "2026-06-02T03:04:05Z",
+    });
+    expect(i.signingKeyConfigured).toBe(true);
+    expect(i.signingKeyCreatedAt).toBeInstanceOf(Date);
+    expect(i.signingKeyCreatedAt!.toISOString()).toBe("2026-06-02T03:04:05.000Z");
+  });
+
+  it("defaults signing-key status when absent", () => {
+    const i = parseAgentIdentitySummary(RAW_IDENTITY);
+    expect(i.signingKeyConfigured).toBe(false);
+    expect(i.signingKeyCreatedAt).toBeNull();
+  });
 });
 
 describe("parseAgentIdentityData", () => {

--- a/sdk/typescript/tests/identity-scoped-features.test.ts
+++ b/sdk/typescript/tests/identity-scoped-features.test.ts
@@ -1,0 +1,557 @@
+// sdk/typescript/tests/identity-scoped-features.test.ts
+//
+// Tests for the identity-scoped contact rules + per-identity signing keys:
+// - MailIdentityContactRulesResource / PhoneIdentityContactRulesResource
+// - SigningKeysResource per-identity status/rotate (+ deprecated org-level)
+// - WebhookSubscriptionsResource.create -> WebhookSubscriptionCreateResponse
+// - AgentIdentity convenience methods + identity.update filter modes
+//
+// Mirrors sdk/python/tests/test_identity_scoped_features.py. Uses the
+// vi.fn() mock-transport pattern (same as signing-keys.test.ts).
+
+import { describe, it, expect, vi } from "vitest";
+import { HttpTransport, InkboxError } from "../src/_http.js";
+import { AgentIdentity } from "../src/agent_identity.js";
+import {
+  parseAgentIdentityData,
+  parseAgentIdentitySummary,
+} from "../src/identities/types.js";
+import {
+  ContactRuleStatus,
+  FilterMode,
+  MailIdentityContactRule,
+  MailRuleAction,
+  MailRuleMatchType,
+  parseMailIdentityContactRule,
+} from "../src/mail/types.js";
+import { MailIdentityContactRulesResource } from "../src/mail/resources/identityContactRules.js";
+import {
+  PhoneIdentityContactRule,
+  PhoneRuleAction,
+  parsePhoneIdentityContactRule,
+} from "../src/phone/types.js";
+import { PhoneIdentityContactRulesResource } from "../src/phone/resources/identityContactRules.js";
+import {
+  SigningKeysResource,
+  SigningKeyStatus,
+} from "../src/signing_keys.js";
+import {
+  WebhookSubscriptionsResource,
+  parseWebhookSubscription,
+} from "../src/webhooks/subscriptions.js";
+import type { RawWebhookSubscriptionCreateResponse } from "../src/webhooks/subscriptions.js";
+import type { Inkbox } from "../src/inkbox.js";
+import { RAW_IDENTITY_DETAIL } from "./sampleData.js";
+
+const AGENT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+const MAIL_RULE_DICT = {
+  id: "11111111-1111-1111-1111-111111111111",
+  agent_identity_id: AGENT_ID,
+  action: "block",
+  match_type: "exact_email",
+  match_target: "spam@example.com",
+  status: "active",
+  created_at: "2026-06-09T12:30:00Z",
+  updated_at: "2026-06-09T12:30:00Z",
+};
+
+const PHONE_RULE_DICT = {
+  id: "22222222-2222-2222-2222-222222222222",
+  agent_identity_id: AGENT_ID,
+  action: "block",
+  match_type: "exact_number",
+  match_target: "+14155550199",
+  status: "active",
+  created_at: "2026-06-09T12:30:00Z",
+  updated_at: "2026-06-09T12:30:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// Mail identity contact-rule resource
+// ---------------------------------------------------------------------------
+
+function makeMailResource() {
+  const http = {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as HttpTransport;
+  return {
+    resource: new MailIdentityContactRulesResource(http),
+    http: http as {
+      get: ReturnType<typeof vi.fn>;
+      post: ReturnType<typeof vi.fn>;
+      patch: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    },
+  };
+}
+
+describe("MailIdentityContactRulesResource", () => {
+  it("list hits the identity path, forwards params, and parses agentIdentityId", async () => {
+    const { resource, http } = makeMailResource();
+    http.get.mockResolvedValue([MAIL_RULE_DICT]);
+
+    const rows = await resource.list("my-agent", { action: MailRuleAction.BLOCK });
+
+    expect(http.get).toHaveBeenCalledOnce();
+    expect(http.get).toHaveBeenCalledWith(
+      "/identities/my-agent/mail-contact-rules",
+      { action: "block" },
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject<Partial<MailIdentityContactRule>>({
+      agentIdentityId: AGENT_ID,
+    });
+    expect(rows[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  it("list unwraps an { items } envelope too", async () => {
+    const { resource, http } = makeMailResource();
+    http.get.mockResolvedValue({ items: [MAIL_RULE_DICT] });
+
+    const rows = await resource.list("my-agent");
+
+    expect(http.get).toHaveBeenCalledWith(
+      "/identities/my-agent/mail-contact-rules",
+      {},
+    );
+    expect(rows[0].agentIdentityId).toBe(AGENT_ID);
+  });
+
+  it("create posts the wire-shape body to the identity path", async () => {
+    const { resource, http } = makeMailResource();
+    http.post.mockResolvedValue(MAIL_RULE_DICT);
+
+    await resource.create("my-agent", {
+      action: MailRuleAction.BLOCK,
+      matchType: MailRuleMatchType.EXACT_EMAIL,
+      matchTarget: "spam@example.com",
+    });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/identities/my-agent/mail-contact-rules",
+      {
+        action: "block",
+        match_type: "exact_email",
+        match_target: "spam@example.com",
+      },
+    );
+  });
+
+  it("get / update / delete use the per-rule identity paths", async () => {
+    const { resource, http } = makeMailResource();
+    http.get.mockResolvedValue(MAIL_RULE_DICT);
+    http.patch.mockResolvedValue(MAIL_RULE_DICT);
+    http.delete.mockResolvedValue(undefined);
+    const rid = MAIL_RULE_DICT.id;
+
+    await resource.get("my-agent", rid);
+    expect(http.get).toHaveBeenCalledWith(
+      `/identities/my-agent/mail-contact-rules/${rid}`,
+    );
+
+    await resource.update("my-agent", rid, { status: ContactRuleStatus.PAUSED });
+    expect(http.patch).toHaveBeenCalledWith(
+      `/identities/my-agent/mail-contact-rules/${rid}`,
+      { status: "paused" },
+    );
+
+    await resource.delete("my-agent", rid);
+    expect(http.delete).toHaveBeenCalledWith(
+      `/identities/my-agent/mail-contact-rules/${rid}`,
+    );
+  });
+
+  it("listAll hits the org-wide path filtered by agentIdentityId", async () => {
+    const { resource, http } = makeMailResource();
+    http.get.mockResolvedValue([MAIL_RULE_DICT]);
+
+    await resource.listAll({ agentIdentityId: AGENT_ID });
+
+    expect(http.get).toHaveBeenCalledWith("/mail/contact-rules", {
+      agent_identity_id: AGENT_ID,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phone identity contact-rule resource
+// ---------------------------------------------------------------------------
+
+function makePhoneResource() {
+  const http = {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as HttpTransport;
+  return {
+    resource: new PhoneIdentityContactRulesResource(http),
+    http: http as {
+      get: ReturnType<typeof vi.fn>;
+      post: ReturnType<typeof vi.fn>;
+      patch: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    },
+  };
+}
+
+describe("PhoneIdentityContactRulesResource", () => {
+  it("list hits the identity path and parses agentIdentityId", async () => {
+    const { resource, http } = makePhoneResource();
+    http.get.mockResolvedValue([PHONE_RULE_DICT]);
+
+    const rows = await resource.list("my-agent");
+
+    expect(http.get).toHaveBeenCalledWith(
+      "/identities/my-agent/phone-contact-rules",
+      {},
+    );
+    expect(rows[0]).toMatchObject<Partial<PhoneIdentityContactRule>>({
+      agentIdentityId: AGENT_ID,
+    });
+  });
+
+  it("create defaults matchType to exact_number", async () => {
+    const { resource, http } = makePhoneResource();
+    http.post.mockResolvedValue(PHONE_RULE_DICT);
+
+    await resource.create("my-agent", {
+      action: PhoneRuleAction.BLOCK,
+      matchTarget: "+14155550199",
+    });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/identities/my-agent/phone-contact-rules",
+      {
+        action: "block",
+        match_type: "exact_number",
+        match_target: "+14155550199",
+      },
+    );
+  });
+
+  it("listAll hits the org-wide path filtered by agentIdentityId + action", async () => {
+    const { resource, http } = makePhoneResource();
+    http.get.mockResolvedValue([PHONE_RULE_DICT]);
+
+    await resource.listAll({ agentIdentityId: AGENT_ID, action: PhoneRuleAction.BLOCK });
+
+    expect(http.get).toHaveBeenCalledWith("/phone/contact-rules", {
+      agent_identity_id: AGENT_ID,
+      action: "block",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signing keys (per-identity + deprecated org-level)
+// ---------------------------------------------------------------------------
+
+function makeSigningResource() {
+  const http = {
+    get: vi.fn(),
+    post: vi.fn(),
+  } as unknown as HttpTransport;
+  return {
+    resource: new SigningKeysResource(http),
+    http: http as {
+      get: ReturnType<typeof vi.fn>;
+      post: ReturnType<typeof vi.fn>;
+    },
+  };
+}
+
+describe("SigningKeysResource (per-identity + org-level)", () => {
+  it("createOrRotate(handle) hits the per-identity path", async () => {
+    const { resource, http } = makeSigningResource();
+    http.post.mockResolvedValue({
+      signing_key: "sk-fresh",
+      created_at: "2026-06-09T00:00:00Z",
+    });
+
+    const key = await resource.createOrRotate("my-agent");
+
+    expect(http.post).toHaveBeenCalledWith("/identities/my-agent/signing-key", {});
+    expect(key.signingKey).toBe("sk-fresh");
+    expect(key.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("createOrRotate() with no handle hits the deprecated org path", async () => {
+    const { resource, http } = makeSigningResource();
+    http.post.mockResolvedValue({
+      signing_key: "sk-org",
+      created_at: "2026-06-09T00:00:00Z",
+    });
+
+    await resource.createOrRotate();
+
+    expect(http.post).toHaveBeenCalledWith("/signing-keys", {});
+  });
+
+  it("getStatus(handle) hits the per-identity path and parses configured + createdAt", async () => {
+    const { resource, http } = makeSigningResource();
+    http.get.mockResolvedValue({
+      configured: true,
+      created_at: "2026-06-09T00:00:00Z",
+    });
+
+    const status = await resource.getStatus("my-agent");
+
+    expect(http.get).toHaveBeenCalledWith("/identities/my-agent/signing-key");
+    expect(status).toMatchObject<Partial<SigningKeyStatus>>({ configured: true });
+    expect(status.createdAt).toBeInstanceOf(Date);
+    expect(status.createdAt?.toISOString()).toBe("2026-06-09T00:00:00.000Z");
+  });
+
+  it("getStatus parses the not-configured shape (createdAt null)", async () => {
+    const { resource, http } = makeSigningResource();
+    http.get.mockResolvedValue({ configured: false, created_at: null });
+
+    const status = await resource.getStatus("my-agent");
+
+    expect(status.configured).toBe(false);
+    expect(status.createdAt).toBeNull();
+  });
+
+  it("getStatus() with no handle hits the deprecated org path", async () => {
+    const { resource, http } = makeSigningResource();
+    http.get.mockResolvedValue({ configured: true, created_at: null });
+
+    await resource.getStatus();
+
+    expect(http.get).toHaveBeenCalledWith("/signing-keys");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook subscription create-response (signingKey + ownerIdentityId)
+// ---------------------------------------------------------------------------
+
+function rawSub(
+  overrides: Partial<RawWebhookSubscriptionCreateResponse> = {},
+): RawWebhookSubscriptionCreateResponse {
+  return {
+    id: "33333333-3333-3333-3333-333333333333",
+    organization_id: "org_abc",
+    mailbox_id: "44444444-4444-4444-4444-444444444444",
+    phone_number_id: null,
+    agent_identity_id: null,
+    owner_identity_id: AGENT_ID,
+    url: "https://example.com/hook",
+    event_types: ["message.received"],
+    status: "active",
+    created_at: "2026-06-09T00:00:00Z",
+    updated_at: "2026-06-09T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeWebhookResource() {
+  const http = { post: vi.fn() } as unknown as HttpTransport;
+  return {
+    resource: new WebhookSubscriptionsResource(http),
+    http: http as { post: ReturnType<typeof vi.fn> },
+  };
+}
+
+describe("WebhookSubscriptionsResource.create -> create response", () => {
+  it("returns the one-time signingKey and resolved ownerIdentityId when present", async () => {
+    const { resource, http } = makeWebhookResource();
+    http.post.mockResolvedValue(rawSub({ signing_key: "sk-once" }));
+
+    const result = await resource.create({
+      mailboxId: "44444444-4444-4444-4444-444444444444",
+      url: "https://example.com/hook",
+      eventTypes: ["message.received"],
+    });
+
+    expect(result.signingKey).toBe("sk-once");
+    expect(result.ownerIdentityId).toBe(AGENT_ID);
+  });
+
+  it("returns signingKey null when the server omits it", async () => {
+    const { resource, http } = makeWebhookResource();
+    http.post.mockResolvedValue(rawSub()); // no signing_key field
+
+    const result = await resource.create({
+      mailboxId: "44444444-4444-4444-4444-444444444444",
+      url: "https://example.com/hook",
+      eventTypes: ["message.received"],
+    });
+
+    expect(result.signingKey).toBeNull();
+  });
+
+  it("parses ownerIdentityId and tolerates it being absent (back-compat)", () => {
+    expect(parseWebhookSubscription(rawSub()).ownerIdentityId).toBe(AGENT_ID);
+
+    const legacy = rawSub();
+    delete (legacy as { owner_identity_id?: string | null }).owner_identity_id;
+    expect(parseWebhookSubscription(legacy).ownerIdentityId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentIdentity convenience methods + filter-mode update
+// ---------------------------------------------------------------------------
+
+function mockInkbox() {
+  return {
+    _mailIdentityContactRules: {
+      list: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    _phoneIdentityContactRules: {
+      list: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    _signingKeys: { createOrRotate: vi.fn(), getStatus: vi.fn() },
+    _idsResource: { update: vi.fn(), get: vi.fn() },
+  } as unknown as Inkbox;
+}
+
+function identityWithPhone() {
+  const data = parseAgentIdentityData(RAW_IDENTITY_DETAIL);
+  const inkbox = mockInkbox();
+  return { identity: new AgentIdentity(data, inkbox), inkbox };
+}
+
+function identityWithoutPhone() {
+  const data = parseAgentIdentityData({ ...RAW_IDENTITY_DETAIL, phone_number: null });
+  const inkbox = mockInkbox();
+  return { identity: new AgentIdentity(data, inkbox), inkbox };
+}
+
+describe("AgentIdentity contact-rule delegation", () => {
+  it("createMailContactRule delegates with the identity handle", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    vi.mocked(inkbox._mailIdentityContactRules.create).mockResolvedValue(
+      parseMailIdentityContactRule(MAIL_RULE_DICT),
+    );
+
+    const options = {
+      action: MailRuleAction.BLOCK,
+      matchType: MailRuleMatchType.EXACT_EMAIL,
+      matchTarget: "spam@example.com",
+    };
+    await identity.createMailContactRule(options);
+
+    expect(inkbox._mailIdentityContactRules.create).toHaveBeenCalledWith(
+      identity.agentHandle,
+      options,
+    );
+  });
+
+  it("updateMailContactRule forwards rule id + options", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    vi.mocked(inkbox._mailIdentityContactRules.update).mockResolvedValue(
+      parseMailIdentityContactRule(MAIL_RULE_DICT),
+    );
+
+    await identity.updateMailContactRule("rid", { status: ContactRuleStatus.PAUSED });
+
+    expect(inkbox._mailIdentityContactRules.update).toHaveBeenCalledWith(
+      identity.agentHandle,
+      "rid",
+      { status: ContactRuleStatus.PAUSED },
+    );
+  });
+
+  it("createPhoneContactRule delegates with the identity handle", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    vi.mocked(inkbox._phoneIdentityContactRules.create).mockResolvedValue(
+      parsePhoneIdentityContactRule(PHONE_RULE_DICT),
+    );
+
+    const options = { action: PhoneRuleAction.BLOCK, matchTarget: "+14155550199" };
+    await identity.createPhoneContactRule(options);
+
+    expect(inkbox._phoneIdentityContactRules.create).toHaveBeenCalledWith(
+      identity.agentHandle,
+      options,
+    );
+  });
+
+  it("phone contact-rule methods throw when the identity has no phone number", async () => {
+    const { identity, inkbox } = identityWithoutPhone();
+
+    await expect(identity.listPhoneContactRules()).rejects.toThrow(InkboxError);
+    await expect(
+      identity.createPhoneContactRule({
+        action: PhoneRuleAction.BLOCK,
+        matchTarget: "+14155550199",
+      }),
+    ).rejects.toThrow(/no phone number/);
+    expect(inkbox._phoneIdentityContactRules.list).not.toHaveBeenCalled();
+    expect(inkbox._phoneIdentityContactRules.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentIdentity signing-key delegation", () => {
+  it("createSigningKey delegates with the identity handle", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    vi.mocked(inkbox._signingKeys.createOrRotate).mockResolvedValue({
+      signingKey: "sk",
+      createdAt: new Date(),
+    });
+
+    await identity.createSigningKey();
+
+    expect(inkbox._signingKeys.createOrRotate).toHaveBeenCalledWith(
+      identity.agentHandle,
+    );
+  });
+
+  it("getSigningKeyStatus delegates with the identity handle", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    vi.mocked(inkbox._signingKeys.getStatus).mockResolvedValue({
+      configured: true,
+      createdAt: null,
+    });
+
+    await identity.getSigningKeyStatus();
+
+    expect(inkbox._signingKeys.getStatus).toHaveBeenCalledWith(identity.agentHandle);
+  });
+});
+
+describe("AgentIdentity.update filter modes", () => {
+  it("sends mail/phone filter modes and the cached getters reflect the result", async () => {
+    const { identity, inkbox } = identityWithPhone();
+    const updated = parseAgentIdentitySummary({
+      id: identity.id,
+      organization_id: "org-abc123",
+      agent_handle: identity.agentHandle,
+      display_name: null,
+      description: null,
+      email_address: null,
+      created_at: "2026-06-09T00:00:00Z",
+      updated_at: "2026-06-09T00:00:00Z",
+      imessage_enabled: false,
+      imessage_filter_mode: "blacklist",
+      mail_filter_mode: "whitelist",
+      phone_filter_mode: "whitelist",
+    });
+    vi.mocked(inkbox._idsResource.update).mockResolvedValue(updated);
+
+    await identity.update({ mailFilterMode: "whitelist", phoneFilterMode: "whitelist" });
+
+    expect(inkbox._idsResource.update).toHaveBeenCalledWith(identity.agentHandle, {
+      mailFilterMode: "whitelist",
+      phoneFilterMode: "whitelist",
+    });
+    // Regression: the cache rebuild must not reset the modes to default.
+    expect(identity.mailFilterMode).toBe(FilterMode.WHITELIST);
+    expect(identity.phoneFilterMode).toBe(FilterMode.WHITELIST);
+  });
+});

--- a/sdk/typescript/tests/identity-scoped-features.test.ts
+++ b/sdk/typescript/tests/identity-scoped-features.test.ts
@@ -482,18 +482,35 @@ describe("AgentIdentity contact-rule delegation", () => {
     );
   });
 
-  it("phone contact-rule methods throw when the identity has no phone number", async () => {
+  it("listPhoneContactRules returns [] for a phoneless identity (no prethrow)", async () => {
+    const { identity, inkbox } = identityWithoutPhone();
+    vi.mocked(inkbox._phoneIdentityContactRules.list).mockResolvedValue([]);
+
+    // List must not prethrow: the server requires a phone only for
+    // create/get/update/delete, not for list.
+    await expect(identity.listPhoneContactRules()).resolves.toEqual([]);
+    expect(inkbox._phoneIdentityContactRules.list).toHaveBeenCalledWith(
+      identity.agentHandle,
+      {},
+    );
+  });
+
+  it("create/get/update/delete phone contact-rule methods throw when no phone number", async () => {
     const { identity, inkbox } = identityWithoutPhone();
 
-    await expect(identity.listPhoneContactRules()).rejects.toThrow(InkboxError);
     await expect(
       identity.createPhoneContactRule({
         action: PhoneRuleAction.BLOCK,
         matchTarget: "+14155550199",
       }),
     ).rejects.toThrow(/no phone number/);
-    expect(inkbox._phoneIdentityContactRules.list).not.toHaveBeenCalled();
+    await expect(identity.getPhoneContactRule("rid")).rejects.toThrow(InkboxError);
+    await expect(
+      identity.updatePhoneContactRule("rid", { status: ContactRuleStatus.PAUSED }),
+    ).rejects.toThrow(InkboxError);
+    await expect(identity.deletePhoneContactRule("rid")).rejects.toThrow(InkboxError);
     expect(inkbox._phoneIdentityContactRules.create).not.toHaveBeenCalled();
+    expect(inkbox._phoneIdentityContactRules.get).not.toHaveBeenCalled();
   });
 });
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -71,12 +71,14 @@ These commands can send real traffic or mutate real resources. Confirm with the 
 - `email delete`
 - `email delete-thread`
 - `vault delete`
-- `mailbox update --filter-mode ...` (admin-only; flips allow/block semantics for that mailbox)
+- `identity update --mail-filter-mode ... / --phone-filter-mode ...` (admin-only; flips allow/block semantics for that identity's channel)
+- `mailbox update --filter-mode ...` (DEPRECATED channel path; admin-only)
 - `number release`
-- `number update --filter-mode ...` (admin-only; same caveat as mailbox)
-- `signing-key create`
+- `number update --filter-mode ...` (DEPRECATED channel path; admin-only)
+- `identity signing-key rotate <handle>` (rotates that identity's webhook signing key)
+- `signing-key create` (DEPRECATED org-level path)
 
-`contacts delete`, `notes delete`, `mailbox rules delete`, `number rules delete` affect downstream filtering and access — confirm intent before running.
+`contacts delete`, `notes delete`, `identity mail-rules delete`, `identity phone-rules delete`, `mailbox rules delete` (deprecated), `number rules delete` (deprecated) affect downstream filtering and access — confirm intent before running.
 
 Also confirm before creating or rotating secrets if the values were not explicitly provided by the user.
 
@@ -109,9 +111,13 @@ inkbox identity create <handle> [--display-name <name>] [--description <text>]
 inkbox identity delete <handle>
 inkbox identity update <handle> [--new-handle <handle>] [--display-name <name>]
                                  [--description <text> | --clear-description]
+                                 [--mail-filter-mode whitelist|blacklist]
+                                 [--phone-filter-mode whitelist|blacklist]
                                  [--status active|paused]
 inkbox identity refresh <handle>
 ```
+
+`--mail-filter-mode` / `--phone-filter-mode` set the identity's contact-rule mode (admin-only). Unlike the deprecated `mailbox update --filter-mode` / `number update --filter-mode`, the identity path does **not** print a change notice. `--phone-filter-mode` requires the identity to have a phone number (else a 422).
 
 `identity create` atomically provisions the mailbox AND the tunnel. The JSON output includes both (`mailbox`, `tunnel.publicHost`, `tunnel.tlsMode`).
 
@@ -156,6 +162,39 @@ Secret types:
 
 ```text
 login, api_key, ssh_key, key_pair, other
+```
+
+### Identity Contact Rules
+
+Allow/block lists are scoped to the **agent identity** (keyed by handle), combined with the identity's mail/phone filter mode (`inkbox identity update --mail-filter-mode / --phone-filter-mode`). Mail matches by exact email or domain; phone matches by exact E.164 number.
+
+```bash
+# Mail rules
+inkbox identity mail-rules list <handle> [--action allow|block] [--match-type exact_email|domain] [--limit <n>] [--offset <n>]
+inkbox identity mail-rules list-all [--agent-identity-id <id>] [--action …] [--match-type …]   # admin-only, org-wide
+inkbox identity mail-rules get <handle> <rule-id>
+inkbox identity mail-rules create <handle> --action allow|block --match-type exact_email|domain --match-target <value>
+inkbox identity mail-rules update <handle> <rule-id> [--action allow|block] [--status active|paused]   # admin-only
+inkbox identity mail-rules delete <handle> <rule-id>                                                    # admin-only
+
+# Phone rules — require the identity to have a phone number; only exact_number is supported.
+inkbox identity phone-rules list <handle> [--action allow|block] [--match-type exact_number] [--limit <n>] [--offset <n>]
+inkbox identity phone-rules list-all [--agent-identity-id <id>] [--action …]   # admin-only, org-wide
+inkbox identity phone-rules get <handle> <rule-id>
+inkbox identity phone-rules create <handle> --action allow|block --match-target <e164> [--match-type exact_number]
+inkbox identity phone-rules update <handle> <rule-id> [--action allow|block] [--status active|paused]   # admin-only
+inkbox identity phone-rules delete <handle> <rule-id>                                                    # admin-only
+```
+
+New rules always start active; use `update --status paused` to pause one. These replace the deprecated `inkbox mailbox rules` / `inkbox number rules` groups below.
+
+### Identity Signing Key
+
+Each identity has its own webhook signing key:
+
+```bash
+inkbox identity signing-key status <handle>
+inkbox identity signing-key rotate <handle>   # mints or rotates; prints the plaintext secret ONCE
 ```
 
 ## Email
@@ -319,7 +358,7 @@ inkbox mailbox update <email-address> [--filter-mode whitelist|blacklist]
 # --mailbox-id <id> --url <url> --event-type message.received ...`.
 ```
 
-`mailbox list` / `get` / `update` rows include `filterMode` and `agentIdentityId`. `--filter-mode` is admin-only; when the value actually changes, a note is printed to **stderr** telling you how many existing rules are now redundant under the new mode.
+`mailbox list` / `get` / `update` rows include `filterMode` and `agentIdentityId`. `mailbox update --filter-mode` is the **deprecated** channel path (admin-only; prints a stderr change note when the value actually changes). Prefer `inkbox identity update <handle> --mail-filter-mode whitelist|blacklist`, which sets the mode on the identity and prints no change note.
 
 ## Tunnels
 
@@ -345,9 +384,9 @@ inkbox domain set-default <domain-name>
 
 `domain list` shows registered custom domains for your org, optionally filtered by status (e.g. `verified`). `domain set-default` requires an admin-scoped API key; pass the bare custom domain name to set it, or pass the platform sending domain (e.g. `inkboxmail.com` in production) to revert. Domain registration, DNS records, verification, DKIM rotation, and deletion stay in the console.
 
-### Mailbox Contact Rules (`inkbox mailbox rules …`)
+### Mailbox Contact Rules (`inkbox mailbox rules …`) — DEPRECATED
 
-Per-mailbox allow/block rules (combined with the mailbox's `filterMode`).
+**Deprecated** (Sunset 2026-08-31) — use `inkbox identity mail-rules …` (keyed by agent handle) instead. Per-mailbox allow/block rules (combined with the mailbox's `filterMode`).
 
 ```bash
 inkbox mailbox rules list --mailbox <email> [--action allow|block] [--match-type exact_email|domain] [--limit <n>] [--offset <n>]
@@ -368,11 +407,11 @@ inkbox number update <id> [--incoming-call-action auto_accept|auto_reject|webhoo
 inkbox number release <number-id>
 ```
 
-Use `--state` only when provisioning a local number. Phone-number rows also carry `filterMode` / `agentIdentityId`; `--filter-mode` is admin-only and prints a stderr note when the value changes.
+Use `--state` only when provisioning a local number. Phone-number rows also carry `filterMode` / `agentIdentityId`; `number update --filter-mode` is the **deprecated** channel path (admin-only; prints a stderr note when the value changes). Prefer `inkbox identity update <handle> --phone-filter-mode whitelist|blacklist`.
 
-### Number Contact Rules (`inkbox number rules …`)
+### Number Contact Rules (`inkbox number rules …`) — DEPRECATED
 
-Per-number allow/block rules (combined with the number's `filterMode`).
+**Deprecated** (Sunset 2026-08-31) — use `inkbox identity phone-rules …` (keyed by agent handle) instead. Per-number allow/block rules (combined with the number's `filterMode`).
 
 ```bash
 inkbox number rules list --number <id> [--action allow|block] [--match-type exact_number] [--limit <n>] [--offset <n>]
@@ -424,9 +463,16 @@ inkbox notes access revoke <note-id> <identity-id>
 
 ## Whoami, Signing Keys, Webhooks
 
+Each agent identity has its own webhook signing key. Manage it with the
+per-identity commands; the org-level `inkbox signing-key create` is deprecated
+(with an agent-scoped key it still rotates that identity's key; with an admin key
+the server returns 409).
+
 ```bash
 inkbox whoami
-inkbox signing-key create
+inkbox identity signing-key status <handle>
+inkbox identity signing-key rotate <handle>   # mints/rotates; prints the secret ONCE
+inkbox signing-key create                     # DEPRECATED — use the per-identity commands above
 inkbox webhook verify --payload <payload> --secret <secret> -H "X-Header: value"
 
 # Webhook subscriptions (fan-out per (owner, url, event_types)):
@@ -439,6 +485,8 @@ inkbox webhook subscription create --agent-identity-id <id> --url <url> \
 inkbox webhook subscription update <sub-id> [--url <url>] [--event-type <type>...]
 inkbox webhook subscription delete <sub-id>
 ```
+
+Every subscription row carries `ownerIdentityId` (the resolved owning agent identity). The **first** subscription created for an identity that has no signing key yet returns that identity's `signingKey` **once** in the create output (otherwise null) — capture it then, it cannot be retrieved again (use `--json` to read it reliably).
 
 Use `whoami --json` when you need the authenticated caller shape exactly.
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -37,22 +37,29 @@ Inkbox (admin-only client)
 ├── .texts                    → TextsResource
 ├── .imessages                → IMessagesResource
 ├── .imessage_contact_rules   → IMessageContactRulesResource
-├── .mail_contact_rules       → MailContactRulesResource
-├── .phone_contact_rules      → PhoneContactRulesResource
+├── .mail_identity_contact_rules  → MailIdentityContactRulesResource   (keyed by agent_handle)
+├── .phone_identity_contact_rules → PhoneIdentityContactRulesResource  (keyed by agent_handle)
+├── .signing_keys             → SigningKeysResource  (per-identity: create_or_rotate/get_status)
+├── .mail_contact_rules       → MailContactRulesResource   (DEPRECATED — per-mailbox)
+├── .phone_contact_rules      → PhoneContactRulesResource  (DEPRECATED — per-number)
 ├── .sms_opt_ins              → SmsOptInsResource
 ├── .contacts                 → ContactsResource  (.access, .vcards)
 ├── .notes                    → NotesResource     (.access)
 ├── .vault                    → VaultResource
 ├── .whoami()                 → WhoamiResponse
-└── .create_signing_key()     → SigningKey
+└── .create_signing_key()     → SigningKey  (DEPRECATED — org-level; use .signing_keys)
 
 AgentIdentity (identity-scoped helper)
 ├── .mailbox                 → IdentityMailbox | None
 ├── .phone_number            → IdentityPhoneNumber | None
+├── .mail_filter_mode / .phone_filter_mode → FilterMode
 ├── .credentials             → Credentials  (requires vault unlocked)
 ├── .list_access()           → list[IdentityAccess]
 ├── .grant_access(viewer_id|None) → IdentityAccess
 ├── .revoke_access(viewer_id) → None
+├── .list_mail_contact_rules() / .create_mail_contact_rule(...) / .get_/.update_/.delete_
+├── .list_phone_contact_rules() / .create_phone_contact_rule(...) / ...  (requires phone number)
+├── .get_signing_key_status() / .create_signing_key()
 ├── mail methods             (requires assigned mailbox)
 ├── phone methods            (requires assigned phone number)
 └── text methods             (requires assigned phone number)
@@ -557,7 +564,9 @@ mailbox   = inkbox.mailboxes.get("abc@inkboxmail.com")
 # mailbox PATCH endpoint hard-rejects `display_name` with a 422. To
 # attach a webhook receiver, see "Webhooks" below.
 
-# Switch contact-rule filter mode (admin-only — agent-scoped keys get 403)
+# DEPRECATED channel path — the mail filter mode now lives on the identity.
+# Prefer `identity.update(mail_filter_mode="whitelist")` (which does NOT return
+# a change notice). This legacy mailbox flip still works and still returns one:
 updated = inkbox.mailboxes.update(mailbox.email_address, filter_mode="whitelist")
 if updated.filter_mode_change_notice:
     # Populated when filter_mode actually changed — tells you how many
@@ -622,11 +631,11 @@ hits = inkbox.phone_numbers.search_transcripts(number.id, q="refund", party="rem
 inkbox.phone_numbers.release(number.id)
 ```
 
-Phone numbers carry the same `filter_mode` / `agent_identity_id` / `filter_mode_change_notice` fields as mailboxes; flipping `filter_mode` is admin-only and returns a change-notice when the value actually changed.
+Phone numbers carry the same `filter_mode` / `agent_identity_id` / `filter_mode_change_notice` fields as mailboxes; flipping `filter_mode` here is the **deprecated** channel path (admin-only; returns a change-notice when the value actually changed). Prefer `identity.update(phone_filter_mode="whitelist")`, which sets the mode on the identity and does not return a change notice.
 
 ## Contact Rules
 
-Per-mailbox or per-phone-number allow/block lists, enforced server-side. The active `filter_mode` on the owning resource controls whether the rules are interpreted as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+Allow/block lists are scoped to the **agent identity** (mirroring iMessage), addressed by `agent_handle`. The identity's `mail_filter_mode` / `phone_filter_mode` decides whether each channel's rules act as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number. Returned rows are `MailIdentityContactRule` / `PhoneIdentityContactRule`, keyed by `rule.agent_identity_id` (not a mailbox/phone-number id).
 
 ```python
 from inkbox import (
@@ -634,40 +643,73 @@ from inkbox import (
     DuplicateContactRuleError,
 )
 
-# Mail rules — scoped to a single mailbox. New rules always start active;
-# call `update(..., status="paused")` afterwards to pause one.
-rule = inkbox.mail_contact_rules.create(
-    mailbox.email_address,
+identity = inkbox.get_identity("sales-agent")
+
+# Mail rules via the identity convenience methods. New rules always start
+# active; call `update(..., status="paused")` afterwards to pause one.
+rule = identity.create_mail_contact_rule(
     action=MailRuleAction.ALLOW,         # or BLOCK
     match_type=MailRuleMatchType.DOMAIN, # or EXACT_EMAIL
     match_target="example.com",
 )
-inkbox.mail_contact_rules.list(mailbox.email_address)
-inkbox.mail_contact_rules.get(mailbox.email_address, rule.id)
-inkbox.mail_contact_rules.update(mailbox.email_address, rule.id, status="paused")  # admin-only
-inkbox.mail_contact_rules.delete(mailbox.email_address, rule.id)                   # admin-only
-
-# Admin-only list; optionally narrow to a single mailbox_id
-all_rules = inkbox.mail_contact_rules.list_all(mailbox_id=str(mailbox.id))
-
-# Duplicate (match_type, match_target) on the same mailbox raises 409:
-try:
-    inkbox.mail_contact_rules.create(
-        mailbox.email_address,
-        action="allow", match_type="domain", match_target="example.com",
-    )
-except DuplicateContactRuleError as e:
-    print(e.existing_rule_id)   # UUID of the rule that already matched
+identity.list_mail_contact_rules()
+identity.get_mail_contact_rule(rule.id)
+identity.update_mail_contact_rule(rule.id, status="paused")  # admin-only
+identity.delete_mail_contact_rule(rule.id)                   # admin-only
 
 # Phone rules — same shape, only match_type="exact_number" is supported.
-inkbox.phone_contact_rules.create(
-    number.id,
+# Phone helpers require the identity to have a phone number (else InkboxError).
+identity.create_phone_contact_rule(
     action=PhoneRuleAction.BLOCK,
-    match_type=PhoneRuleMatchType.EXACT_NUMBER,
     match_target="+15551234567",
+    match_type=PhoneRuleMatchType.EXACT_NUMBER,
 )
-inkbox.phone_contact_rules.list(number.id)
-inkbox.phone_contact_rules.list_all(phone_number_id=str(number.id))
+identity.list_phone_contact_rules()
+
+# Equivalent org-level resources, keyed by agent_handle, with an org-wide list_all:
+inkbox.mail_identity_contact_rules.create(
+    "sales-agent", action="allow", match_type="domain", match_target="example.com",
+)
+inkbox.mail_identity_contact_rules.list("sales-agent")
+inkbox.mail_identity_contact_rules.list_all(agent_identity_id=str(identity.id))  # admin-only, org-wide
+inkbox.phone_identity_contact_rules.list_all()                                   # admin-only, org-wide
+
+# Duplicate (match_type, match_target) on the same identity raises 409:
+try:
+    identity.create_mail_contact_rule(action="allow", match_type="domain", match_target="example.com")
+except DuplicateContactRuleError as e:
+    print(e.existing_rule_id)   # UUID of the rule that already matched
+```
+
+### Filter mode
+
+The whitelist/blacklist mode lives on the identity. Flip it with `identity.update`
+(admin-only). Unlike the deprecated channel update, this does **not** return a
+`FilterModeChangeNotice`. `phone_filter_mode` requires the identity to have a phone
+number (else a 422).
+
+```python
+identity.update(mail_filter_mode="whitelist", phone_filter_mode="blacklist")
+print(identity.mail_filter_mode, identity.phone_filter_mode)
+```
+
+### Deprecated: per-mailbox / per-number rules
+
+The legacy per-mailbox `inkbox.mail_contact_rules` and per-number
+`inkbox.phone_contact_rules` resources still work but hit deprecated server routes
+(Sunset 2026-08-31). Prefer the identity-keyed surface above.
+
+```python
+# Deprecated — per-mailbox mail rule:
+inkbox.mail_contact_rules.create(
+    mailbox.email_address,
+    action="allow", match_type="domain", match_target="example.com",
+)
+inkbox.mail_contact_rules.list_all(mailbox_id=str(mailbox.id))
+# Deprecated — per-number phone rule:
+inkbox.phone_contact_rules.create(
+    number.id, action="block", match_type="exact_number", match_target="+15551234567",
+)
 ```
 
 ## Contacts
@@ -832,8 +874,15 @@ from inkbox import (
     MailWebhookPayload, TextWebhookPayload, PhoneIncomingCallWebhookPayload,
 )
 
-# Rotate signing key (plaintext returned once — save it)
-key = inkbox.create_signing_key()
+# Each agent identity has its own webhook signing key. Create/rotate it
+# (plaintext returned once — save it), or read its status:
+key = identity.create_signing_key()                        # → SigningKey
+status = identity.get_signing_key_status()                 # → SigningKeyStatus(configured, created_at)
+# Org-level resource, keyed by agent_handle:
+key = inkbox.signing_keys.create_or_rotate("sales-agent")
+status = inkbox.signing_keys.get_status("sales-agent")
+# DEPRECATED: org-level inkbox.create_signing_key() — with an agent-scoped key it
+# still rotates that identity's key; with an admin key the server returns 409.
 
 # Verify, then parse + discriminate
 if not verify_webhook(payload=raw_body, headers=request.headers, secret="whsec_..."):
@@ -854,6 +903,17 @@ Algorithm: HMAC-SHA256 over `"{request_id}.{timestamp}.{body}"`.
 - **Inbound call** (flat, synchronous) — `PhoneIncomingCallWebhookPayload` on a phone number's `incoming_call_webhook_url`. Not subscribable; the URL stays on the phone-number resource because the response (`action: "answer" | "reject"` + optional `client_websocket_url`) decides the call's fate. Non-200, invalid bodies, and timeouts are treated as "decline routing" by Inkbox.
 
 **Subscription resource:** `inkbox.webhooks.subscriptions.{list,get,create,update,delete}`. Each subscription names exactly one owner (mailbox, phone number, **or** agent identity), one HTTPS destination URL, and a non-empty subset of the catalog's event types. Multiple subscriptions on the same owner fan out independently (cap: 20 active per owner). The SDK runs structural + prefix validation client-side (exactly-one-FK, non-empty distinct events, no `phone.incoming_call`, `message.` / `text.` / `imessage.` prefix matching the owner's channel) so most shape mistakes surface as `ValueError` before the request leaves the client. The server remains authoritative for the exact event-name enum, so a typo with a valid prefix (e.g. `message.received_typo`) passes the SDK's check and is rejected as 422 by the server.
+
+`create(...)` returns a `WebhookSubscriptionCreateResponse`. The **first** subscription created for an identity that has no signing key yet carries that identity's `signing_key` **once** (otherwise `None`) — capture it then, it cannot be retrieved again. Every subscription (read or created) also carries `owner_identity_id`, the resolved owning agent identity (mail/phone/iMessage).
+
+```python
+created = inkbox.webhooks.subscriptions.create(
+    mailbox_id=str(mailbox.id), url="https://example.com/hook", event_types=["message.received"],
+)
+print(created.owner_identity_id)
+if created.signing_key:                # populated once if the identity had no key yet
+    save_secret(created.signing_key)
+```
 
 **Mail contact / identity resolution:** `data["contacts"]` and `data["agent_identities"]` are lists of `{"bucket", "address", "id", ...}` entries (always present, possibly empty). Inbound events resolve `from` + every `cc`; outbound events resolve every `to` + `cc` + `bcc`. Pair entries to the source field by `(bucket, address)`. Outbound payloads also carry `data["message"]["bcc_addresses"]` (`None` on inbound, since BCC is not visible to recipients).
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -36,22 +36,29 @@ Inkbox (admin-only client)
 ├── .texts                    → TextsResource
 ├── .imessages                → IMessagesResource
 ├── .imessageContactRules     → IMessageContactRulesResource
-├── .mailContactRules         → MailContactRulesResource
-├── .phoneContactRules        → PhoneContactRulesResource
+├── .mailIdentityContactRules  → MailIdentityContactRulesResource    (keyed by agentHandle)
+├── .phoneIdentityContactRules → PhoneIdentityContactRulesResource   (keyed by agentHandle)
+├── .signingKeys              → SigningKeysResource  (per-identity: createOrRotate/getStatus)
+├── .mailContactRules         → MailContactRulesResource    (DEPRECATED — per-mailbox)
+├── .phoneContactRules        → PhoneContactRulesResource   (DEPRECATED — per-number)
 ├── .smsOptIns                → SmsOptInsResource
 ├── .contacts                 → ContactsResource   (.access, .vcards)
 ├── .notes                    → NotesResource      (.access)
 ├── .vault                    → VaultResource
 ├── .whoami()                 → Promise<WhoamiResponse>
-└── .createSigningKey()       → Promise<SigningKey>
+└── .createSigningKey()       → Promise<SigningKey>  (DEPRECATED — org-level; use .signingKeys)
 
 AgentIdentity (identity-scoped helper)
 ├── .mailbox                → IdentityMailbox | null
 ├── .phoneNumber            → IdentityPhoneNumber | null
+├── .mailFilterMode / .phoneFilterMode → FilterMode
 ├── .getCredentials()       → Promise<Credentials>  (requires vault unlocked)
 ├── .listAccess()           → Promise<IdentityAccess[]>
 ├── .grantAccess(viewerId|null) → Promise<IdentityAccess>
 ├── .revokeAccess(viewerId) → Promise<void>
+├── .listMailContactRules() / .createMailContactRule(...) / .get/.update/.delete
+├── .listPhoneContactRules() / .createPhoneContactRule(...) / ...  (requires phone number)
+├── .getSigningKeyStatus() / .createSigningKey()
 ├── mail methods            (requires assigned mailbox)
 ├── phone methods           (requires assigned phone number)
 └── text methods            (requires assigned phone number)
@@ -583,7 +590,9 @@ const mailbox   = await inkbox.mailboxes.get("abc@inkboxmail.com");
 // the mailbox PATCH endpoint hard-rejects `display_name` with a 422.
 // To attach a webhook receiver, see "Webhooks" below.
 
-// Switch contact-rule filter mode (admin-only — agent-scoped keys get 403)
+// DEPRECATED channel path — the mail filter mode now lives on the identity.
+// Prefer `identity.update({ mailFilterMode: "whitelist" })` (which does NOT
+// return a change notice). This legacy mailbox flip still works and returns one:
 const updated = await inkbox.mailboxes.update(mailbox.emailAddress, {
   filterMode: "whitelist",   // or "blacklist" — see FilterMode enum
 });
@@ -646,11 +655,11 @@ const hits = await inkbox.phoneNumbers.searchTranscripts(num.id, { q: "refund", 
 await inkbox.phoneNumbers.release(num.id);
 ```
 
-Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChangeNotice` fields as mailboxes; flipping `filterMode` is admin-only and returns a change-notice when the value actually changed.
+Phone numbers carry the same `filterMode` / `agentIdentityId` / `filterModeChangeNotice` fields as mailboxes; flipping `filterMode` here is the **deprecated** channel path (admin-only; returns a change-notice when the value actually changed). Prefer `identity.update({ phoneFilterMode: "whitelist" })`, which sets the mode on the identity and does not return a change notice.
 
 ## Contact Rules
 
-Per-mailbox or per-phone-number allow/block lists, enforced server-side. The active `filterMode` on the owning resource decides whether the rules are a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number.
+Allow/block lists are scoped to the **agent identity** (mirroring iMessage), addressed by `agentHandle`. The identity's `mailFilterMode` / `phoneFilterMode` decides whether each channel's rules act as a whitelist or blacklist. Mail matches by exact email or domain; phone matches by exact E.164 number. Returned rows are `MailIdentityContactRule` / `PhoneIdentityContactRule`, keyed by `rule.agentIdentityId` (not a mailbox/phone-number id).
 
 ```typescript
 import {
@@ -658,24 +667,40 @@ import {
   DuplicateContactRuleError,
 } from "@inkbox/sdk";
 
-// Mail rules — scoped to a single mailbox. New rules always start active;
-// call `update(..., { status: "paused" })` afterwards to pause one.
-const rule = await inkbox.mailContactRules.create(mailbox.emailAddress, {
+const identity = await inkbox.getIdentity("sales-agent");
+
+// Mail rules via the identity convenience methods. New rules always start
+// active; call `update(..., { status: "paused" })` afterwards to pause one.
+const rule = await identity.createMailContactRule({
   action: MailRuleAction.ALLOW,          // or BLOCK
   matchType: MailRuleMatchType.DOMAIN,   // or EXACT_EMAIL
   matchTarget: "example.com",
 });
-await inkbox.mailContactRules.list(mailbox.emailAddress);
-await inkbox.mailContactRules.get(mailbox.emailAddress, rule.id);
-await inkbox.mailContactRules.update(mailbox.emailAddress, rule.id, { status: "paused" });  // admin-only
-await inkbox.mailContactRules.delete(mailbox.emailAddress, rule.id);                        // admin-only
+await identity.listMailContactRules();
+await identity.getMailContactRule(rule.id);
+await identity.updateMailContactRule(rule.id, { status: "paused" });  // admin-only
+await identity.deleteMailContactRule(rule.id);                        // admin-only
 
-// Admin-only list; optionally narrow to a single mailboxId
-const allRules = await inkbox.mailContactRules.listAll({ mailboxId: mailbox.id });
+// Phone rules — same shape, only matchType: "exact_number" is supported.
+// Phone helpers require the identity to have a phone number (else InkboxError).
+await identity.createPhoneContactRule({
+  action: PhoneRuleAction.BLOCK,
+  matchTarget: "+15551234567",
+  matchType: PhoneRuleMatchType.EXACT_NUMBER,
+});
+await identity.listPhoneContactRules();
 
-// Duplicate (matchType, matchTarget) on the same mailbox throws 409:
+// Equivalent org-level resources, keyed by agentHandle, with an org-wide listAll:
+await inkbox.mailIdentityContactRules.create("sales-agent", {
+  action: "allow", matchType: "domain", matchTarget: "example.com",
+});
+await inkbox.mailIdentityContactRules.list("sales-agent");
+await inkbox.mailIdentityContactRules.listAll({ agentIdentityId: identity.id });  // admin-only, org-wide
+await inkbox.phoneIdentityContactRules.listAll();                                 // admin-only, org-wide
+
+// Duplicate (matchType, matchTarget) on the same identity throws 409:
 try {
-  await inkbox.mailContactRules.create(mailbox.emailAddress, {
+  await identity.createMailContactRule({
     action: "allow", matchType: "domain", matchTarget: "example.com",
   });
 } catch (e) {
@@ -683,15 +708,36 @@ try {
     console.log(e.existingRuleId);   // id of the rule that already matched
   }
 }
+```
 
-// Phone rules — same shape, only matchType: "exact_number" is supported.
-await inkbox.phoneContactRules.create(num.id, {
-  action: PhoneRuleAction.BLOCK,
-  matchType: PhoneRuleMatchType.EXACT_NUMBER,
-  matchTarget: "+15551234567",
+### Filter mode
+
+The whitelist/blacklist mode lives on the identity. Flip it with `identity.update`
+(admin-only). Unlike the deprecated channel update, this does **not** return a
+`FilterModeChangeNotice`. `phoneFilterMode` requires the identity to have a phone
+number (else a 422).
+
+```typescript
+await identity.update({ mailFilterMode: "whitelist", phoneFilterMode: "blacklist" });
+console.log(identity.mailFilterMode, identity.phoneFilterMode);
+```
+
+### Deprecated: per-mailbox / per-number rules
+
+The legacy per-mailbox `inkbox.mailContactRules` and per-number
+`inkbox.phoneContactRules` resources still work but hit deprecated server routes
+(Sunset 2026-08-31). Prefer the identity-keyed surface above.
+
+```typescript
+// Deprecated — per-mailbox mail rule:
+await inkbox.mailContactRules.create(mailbox.emailAddress, {
+  action: "allow", matchType: "domain", matchTarget: "example.com",
 });
-await inkbox.phoneContactRules.list(num.id);
-await inkbox.phoneContactRules.listAll({ phoneNumberId: num.id });
+await inkbox.mailContactRules.listAll({ mailboxId: mailbox.id });
+// Deprecated — per-number phone rule:
+await inkbox.phoneContactRules.create(num.id, {
+  action: "block", matchType: "exact_number", matchTarget: "+15551234567",
+});
 ```
 
 ## Contacts
@@ -865,8 +911,15 @@ import {
   MailWebhookPayload, TextWebhookPayload, PhoneIncomingCallWebhookPayload,
 } from "@inkbox/sdk";
 
-// Rotate signing key (plaintext returned once — save it)
-const key = await inkbox.createSigningKey();
+// Each agent identity has its own webhook signing key. Create/rotate it
+// (plaintext returned once — save it), or read its status:
+const key = await identity.createSigningKey();                 // → SigningKey
+const status = await identity.getSigningKeyStatus();           // → SigningKeyStatus { configured, createdAt }
+// Org-level resource, keyed by agentHandle:
+const key2 = await inkbox.signingKeys.createOrRotate("sales-agent");
+const status2 = await inkbox.signingKeys.getStatus("sales-agent");
+// DEPRECATED: org-level inkbox.createSigningKey() — with an agent-scoped key it
+// still rotates that identity's key; with an admin key the server returns 409.
 
 // Verify, then parse + discriminate
 const valid = verifyWebhook({
@@ -892,6 +945,16 @@ Algorithm: HMAC-SHA256 over `"{requestId}.{timestamp}.{body}"`.
 - **Inbound call** (flat, synchronous) — `PhoneIncomingCallWebhookPayload` on a phone number's `incomingCallWebhookUrl`. Not subscribable; the URL stays on the phone-number resource because the response (`action: "answer" | "reject"` + optional `clientWebsocketUrl`) decides the call's fate. Non-200, invalid bodies, and timeouts are treated as "decline routing" by Inkbox.
 
 **Subscription resource:** `inkbox.webhooks.subscriptions.{list,get,create,update,delete}`. Each subscription names exactly one owner (mailbox, phone number, **or** agent identity), one HTTPS destination URL, and a non-empty subset of the catalog's event types. Multiple subscriptions on the same owner fan out independently (cap: 20 active per owner). The SDK runs structural + prefix validation client-side (exactly-one-FK, non-empty distinct events, no `phone.incoming_call`, `message.` / `text.` / `imessage.` prefix matching the owner's channel) so most shape mistakes surface as `Error` before the request leaves the client. The server remains authoritative for the exact event-name enum, so a typo with a valid prefix (e.g. `message.received_typo`) passes the SDK's check and is rejected as 422 by the server.
+
+`create(...)` returns a `WebhookSubscriptionCreateResponse`. The **first** subscription created for an identity that has no signing key yet carries that identity's `signingKey` **once** (otherwise `null`) — capture it then, it cannot be retrieved again. Every subscription (read or created) also carries `ownerIdentityId`, the resolved owning agent identity (mail/phone/iMessage).
+
+```typescript
+const created = await inkbox.webhooks.subscriptions.create({
+  mailboxId: mailbox.id, url: "https://example.com/hook", eventTypes: ["message.received"],
+});
+console.log(created.ownerIdentityId);
+if (created.signingKey) saveSecret(created.signingKey);   // populated once if the identity had no key yet
+```
 
 **Mail contact / identity resolution:** `data.contacts` and `data.agent_identities` are lists of `{ bucket, address, id, ... }` entries (always present, possibly empty). Inbound events resolve `from` + every `cc`; outbound events resolve every `to` + `cc` + `bcc`. Pair entries to the source field by `(bucket, address)`. Outbound payloads also carry `data.message.bcc_addresses` (`null` on inbound, since BCC is not visible to recipients).
 

--- a/tests/integration/cli/cli_lifecycle.test.ts
+++ b/tests/integration/cli/cli_lifecycle.test.ts
@@ -183,10 +183,43 @@ describe("CLI lifecycle", { timeout: 300_000 }, () => {
     const forwardedInbound = alphaList.find((m) => m.subject === forwardSubject)!;
     expect(forwardedInbound.direction).toBe("inbound");
 
-    // ── signing key ───────────────────────────────────────────
-    logStep(config, "create signing key");
-    const signingKey = inkboxJson<{ signingKey: string }>("signing-key create", cliOpts);
+    // ── identity-scoped contact rules + filter mode ───────────
+    // (mail only — alpha has no phone number, and we don't provision
+    // real numbers in CI; phone rules require a number server-side.)
+    logStep(config, "set alpha mail filter mode to whitelist");
+    inkbox(`identity update ${alphaHandle} --mail-filter-mode whitelist`, cliOpts);
+    const alphaAfterFlip = inkboxJson<{ mailFilterMode: string }>(
+      `identity get ${alphaHandle}`,
+      cliOpts,
+    );
+    expect(alphaAfterFlip.mailFilterMode).toBe("whitelist");
+
+    logStep(config, "create + list + delete an identity-keyed mail contact rule");
+    const rule = inkboxJson<{ id: string; agentIdentityId: string }>(
+      `identity mail-rules create ${alphaHandle} --action allow --match-type exact_email --match-target vip@example.com`,
+      cliOpts,
+    );
+    expect(rule.agentIdentityId).toBe(alphaCreate.id);
+    const ruleList = inkboxJson<Array<{ id: string }>>(
+      `identity mail-rules list ${alphaHandle}`,
+      cliOpts,
+    );
+    expect(ruleList.some((r) => r.id === rule.id)).toBe(true);
+    inkbox(`identity mail-rules delete ${alphaHandle} ${rule.id}`, cliOpts);
+    inkbox(`identity update ${alphaHandle} --mail-filter-mode blacklist`, cliOpts);
+
+    // ── per-identity signing key ──────────────────────────────
+    logStep(config, "per-identity signing key: rotate + status");
+    const signingKey = inkboxJson<{ signingKey: string }>(
+      `identity signing-key rotate ${alphaHandle}`,
+      cliOpts,
+    );
     expect(signingKey.signingKey).toBeTruthy();
+    const skStatus = inkboxJson<{ configured: boolean }>(
+      `identity signing-key status ${alphaHandle}`,
+      cliOpts,
+    );
+    expect(skStatus.configured).toBe(true);
 
     // ── cleanup: delete identities (cascades to mailbox + tunnel) ─
     logStep(config, "delete identities");

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -232,11 +232,38 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         alpha.delete_secret(secret_b.id)
         assert len(inkbox.vault.list_secrets()) == 0
 
-        # ── signing key ───────────────────────────────────────────
-        log_step(ctx, "create signing key")
-        signing_key = inkbox.create_signing_key()
+        # ── identity-scoped contact rules + filter mode ───────────
+        # (mail only — alpha has no phone number, and we don't provision
+        # real numbers in CI; phone rules require a number server-side.)
+        log_step(ctx, "set alpha mail filter mode to whitelist")
+        alpha.update(mail_filter_mode="whitelist")
+        assert inkbox.get_identity(alpha_handle).mail_filter_mode == "whitelist"
+
+        log_step(ctx, "create a mail contact rule on alpha (identity-keyed)")
+        rule = alpha.create_mail_contact_rule(
+            action="allow", match_type="exact_email", match_target="vip@example.com",
+        )
+        assert str(rule.agent_identity_id) == str(alpha.id)
+
+        log_step(ctx, "list alpha's mail rules + org-wide list filtered by identity")
+        assert any(r.id == rule.id for r in alpha.list_mail_contact_rules())
+        org_rules = inkbox.mail_identity_contact_rules.list_all(agent_identity_id=alpha.id)
+        assert any(r.id == rule.id for r in org_rules)
+
+        log_step(ctx, "delete the mail contact rule + reset filter mode")
+        alpha.delete_mail_contact_rule(rule.id)
+        assert all(r.id != rule.id for r in alpha.list_mail_contact_rules())
+        alpha.update(mail_filter_mode="blacklist")
+        assert inkbox.get_identity(alpha_handle).mail_filter_mode == "blacklist"
+
+        # ── per-identity signing key ──────────────────────────────
+        log_step(ctx, "per-identity signing key: status -> create -> status")
+        pre = alpha.get_signing_key_status()
+        assert isinstance(pre.configured, bool)
+        signing_key = alpha.create_signing_key()
         assert signing_key.signing_key is not None
         assert signing_key.created_at is not None
+        assert alpha.get_signing_key_status().configured is True
 
         # ── cleanup: delete identities (cascades to mailbox + tunnel) ─
         log_step(ctx, "delete identities")

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -243,11 +243,40 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
     const remaining = await inkbox.vault.listSecrets();
     expect(remaining).toHaveLength(0);
 
-    // ── signing key ───────────────────────────────────────────
-    logStep(config, "create signing key");
-    const signingKey = await inkbox.createSigningKey();
+    // ── identity-scoped contact rules + filter mode ───────────
+    // (mail only — alpha has no phone number, and we don't provision
+    // real numbers in CI; phone rules require a number server-side.)
+    logStep(config, "set alpha mail filter mode to whitelist");
+    await alpha.update({ mailFilterMode: "whitelist" });
+    expect((await inkbox.getIdentity(alphaHandle)).mailFilterMode).toBe("whitelist");
+
+    logStep(config, "create a mail contact rule on alpha (identity-keyed)");
+    const rule = await alpha.createMailContactRule({
+      action: "allow",
+      matchType: "exact_email",
+      matchTarget: "vip@example.com",
+    });
+    expect(rule.agentIdentityId).toBe(alpha.id);
+
+    logStep(config, "list alpha's mail rules + org-wide list filtered by identity");
+    expect((await alpha.listMailContactRules()).some((r) => r.id === rule.id)).toBe(true);
+    const orgRules = await inkbox.mailIdentityContactRules.listAll({ agentIdentityId: alpha.id });
+    expect(orgRules.some((r) => r.id === rule.id)).toBe(true);
+
+    logStep(config, "delete the mail contact rule + reset filter mode");
+    await alpha.deleteMailContactRule(rule.id);
+    expect((await alpha.listMailContactRules()).some((r) => r.id === rule.id)).toBe(false);
+    await alpha.update({ mailFilterMode: "blacklist" });
+    expect((await inkbox.getIdentity(alphaHandle)).mailFilterMode).toBe("blacklist");
+
+    // ── per-identity signing key ──────────────────────────────
+    logStep(config, "per-identity signing key: status -> create -> status");
+    const preStatus = await alpha.getSigningKeyStatus();
+    expect(typeof preStatus.configured).toBe("boolean");
+    const signingKey = await alpha.createSigningKey();
     expect(signingKey.signingKey).toBeTruthy();
     expect(signingKey.createdAt).toBeTruthy();
+    expect((await alpha.getSigningKeyStatus()).configured).toBe(true);
 
     // ── cleanup: delete identities ────────────────────────────
     logStep(config, "delete identities (cascades to mailbox + tunnel)");


### PR DESCRIPTION
Mail and phone contact rules (and their filter mode) are now keyed by agent identity, matching iMessage. Webhook signing keys are now per identity.

- New identity-keyed contact-rule resources + `identity.*_contact_rule(...)` helpers; `mail_filter_mode` / `phone_filter_mode` via `identity.update(...)`.
- Per-identity signing keys (`identity.create_signing_key()` / status); the first webhook subscription for an identity returns its secret once; subscriptions expose `owner_identity_id`.
- Previous per-mailbox/per-number contact-rule methods and the org-level signing key are deprecated but still work.
- Python, TypeScript, and Rust SDKs + CLI. Unit + integration tests, docs, and CHANGELOG updated. Version 0.4.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)