### PR TITLE
`0.4.17`: Inline images, CLI attachments, and mark-unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.4.17 — Inline images, CLI attachments, and mark-unread
+
+### Added
+
+- **Inline images.** Attachment entries on `messages.send(...)` / `reply_all(...)` (and the identity `send_email` / `reply_all_email`) accept `content_id` (TS `contentId`; Rust `Attachment.content_id`). A part with `content_id` renders inline in the HTML body — reference it as `cid:<content_id>` (e.g. `<img src="cid:chart1">`) — instead of as a download, and is not counted in `has_attachments`. Requires `body_html`, an `image/*` `content_type`, and a unique id per send (else 422). Not supported on forwards (`additional_attachments`) — 422. CLI: `--inline-image <cid=path>` on `email send` / `email reply-all` (requires `--body-html`; repeatable).
+- **`mark_emails_unread`** (TS `markEmailsUnread`) on the identity across the TypeScript, Python, and Rust SDKs — the batch counterpart to `mark_emails_read`. CLI: `email mark-unread <message-ids...>`.
+- **CLI attachments.** `email send` / `email reply-all` / `email forward` gain `--attach <path>` (repeatable) to attach files; the content type is inferred from the file extension. `email download-attachment <message-id> <filename>` returns a time-limited download URL for a stored attachment.
+
 ## 0.4.16 — Configurable webhook context + open tracking
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 - **`mark_emails_unread`** (TS `markEmailsUnread`) on the identity across the TypeScript, Python, and Rust SDKs — the batch counterpart to `mark_emails_read`. CLI: `email mark-unread <message-ids...>`.
 - **CLI attachments.** `email send` / `email reply-all` / `email forward` gain `--attach <path>` (repeatable) to attach files; the content type is inferred from the file extension. `email download-attachment <message-id> <filename>` returns a time-limited download URL for a stored attachment.
 
+### Changed
+
+- **Rust `Attachment` gains a `content_id` field.** This is source-breaking for code that builds `Attachment` with a struct literal; add `content_id: None` or use `..Default::default()`. The Python dict and TypeScript object attachment shapes are additive and unaffected.
+
 ## 0.4.16 — Configurable webhook context + open tracking
 
 ### Added

--- a/cli/README.md
+++ b/cli/README.md
@@ -133,6 +133,11 @@ inkbox email send -i <handle>                # Send an email
   --cc <addresses>                           #   Comma-separated CC
   --bcc <addresses>                          #   Comma-separated BCC
   --in-reply-to <message-id>                 #   Message ID to reply to
+  --attach <path>                            #   Attach a file (repeatable)
+  --inline-image <cid=path>                  #   Embed an image inline as cid:<cid>
+                                             #     (repeatable; requires --body-html,
+                                             #     image/*; reference it in the HTML
+                                             #     as <img src="cid:<cid>">)
   --track-opens                              #   Embed an open-tracking pixel
                                              #     (requires --body-html)
 
@@ -141,6 +146,9 @@ inkbox email reply-all <message-id> -i <handle>  # Reply to everyone on a messag
   --body-text <text>                         #   Plain text body
   --body-html <html>                         #   HTML body
   --reply-to <address>                       #   Reply-To address
+  --attach <path>                            #   Attach a file (repeatable)
+  --inline-image <cid=path>                  #   Embed an image inline as cid:<cid>
+                                             #     (repeatable; requires --body-html)
 
 inkbox email forward <message-id> -i <handle>    # Forward a message
   --to <addresses>                           #   Comma-separated recipients
@@ -153,6 +161,7 @@ inkbox email forward <message-id> -i <handle>    # Forward a message
   --body-html <html>                         #   HTML caller note
   --no-include-original-attachments          #   Drop originals (inline mode)
   --reply-to <address>                       #   Reply-To for the forward
+  --attach <path>                            #   Attach an additional file (repeatable)
   --track-opens                              #   Embed an open-tracking pixel
                                              #     (inline forwards reuse the
                                              #     original's HTML; server 422s
@@ -175,6 +184,8 @@ inkbox email unread -i <handle>              # List unread emails
   --limit <n>                                #   Max messages (default: 50)
 
 inkbox email mark-read <ids...> -i <handle>  # Mark messages as read
+inkbox email mark-unread <ids...> -i <handle>  # Mark messages as unread
+inkbox email download-attachment <message-id> <filename> -i <handle>  # Time-limited download URL
 inkbox email delete <message-id> -i <handle> # Delete a message
 inkbox email delete-thread <thread-id> -i <handle>  # Delete a thread
 inkbox email star <message-id> -i <handle>   # Star a message

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.4.16",
+        "@inkbox/sdk": "^0.4.17",
         "commander": "^13.0.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.16",
+    "@inkbox/sdk": "^0.4.17",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -4,6 +4,9 @@ import * as path from "node:path";
 import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
+// Keep in sync with package.json "version".
+export const CLI_VERSION = "0.4.17";
+
 export interface GlobalOpts {
   apiKey?: string;
   vaultKey?: string;
@@ -58,5 +61,6 @@ export function createClient(opts: GlobalOpts): Inkbox {
     apiKey,
     vaultKey: vaultKey || undefined,
     baseUrl,
+    userAgentPrefix: `inkbox-cli/${CLI_VERSION}`,
   });
 }

--- a/cli/src/commands/email.ts
+++ b/cli/src/commands/email.ts
@@ -21,6 +21,13 @@ const MIME_BY_EXT: Record<string, string> = {
   ".gif": "image/gif",
   ".webp": "image/webp",
   ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".ico": "image/x-icon",
+  ".avif": "image/avif",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
   ".pdf": "application/pdf",
   ".txt": "text/plain",
   ".csv": "text/csv",
@@ -77,7 +84,14 @@ function buildAttachments(attach: string[], inlineImage: string[]): AttachmentIn
       console.error((e as Error).message);
       process.exit(1);
     }
-    attachments.push(fileToAttachment(parsed.path, parsed.cid));
+    const att = fileToAttachment(parsed.path, parsed.cid);
+    if (!att.contentType.startsWith("image/")) {
+      console.error(
+        `--inline-image ${parsed.cid} must be an image; got ${att.contentType} for ${parsed.path}.`,
+      );
+      process.exit(1);
+    }
+    attachments.push(att);
   }
   return attachments.length > 0 ? attachments : undefined;
 }

--- a/cli/src/commands/email.ts
+++ b/cli/src/commands/email.ts
@@ -1,9 +1,86 @@
+import { readFileSync } from "node:fs";
+import { basename, extname } from "node:path";
 import { Command } from "commander";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
 import type { Message, MessageDirection, ThreadDetail } from "@inkbox/sdk";
 import { ForwardMode } from "@inkbox/sdk";
+
+type AttachmentInput = {
+  filename: string;
+  contentType: string;
+  contentBase64: string;
+  contentId?: string;
+};
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".zip": "application/zip",
+};
+
+/** Accumulate a repeatable Commander option into an array. */
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/** MIME type inferred from a file extension, defaulting to octet-stream. */
+export function contentTypeForPath(path: string): string {
+  return MIME_BY_EXT[extname(path).toLowerCase()] ?? "application/octet-stream";
+}
+
+/** Split a "<cid>=<path>" inline-image spec. Throws on malformed input. */
+export function parseInlineImageSpec(spec: string): { cid: string; path: string } {
+  const eq = spec.indexOf("=");
+  if (eq <= 0 || eq === spec.length - 1) {
+    throw new Error(`--inline-image must be <cid>=<path>, got: ${spec}`);
+  }
+  return { cid: spec.slice(0, eq).trim(), path: spec.slice(eq + 1).trim() };
+}
+
+/** Read a file into an SDK attachment; set contentId to embed it inline (cid:). */
+function fileToAttachment(path: string, contentId?: string): AttachmentInput {
+  let buf: Buffer;
+  try {
+    buf = readFileSync(path);
+  } catch {
+    console.error(`Cannot read attachment file: ${path}`);
+    process.exit(1);
+  }
+  const att: AttachmentInput = {
+    filename: basename(path),
+    contentType: contentTypeForPath(path),
+    contentBase64: buf.toString("base64"),
+  };
+  if (contentId !== undefined) att.contentId = contentId;
+  return att;
+}
+
+/** Build the attachments array from --attach paths and --inline-image cid=path specs. */
+function buildAttachments(attach: string[], inlineImage: string[]): AttachmentInput[] | undefined {
+  const attachments = attach.map((p) => fileToAttachment(p));
+  for (const spec of inlineImage) {
+    let parsed: { cid: string; path: string };
+    try {
+      parsed = parseInlineImageSpec(spec);
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
+    attachments.push(fileToAttachment(parsed.path, parsed.cid));
+  }
+  return attachments.length > 0 ? attachments : undefined;
+}
 
 export function registerEmailCommands(program: Command): void {
   const email = program
@@ -22,6 +99,13 @@ export function registerEmailCommands(program: Command): void {
     .option("--bcc <addresses>", "Comma-separated BCC addresses")
     .option("--in-reply-to <message-id>", "Message ID to reply to")
     .option("--track-opens", "Embed an open-tracking pixel (requires --body-html)")
+    .option("--attach <path>", "Attach a file (repeatable)", collect, [])
+    .option(
+      "--inline-image <cid=path>",
+      "Embed an image inline in the HTML body, referenced as cid:<cid> (repeatable)",
+      collect,
+      [],
+    )
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -35,11 +119,17 @@ export function registerEmailCommands(program: Command): void {
           bcc?: string;
           inReplyTo?: string;
           trackOpens?: boolean;
+          attach: string[];
+          inlineImage: string[];
         },
       ) {
         const opts = getGlobalOpts(this);
         if (cmdOpts.trackOpens && !cmdOpts.bodyHtml) {
           console.error("--track-opens requires --body-html.");
+          process.exit(1);
+        }
+        if (cmdOpts.inlineImage.length > 0 && !cmdOpts.bodyHtml) {
+          console.error("--inline-image requires --body-html (reference it as cid:<cid>).");
           process.exit(1);
         }
         const inkbox = createClient(opts);
@@ -53,6 +143,7 @@ export function registerEmailCommands(program: Command): void {
           bcc: cmdOpts.bcc?.split(",").map((s) => s.trim()),
           inReplyToMessageId: cmdOpts.inReplyTo,
           trackOpens: cmdOpts.trackOpens,
+          attachments: buildAttachments(cmdOpts.attach, cmdOpts.inlineImage),
         });
         output(
           {
@@ -74,6 +165,13 @@ export function registerEmailCommands(program: Command): void {
     .option("--body-text <text>", "Plain text body")
     .option("--body-html <html>", "HTML body")
     .option("--reply-to <address>", "Reply-To address")
+    .option("--attach <path>", "Attach a file (repeatable)", collect, [])
+    .option(
+      "--inline-image <cid=path>",
+      "Embed an image inline in the HTML body, referenced as cid:<cid> (repeatable)",
+      collect,
+      [],
+    )
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -84,9 +182,15 @@ export function registerEmailCommands(program: Command): void {
           bodyText?: string;
           bodyHtml?: string;
           replyTo?: string;
+          attach: string[];
+          inlineImage: string[];
         },
       ) {
         const opts = getGlobalOpts(this);
+        if (cmdOpts.inlineImage.length > 0 && !cmdOpts.bodyHtml) {
+          console.error("--inline-image requires --body-html (reference it as cid:<cid>).");
+          process.exit(1);
+        }
         const inkbox = createClient(opts);
         const identity = await inkbox.getIdentity(cmdOpts.identity);
         const msg = await identity.replyAllEmail(messageId, {
@@ -94,6 +198,7 @@ export function registerEmailCommands(program: Command): void {
           bodyText: cmdOpts.bodyText,
           bodyHtml: cmdOpts.bodyHtml,
           replyTo: cmdOpts.replyTo,
+          attachments: buildAttachments(cmdOpts.attach, cmdOpts.inlineImage),
         });
         output(
           {
@@ -128,6 +233,7 @@ export function registerEmailCommands(program: Command): void {
     )
     .option("--reply-to <address>", "Reply-To address for the forward")
     .option("--track-opens", "Embed an open-tracking pixel (inline forwards can reuse the original's HTML)")
+    .option("--attach <path>", "Attach an additional file alongside the forward (repeatable)", collect, [])
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -144,6 +250,7 @@ export function registerEmailCommands(program: Command): void {
           includeOriginalAttachments: boolean;
           replyTo?: string;
           trackOpens?: boolean;
+          attach: string[];
         },
       ) {
         const opts = getGlobalOpts(this);
@@ -167,6 +274,7 @@ export function registerEmailCommands(program: Command): void {
           subject: cmdOpts.subject,
           bodyText: cmdOpts.bodyText,
           bodyHtml: cmdOpts.bodyHtml,
+          additionalAttachments: buildAttachments(cmdOpts.attach, []),
           includeOriginalAttachments: cmdOpts.includeOriginalAttachments,
           replyTo: cmdOpts.replyTo,
           trackOpens: cmdOpts.trackOpens,
@@ -357,6 +465,56 @@ export function registerEmailCommands(program: Command): void {
         const identity = await inkbox.getIdentity(cmdOpts.identity);
         await identity.markEmailsRead(messageIds);
         console.log(`Marked ${messageIds.length} message(s) as read.`);
+      }),
+    );
+
+  email
+    .command("mark-unread <message-ids...>")
+    .description("Mark messages as unread")
+    .requiredOption("-i, --identity <handle>", "Agent identity handle")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        messageIds: string[],
+        cmdOpts: { identity: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const identity = await inkbox.getIdentity(cmdOpts.identity);
+        await identity.markEmailsUnread(messageIds);
+        console.log(`Marked ${messageIds.length} message(s) as unread.`);
+      }),
+    );
+
+  email
+    .command("download-attachment <message-id> <filename>")
+    .description("Get a time-limited download URL for a message attachment")
+    .requiredOption("-i, --identity <handle>", "Agent identity handle")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        messageId: string,
+        filename: string,
+        cmdOpts: { identity: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const identity = await inkbox.getIdentity(cmdOpts.identity);
+        if (!identity.mailbox) {
+          console.error(
+            `Identity '${cmdOpts.identity}' has no mailbox assigned.`,
+          );
+          process.exit(1);
+        }
+        const att = await inkbox.messages.getAttachment(
+          identity.mailbox.emailAddress,
+          messageId,
+          filename,
+        );
+        output(
+          { url: att.url, filename: att.filename, expiresIn: att.expiresIn },
+          { json: !!opts.json },
+        );
       }),
     );
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { CLI_VERSION } from "./client.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerSignupCommands } from "./commands/signup.js";
 import { registerIdentityCommands } from "./commands/identity.js";
@@ -23,7 +24,7 @@ import { registerDomainCommands } from "./commands/domain.js";
 const program = new Command()
   .name("inkbox")
   .description("CLI for the Inkbox API — email, phone, identities, and vault for AI agents")
-  .version("0.4.12")
+  .version(CLI_VERSION)
   .option("--api-key <key>", "Inkbox API key (or set INKBOX_API_KEY)")
   .option("--vault-key <key>", "Vault key for decrypt operations (or set INKBOX_VAULT_KEY)")
   .option("--base-url <url>", "Override API base URL (or set INKBOX_BASE_URL)")

--- a/cli/tests/email-command.test.mjs
+++ b/cli/tests/email-command.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  contentTypeForPath,
+  parseInlineImageSpec,
+} from "../dist/commands/email.js";
+
+test("contentTypeForPath infers common image types", () => {
+  assert.equal(contentTypeForPath("chart.png"), "image/png");
+  assert.equal(contentTypeForPath("photo.JPG"), "image/jpeg");
+  assert.equal(contentTypeForPath("anim.gif"), "image/gif");
+  assert.equal(contentTypeForPath("doc.pdf"), "application/pdf");
+});
+
+test("contentTypeForPath falls back to octet-stream for unknown extensions", () => {
+  assert.equal(contentTypeForPath("mystery.xyz"), "application/octet-stream");
+  assert.equal(contentTypeForPath("noext"), "application/octet-stream");
+});
+
+test("parseInlineImageSpec splits cid=path", () => {
+  assert.deepEqual(parseInlineImageSpec("chart=./chart.png"), {
+    cid: "chart",
+    path: "./chart.png",
+  });
+});
+
+test("parseInlineImageSpec trims whitespace", () => {
+  assert.deepEqual(parseInlineImageSpec(" logo = /tmp/logo.png "), {
+    cid: "logo",
+    path: "/tmp/logo.png",
+  });
+});
+
+test("parseInlineImageSpec rejects malformed specs", () => {
+  assert.throws(() => parseInlineImageSpec("no-equals"));
+  assert.throws(() => parseInlineImageSpec("=/path/only"));
+  assert.throws(() => parseInlineImageSpec("cid-only="));
+});

--- a/cli/tests/version.test.mjs
+++ b/cli/tests/version.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { CLI_VERSION } from "../dist/client.js";
+
+test("CLI_VERSION matches package.json version (the User-Agent constant must not drift)", () => {
+  const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  assert.equal(CLI_VERSION, pkg.version);
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -219,6 +219,21 @@ identity.send_email(
     }],
 )
 
+# Inline images: set content_id on an image attachment and reference it from
+# body_html as cid:<content_id>. Requires body_html + an image/* content_type,
+# a unique id per send, and is not supported on forwards.
+identity.send_email(
+    to=["user@example.com"],
+    subject="Weekly report",
+    body_html='<p>Revenue:</p><img src="cid:chart">',
+    attachments=[{
+        "filename": "chart.png",
+        "content_type": "image/png",
+        "content_base64": "<base64-encoded-content>",
+        "content_id": "chart",
+    }],
+)
+
 # Track opens: embed a tracking pixel when an HTML body is present. Opens
 # surface on the returned Message as first_opened_at / open_count.
 tracked = identity.send_email(
@@ -245,8 +260,9 @@ for msg in identity.iter_emails(direction="inbound"):
 for msg in identity.iter_unread_emails():
     print(msg.subject)
 
-# Mark messages as read
+# Mark messages as read (or unread)
 identity.mark_emails_read([msg.id for msg in identity.iter_unread_emails()])
+identity.mark_emails_unread(["message-uuid"])
 
 # Get all emails in a thread (thread_id comes from msg.thread_id)
 thread = identity.get_thread(msg.thread_id)

--- a/sdk/python/inkbox/_http.py
+++ b/sdk/python/inkbox/_http.py
@@ -6,6 +6,7 @@ Sync HTTP transport (internal). Shared by all resource packages.
 
 from __future__ import annotations
 
+import importlib.metadata
 from typing import Any
 
 import httpx
@@ -21,6 +22,20 @@ from inkbox.exceptions import (
 _DEFAULT_TIMEOUT = 30.0
 
 
+def _sdk_version() -> str:
+    try:
+        return importlib.metadata.version("inkbox")
+    except importlib.metadata.PackageNotFoundError:
+        return "0.0.0"
+
+
+def sdk_user_agent(prefix: str | None = None) -> str:
+    """``User-Agent`` announcing the SDK (e.g. ``inkbox-python/0.4.17``); an
+    optional caller token goes first (``inkbox-cli/1.2.3 inkbox-python/...``)."""
+    base = f"inkbox-python/{_sdk_version()}"
+    return f"{prefix} {base}" if prefix else base
+
+
 class HttpTransport:
     def __init__(
         self,
@@ -28,13 +43,17 @@ class HttpTransport:
         base_url: str,
         timeout: float = _DEFAULT_TIMEOUT,
         cookie_jar: CookieJar | None = None,
+        user_agent: str | None = None,
     ) -> None:
+        headers = {
+            "X-API-Key": api_key,
+            "Accept": "application/json",
+        }
+        if user_agent:
+            headers["User-Agent"] = user_agent
         self._client = httpx.Client(
             base_url=base_url,
-            headers={
-                "X-API-Key": api_key,
-                "Accept": "application/json",
-            },
+            headers=headers,
             timeout=timeout,
         )
         self._cookie_jar = cookie_jar or CookieJar()

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -409,7 +409,9 @@ class AgentIdentity:
             bcc: Blind carbon-copy recipients.
             in_reply_to_message_id: RFC 5322 Message-ID to thread a reply.
             attachments: List of file attachment dicts with ``filename``,
-                ``content_type``, and ``content_base64`` keys.
+                ``content_type``, and ``content_base64`` keys. Add ``content_id``
+                to render an entry inline in the HTML body (``cid:<content_id>``);
+                requires ``body_html`` and an ``image/*`` ``content_type``.
             track_opens: Embed an open-tracking pixel when ``body_html`` is
                 present; opens surface as ``first_opened_at``/``open_count``.
         """
@@ -445,7 +447,9 @@ class AgentIdentity:
             body_text: Plain-text reply body.
             body_html: HTML reply body.
             attachments: List of file attachment dicts with ``filename``,
-                ``content_type``, and ``content_base64`` keys.
+                ``content_type``, and ``content_base64`` keys. Add ``content_id``
+                to render an entry inline in the HTML body (``cid:<content_id>``);
+                requires ``body_html`` and an ``image/*`` ``content_type``.
             reply_to: Optional Reply-To address.
         """
         self._require_mailbox()
@@ -570,6 +574,19 @@ class AgentIdentity:
         self._require_mailbox()
         for mid in message_ids:
             self._inkbox._messages.mark_read(
+                self._mailbox.email_address,  # type: ignore[union-attr]
+                mid,
+            )
+
+    def mark_emails_unread(self, message_ids: list[str]) -> None:
+        """Mark a list of messages as unread.
+
+        Args:
+            message_ids: IDs of the messages to mark as unread.
+        """
+        self._require_mailbox()
+        for mid in message_ids:
+            self._inkbox._messages.mark_unread(
                 self._mailbox.email_address,  # type: ignore[union-attr]
                 mid,
             )

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 import httpx
 
-from inkbox._http import HttpTransport
+from inkbox._http import HttpTransport, sdk_user_agent
 from inkbox._config import resolve_client_settings
 from inkbox._cookies import CookieJar
 from inkbox.agent_identity import AgentIdentity
@@ -116,6 +116,7 @@ class Inkbox:
         base_url: str | None = None,
         timeout: float = 30.0,
         vault_key: str | None = None,
+        user_agent_prefix: str | None = None,
     ) -> None:
         """
         Create an Inkbox client.
@@ -133,6 +134,9 @@ class Inkbox:
             vault_key: Optional vault key or recovery code.  When provided,
                 the vault is unlocked automatically at construction so
                 ``identity.credentials`` is immediately available.
+            user_agent_prefix: Optional token prepended to the ``User-Agent``
+                header (e.g. ``"inkbox-cli/1.2.3"``) so a downstream tool
+                identifies itself ahead of the SDK's own token.
         """
         api_key, base_url, vault_key = resolve_client_settings(
             api_key=api_key, base_url=base_url, vault_key=vault_key,
@@ -155,6 +159,7 @@ class Inkbox:
         _api_base = f"{base_url.rstrip('/')}/api"
         _api_root = f"{base_url.rstrip('/')}/api/v1"
         _cookie_jar = CookieJar()
+        _ua = sdk_user_agent(user_agent_prefix)
 
         # Held for the tunnel-agent runtime, which authenticates the
         # data-plane hello with the same key used for the control plane.
@@ -165,54 +170,63 @@ class Inkbox:
             base_url=f"{_api_root}/mail",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._contacts_http = HttpTransport(
             api_key=api_key,
             base_url=_api_root,
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._phone_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/phone",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._imessage_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/imessage",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._ids_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/identities",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._vault_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/vault",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._domains_http = HttpTransport(
             api_key=api_key,
             base_url=f"{_api_root}/domains",
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._root_api_http = HttpTransport(
             api_key=api_key,
             base_url=_api_base,
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
         self._api_http = HttpTransport(
             api_key=api_key,
             base_url=_api_root,
             timeout=timeout,
             cookie_jar=_cookie_jar,
+            user_agent=_ua,
         )
 
         self._mailboxes = MailboxesResource(self._mail_http)
@@ -551,7 +565,10 @@ class Inkbox:
         """One-shot HTTP request for agent-signup endpoints."""
         cls._validate_base_url(base_url)
         url = f"{base_url.rstrip('/')}/api/v1/agent-signup{path}"
-        headers: dict[str, str] = {"Accept": "application/json"}
+        headers: dict[str, str] = {
+            "Accept": "application/json",
+            "User-Agent": sdk_user_agent(),
+        }
         if api_key:
             headers["X-API-Key"] = api_key
 

--- a/sdk/python/inkbox/mail/resources/messages.py
+++ b/sdk/python/inkbox/mail/resources/messages.py
@@ -121,6 +121,10 @@ class MessagesResource:
                 ``filename`` (str), ``content_type`` (MIME type str), and
                 ``content_base64`` (base64-encoded file content str).
                 Max total size: 25 MB. Blocked extensions: ``.exe``, ``.bat``, ``.scr``.
+                Add ``content_id`` (str) to an entry to render it inline in the
+                HTML body (referenced as ``cid:<content_id>``, e.g.
+                ``<img src="cid:chart1">``) instead of as a download; requires
+                ``body_html``, an ``image/*`` ``content_type``, and a unique id.
             track_opens: Embed an open-tracking pixel in the HTML body.
                 Requires ``body_html``; a plain-text-only send with
                 ``track_opens`` is rejected with 422. Opens surface as
@@ -179,7 +183,7 @@ class MessagesResource:
             body_text: Plain-text reply body.
             body_html: HTML reply body.
             attachments: Optional file attachments. Same shape as
-                ``send(attachments=...)``.
+                ``send(attachments=...)``, including ``content_id`` for inline images.
             reply_to: Optional Reply-To address.
         """
         body: dict[str, Any] = {}
@@ -241,7 +245,8 @@ class MessagesResource:
                 ride alongside the forwarded content. Same shape as
                 ``send(attachments=...)``: each entry must have ``filename``,
                 ``content_type``, and ``content_base64`` keys. Subject to the
-                same blocked-extension and 25 MB limits as ``send``.
+                same blocked-extension and 25 MB limits as ``send``. Inline
+                images (``content_id``) are not supported on forwards (422).
             include_original_attachments: ``inline`` mode only — when ``True``
                 (default) the original attachments are re-attached as direct
                 outbound parts. Ignored in ``wrapped`` mode (originals live

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.16"
+version = "0.4.17"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_agent_identity.py
+++ b/sdk/python/tests/test_agent_identity.py
@@ -70,6 +70,23 @@ class TestAgentIdentityGetMessage:
             identity.get_message("bbbb2222-0000-0000-0000-000000000001")
 
 
+class TestAgentIdentityMarkEmailsUnread:
+    def test_mark_emails_unread_delegates_per_message(self):
+        identity, inkbox = _identity_with_mailbox()
+
+        identity.mark_emails_unread(["msg-1", "msg-2"])
+
+        assert inkbox._messages.mark_unread.call_count == 2
+        inkbox._messages.mark_unread.assert_any_call("sales-agent@inkbox.ai", "msg-1")
+        inkbox._messages.mark_unread.assert_any_call("sales-agent@inkbox.ai", "msg-2")
+
+    def test_mark_emails_unread_requires_mailbox(self):
+        identity, _ = _identity_without_mailbox()
+
+        with pytest.raises(InkboxError, match="has no mailbox"):
+            identity.mark_emails_unread(["msg-1"])
+
+
 class TestAgentIdentityForwardEmail:
     def test_forward_email_delegates_to_messages_resource(self):
         identity, inkbox = _identity_with_mailbox()

--- a/sdk/python/tests/test_agent_signup.py
+++ b/sdk/python/tests/test_agent_signup.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from inkbox import Inkbox
+from inkbox._http import sdk_user_agent
 from inkbox.agent_signup.types import (
     AgentSignupResponse,
     AgentSignupResendResponse,
@@ -87,7 +88,7 @@ class TestSignup:
         client.request.assert_called_once_with(
             "POST",
             "https://inkbox.ai/api/v1/agent-signup",
-            headers={"Accept": "application/json"},
+            headers={"Accept": "application/json", "User-Agent": sdk_user_agent()},
             json={
                 "human_email": "human@example.com",
                 "display_name": "My Agent",
@@ -116,7 +117,7 @@ class TestSignup:
         client.request.assert_called_once_with(
             "POST",
             "https://inkbox.ai/api/v1/agent-signup",
-            headers={"Accept": "application/json"},
+            headers={"Accept": "application/json", "User-Agent": sdk_user_agent()},
             json={
                 "human_email": "human@example.com",
                 "note_to_human": "Please approve me",
@@ -138,7 +139,7 @@ class TestSignup:
         client.request.assert_called_once_with(
             "POST",
             "https://inkbox.ai/api/v1/agent-signup",
-            headers={"Accept": "application/json"},
+            headers={"Accept": "application/json", "User-Agent": sdk_user_agent()},
             json={
                 "human_email": "human@example.com",
                 "note_to_human": "Please approve me",
@@ -174,6 +175,7 @@ class TestVerifySignup:
             "https://inkbox.ai/api/v1/agent-signup/verify",
             headers={
                 "Accept": "application/json",
+                "User-Agent": sdk_user_agent(),
                 "X-API-Key": "ApiKey_abc",
             },
             json={"verification_code": "123456"},
@@ -197,6 +199,7 @@ class TestResendSignupVerification:
             "https://inkbox.ai/api/v1/agent-signup/resend-verification",
             headers={
                 "Accept": "application/json",
+                "User-Agent": sdk_user_agent(),
                 "X-API-Key": "ApiKey_abc",
             },
             json=None,
@@ -220,6 +223,7 @@ class TestGetSignupStatus:
             "https://inkbox.ai/api/v1/agent-signup/status",
             headers={
                 "Accept": "application/json",
+                "User-Agent": sdk_user_agent(),
                 "X-API-Key": "ApiKey_abc",
             },
             json=None,

--- a/sdk/python/tests/test_mail_messages.py
+++ b/sdk/python/tests/test_mail_messages.py
@@ -106,6 +106,28 @@ class TestMessagesSend:
         assert body["in_reply_to_message_id"] == "<orig@mail.com>"
         assert body["attachments"] == [{"filename": "f.txt", "content_type": "text/plain", "content_base64": "aGk="}]
 
+    def test_send_passes_inline_content_id(self):
+        res, http = _resource()
+        http.post.return_value = MESSAGE_DICT
+
+        res.send(
+            MBOX,
+            to=["a@b.com"],
+            subject="Inline",
+            body_html='<img src="cid:chart">',
+            attachments=[
+                {
+                    "filename": "chart.png",
+                    "content_type": "image/png",
+                    "content_base64": "aGk=",
+                    "content_id": "chart",
+                }
+            ],
+        )
+
+        _, kwargs = http.post.call_args
+        assert kwargs["json"]["attachments"][0]["content_id"] == "chart"
+
     def test_optional_fields_omitted(self):
         res, http = _resource()
         http.post.return_value = MESSAGE_DICT

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -408,6 +408,15 @@ impl AgentIdentity {
         Ok(())
     }
 
+    /// Mark a list of messages as unread.
+    pub fn mark_emails_unread(&self, message_ids: &[String]) -> Result<()> {
+        let email = self.require_mailbox()?;
+        for mid in message_ids {
+            self.inkbox.messages().mark_unread(&email, mid)?;
+        }
+        Ok(())
+    }
+
     /// Get a single message with full body content.
     pub fn get_message(&self, message_id: &str) -> Result<MessageDetail> {
         let email = self.require_mailbox()?;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -54,12 +54,23 @@ use crate::whoami::types::{parse_whoami, WhoamiResponse};
 /// self-hosting or tests.
 pub const DEFAULT_BASE_URL: &str = "https://inkbox.ai";
 
+/// `User-Agent` announcing the SDK (e.g. `inkbox-rust/0.4.17`); an optional
+/// caller token goes first (`inkbox-cli/1.2.3 inkbox-rust/...`).
+fn sdk_user_agent(prefix: Option<&str>) -> String {
+    let base = concat!("inkbox-rust/", env!("CARGO_PKG_VERSION"));
+    match prefix {
+        Some(p) => format!("{p} {base}"),
+        None => base.to_string(),
+    }
+}
+
 /// Builder for [`Inkbox`], mirroring the Python `Inkbox(...)` keyword args.
 pub struct InkboxBuilder {
     api_key: String,
     base_url: String,
     timeout_secs: f64,
     vault_key: Option<String>,
+    user_agent_prefix: Option<String>,
 }
 
 impl InkboxBuilder {
@@ -83,6 +94,13 @@ impl InkboxBuilder {
         self
     }
 
+    /// Prepend a token to the `User-Agent` header (e.g. `"inkbox-cli/1.2.3"`)
+    /// so a downstream tool identifies itself ahead of the SDK's own token.
+    pub fn user_agent_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.user_agent_prefix = Some(prefix.into());
+        self
+    }
+
     /// Build the client.
     pub fn build(self) -> Result<Arc<Inkbox>> {
         Inkbox::build(
@@ -90,6 +108,7 @@ impl InkboxBuilder {
             self.base_url,
             self.timeout_secs,
             self.vault_key,
+            self.user_agent_prefix,
         )
     }
 }
@@ -164,6 +183,7 @@ impl Inkbox {
             base_url: DEFAULT_BASE_URL.to_string(),
             timeout_secs: default_timeout(),
             vault_key: None,
+            user_agent_prefix: None,
         }
     }
 
@@ -196,12 +216,14 @@ impl Inkbox {
         base_url: String,
         timeout: f64,
         vault_key: Option<String>,
+        user_agent_prefix: Option<String>,
     ) -> Result<Arc<Self>> {
         validate_base_url(&base_url)?;
         let trimmed = base_url.trim_end_matches('/');
         let api_base = format!("{trimmed}/api");
         let api_root = format!("{trimmed}/api/v1");
         let jar = Arc::new(CookieJar::new());
+        let user_agent = sdk_user_agent(user_agent_prefix.as_deref());
 
         // One transport per sub-base, mirroring client.py.
         let mk = |suffix: &str| -> Result<Arc<HttpTransport>> {
@@ -210,6 +232,7 @@ impl Inkbox {
                 suffix.to_string(),
                 timeout,
                 jar.clone(),
+                &user_agent,
             )?))
         };
         let mail_http = mk(&format!("{api_root}/mail"))?;
@@ -627,6 +650,7 @@ fn signup_request(
         .timeout(std::time::Duration::from_secs_f64(
             timeout_secs.unwrap_or(default_timeout()),
         ))
+        .user_agent(sdk_user_agent(None))
         .build()?;
     let m = reqwest::Method::from_bytes(method.as_bytes())
         .map_err(|_| InkboxError::InvalidArgument(format!("bad method {method}")))?;

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -1,8 +1,8 @@
 //! Blocking HTTP transport (internal). Shared by all resource modules.
 //!
 //! A faithful port of `inkbox/_http.py`'s `HttpTransport`: one transport per
-//! API sub-base, a shared [`CookieJar`], `X-API-Key` + `Accept` defaults, and
-//! the structured `_raise_for_status` error mapping. Built on
+//! API sub-base, a shared [`CookieJar`], `X-API-Key` + `Accept` + `User-Agent`
+//! defaults, and the structured `_raise_for_status` error mapping. Built on
 //! `reqwest::blocking` so the public SDK surface stays synchronous like the
 //! Python and TypeScript SDKs.
 
@@ -39,6 +39,7 @@ impl HttpTransport {
         base_url: impl Into<String>,
         timeout_secs: f64,
         cookie_jar: Arc<CookieJar>,
+        user_agent: &str,
     ) -> Result<Self> {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
@@ -49,6 +50,11 @@ impl HttpTransport {
         headers.insert(
             reqwest::header::ACCEPT,
             reqwest::header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            reqwest::header::HeaderValue::from_str(user_agent)
+                .map_err(|_| InkboxError::InvalidArgument("invalid user_agent bytes".into()))?,
         );
         let client = Client::builder()
             .default_headers(headers)

--- a/sdk/rust/src/mail/resources/messages.rs
+++ b/sdk/rust/src/mail/resources/messages.rs
@@ -14,11 +14,18 @@ const DEFAULT_PAGE_SIZE: i64 = 50;
 ///
 /// Mirrors the Python `dict` shape: each entry must carry `filename`,
 /// `content_type` (MIME type), and `content_base64` (base64-encoded content).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// Set `content_id` to render the part inline in the HTML body (referenced as
+/// `cid:<content_id>`, e.g. `<img src="cid:chart1">`) instead of as a download.
+/// Inline parts require `body_html`, an `image/*` `content_type`, and a unique
+/// id per send; they are only honored on `send`/`reply_all` (forwards 422).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct Attachment {
     pub filename: String,
     pub content_type: String,
     pub content_base64: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_id: Option<String>,
 }
 
 pub struct MessagesResource {
@@ -120,7 +127,8 @@ impl MessagesResource {
     /// * `in_reply_to_message_id` - RFC 5322 Message-ID of the message being
     ///   replied to. Threads the reply automatically.
     /// * `attachments` - Optional file attachments. Max total size: 25 MB.
-    ///   Blocked extensions: `.exe`, `.bat`, `.scr`.
+    ///   Blocked extensions: `.exe`, `.bat`, `.scr`. Set `content_id` on an
+    ///   entry to render it inline in the HTML body (see [`Attachment`]).
     /// * `track_opens` - Embed an open-tracking pixel in the HTML body. Requires
     ///   `body_html`; a plain-text-only send with `track_opens` is rejected 422
     ///   server-side. Opens surface as `first_opened_at` / `open_count`; prefer
@@ -198,7 +206,8 @@ impl MessagesResource {
     /// * `subject` - Optional override; defaults server-side to
     ///   `"Re: " + original.subject`.
     /// * `body_text` / `body_html` - Optional reply body.
-    /// * `attachments` - Optional file attachments. Same shape as `send`.
+    /// * `attachments` - Optional file attachments. Same shape as `send`,
+    ///   including `content_id` for inline images.
     /// * `reply_to` - Optional Reply-To address.
     ///
     /// # Returns
@@ -255,7 +264,8 @@ impl MessagesResource {
     ///   `"Fwd: " + original.subject`.
     /// * `body_text` / `body_html` - Optional caller note.
     /// * `additional_attachments` - Optional caller-authored attachments. Same
-    ///   shape and limits as `send`.
+    ///   shape and limits as `send`, but inline images (`content_id`) are not
+    ///   supported on forwards (422).
     /// * `include_original_attachments` - `inline` mode only: re-attach the
     ///   original attachments. Ignored in `wrapped` mode.
     /// * `reply_to` - Optional Reply-To address for the outer envelope.
@@ -421,5 +431,34 @@ fn d_str(d: MessageDirection) -> &'static str {
     match d {
         MessageDirection::Inbound => "inbound",
         MessageDirection::Outbound => "outbound",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Attachment;
+
+    #[test]
+    fn content_id_omitted_when_none() {
+        let att = Attachment {
+            filename: "doc.pdf".into(),
+            content_type: "application/pdf".into(),
+            content_base64: "aGk=".into(),
+            content_id: None,
+        };
+        let v = serde_json::to_value(&att).unwrap();
+        assert!(v.get("content_id").is_none());
+    }
+
+    #[test]
+    fn content_id_serialized_when_set() {
+        let att = Attachment {
+            filename: "chart.png".into(),
+            content_type: "image/png".into(),
+            content_base64: "aGk=".into(),
+            content_id: Some("chart".into()),
+        };
+        let v = serde_json::to_value(&att).unwrap();
+        assert_eq!(v["content_id"], "chart");
     }
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -226,6 +226,21 @@ await identity.sendEmail({
   }],
 });
 
+// Inline images: set contentId on an image attachment and reference it from
+// bodyHtml as cid:<contentId>. Requires bodyHtml + an image/* contentType, a
+// unique id per send, and is not supported on forwards.
+await identity.sendEmail({
+  to: ["user@example.com"],
+  subject: "Weekly report",
+  bodyHtml: '<p>Revenue:</p><img src="cid:chart">',
+  attachments: [{
+    filename: "chart.png",
+    contentType: "image/png",
+    contentBase64: "<base64-encoded-content>",
+    contentId: "chart",
+  }],
+});
+
 // Track opens: embed a tracking pixel when an HTML body is present. Opens
 // surface on the returned Message as firstOpenedAt / openCount.
 const tracked = await identity.sendEmail({
@@ -255,10 +270,11 @@ for await (const msg of identity.iterUnreadEmails()) {
   console.log(msg.subject);
 }
 
-// Mark messages as read
+// Mark messages as read (or unread)
 const unread: string[] = [];
 for await (const msg of identity.iterUnreadEmails()) unread.push(msg.id);
 await identity.markEmailsRead(unread);
+await identity.markEmailsUnread(["message-uuid"]);
 
 // Get all emails in a thread (threadId comes from msg.threadId)
 const thread = await identity.getThread(msg.threadId!);

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/_http.ts
+++ b/sdk/typescript/src/_http.ts
@@ -240,17 +240,20 @@ export class HttpTransport {
   private readonly baseUrl: string;
   private readonly timeoutMs: number;
   private readonly cookieJar: CookieJar;
+  private readonly userAgent?: string;
 
   constructor(
     apiKey: string,
     baseUrl: string,
     timeoutMs: number = 30_000,
     cookieJar?: CookieJar,
+    userAgent?: string,
   ) {
     this.apiKey = apiKey;
     this.baseUrl = baseUrl;
     this.timeoutMs = timeoutMs;
     this.cookieJar = cookieJar ?? new CookieJar();
+    this.userAgent = userAgent;
   }
 
   async get<T>(path: string, params?: Params, opts?: { timeoutMs?: number }): Promise<T> {
@@ -366,6 +369,9 @@ export class HttpTransport {
       "X-API-Key": this.apiKey,
       Accept: opts.accept ?? "application/json",
     };
+    if (this.userAgent) {
+      headers["User-Agent"] = this.userAgent;
+    }
     const cookieHeader = this.cookieJar.getHeaderValue(url);
     if (cookieHeader) {
       headers.Cookie = cookieHeader;

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -341,7 +341,8 @@ export class AgentIdentity {
     cc?: string[];
     bcc?: string[];
     inReplyToMessageId?: string;
-    attachments?: Array<{ filename: string; contentType: string; contentBase64: string }>;
+    /** `contentId` on an entry renders it inline in the HTML body (`cid:<contentId>`); requires `bodyHtml` + `image/*`. */
+    attachments?: Array<{ filename: string; contentType: string; contentBase64: string; contentId?: string }>;
     /** Embed an open-tracking pixel when `bodyHtml` is present; opens surface as `firstOpenedAt`/`openCount`. */
     trackOpens?: boolean;
   }): Promise<Message> {
@@ -365,7 +366,8 @@ export class AgentIdentity {
       subject?: string;
       bodyText?: string;
       bodyHtml?: string;
-      attachments?: Array<{ filename: string; contentType: string; contentBase64: string }>;
+      /** `contentId` on an entry renders it inline in the HTML body (`cid:<contentId>`); requires `bodyHtml` + `image/*`. */
+      attachments?: Array<{ filename: string; contentType: string; contentBase64: string; contentId?: string }>;
       replyTo?: string;
     } = {},
   ): Promise<Message> {
@@ -463,6 +465,18 @@ export class AgentIdentity {
     this._requireMailbox();
     for (const id of messageIds) {
       await this._inkbox._messages.markRead(this._mailbox!.emailAddress, id);
+    }
+  }
+
+  /**
+   * Mark a list of messages as unread.
+   *
+   * @param messageIds - IDs of the messages to mark as unread.
+   */
+  async markEmailsUnread(messageIds: string[]): Promise<void> {
+    this._requireMailbox();
+    for (const id of messageIds) {
+      await this._inkbox._messages.markUnread(this._mailbox!.emailAddress, id);
     }
   }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,5 @@
 export { Inkbox } from "./inkbox.js";
+export { VERSION } from "./version.js";
 export { AgentIdentity } from "./agent_identity.js";
 export { Credentials } from "./credentials.js";
 export type { InkboxOptions, SignupOptions } from "./inkbox.js";

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -5,6 +5,7 @@
  */
 
 import { CookieJar, HttpTransport, InkboxAPIError } from "./_http.js";
+import { VERSION } from "./version.js";
 import { resolveClientSettings } from "./_config.js";
 import type { RawWhoamiResponse, WhoamiResponse } from "./whoami/types.js";
 import { parseWhoamiResponse } from "./whoami/types.js";
@@ -62,6 +63,15 @@ import {
 
 const DEFAULT_BASE_URL = "https://inkbox.ai";
 
+/**
+ * `User-Agent` announcing the SDK (e.g. `inkbox-typescript/0.4.17`); an
+ * optional caller token goes first (`inkbox-cli/1.2.3 inkbox-typescript/...`).
+ */
+function sdkUserAgent(prefix?: string): string {
+  const base = `inkbox-typescript/${VERSION}`;
+  return prefix ? `${prefix} ${base}` : base;
+}
+
 export interface SignupOptions {
   /** Override the API base URL (useful for self-hosting or testing). */
   baseUrl?: string;
@@ -85,6 +95,12 @@ export interface InkboxOptions {
    * is immediately available.
    */
   vaultKey?: string;
+  /**
+   * Optional token prepended to the `User-Agent` header (e.g.
+   * `"inkbox-cli/1.2.3"`) so a downstream tool identifies itself ahead of
+   * the SDK's own token.
+   */
+  userAgentPrefix?: string;
 }
 
 /**
@@ -186,16 +202,17 @@ export class Inkbox {
     }
     const apiRoot = `${baseUrl.replace(/\/$/, "")}/api/v1`;
     const ms = options.timeoutMs ?? 30_000;
+    const userAgent = sdkUserAgent(options.userAgentPrefix);
     const cookieJar = new CookieJar();
 
-    const mailHttp     = new HttpTransport(apiKey, `${apiRoot}/mail`, ms, cookieJar);
-    const phoneHttp    = new HttpTransport(apiKey, `${apiRoot}/phone`, ms, cookieJar);
-    const imessageHttp = new HttpTransport(apiKey, `${apiRoot}/imessage`, ms, cookieJar);
-    const idsHttp      = new HttpTransport(apiKey, `${apiRoot}/identities`, ms, cookieJar);
-    const vaultHttp    = new HttpTransport(apiKey, `${apiRoot}/vault`, ms, cookieJar);
-    const domainsHttp  = new HttpTransport(apiKey, `${apiRoot}/domains`, ms, cookieJar);
-    const rootApiHttp  = new HttpTransport(apiKey, `${baseUrl.replace(/\/$/, "")}/api`, ms, cookieJar);
-    const apiHttp      = new HttpTransport(apiKey, apiRoot, ms, cookieJar);
+    const mailHttp     = new HttpTransport(apiKey, `${apiRoot}/mail`, ms, cookieJar, userAgent);
+    const phoneHttp    = new HttpTransport(apiKey, `${apiRoot}/phone`, ms, cookieJar, userAgent);
+    const imessageHttp = new HttpTransport(apiKey, `${apiRoot}/imessage`, ms, cookieJar, userAgent);
+    const idsHttp      = new HttpTransport(apiKey, `${apiRoot}/identities`, ms, cookieJar, userAgent);
+    const vaultHttp    = new HttpTransport(apiKey, `${apiRoot}/vault`, ms, cookieJar, userAgent);
+    const domainsHttp  = new HttpTransport(apiKey, `${apiRoot}/domains`, ms, cookieJar, userAgent);
+    const rootApiHttp  = new HttpTransport(apiKey, `${baseUrl.replace(/\/$/, "")}/api`, ms, cookieJar, userAgent);
+    const apiHttp      = new HttpTransport(apiKey, apiRoot, ms, cookieJar, userAgent);
 
     this._mailboxes        = new MailboxesResource(mailHttp);
     this._messages         = new MessagesResource(mailHttp);
@@ -491,7 +508,10 @@ export class Inkbox {
     const url = `${base.replace(/\/$/, "")}/api/v1/agent-signup${path}`;
     const ms = opts.timeoutMs ?? 30_000;
 
-    const headers: Record<string, string> = { Accept: "application/json" };
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "User-Agent": sdkUserAgent(),
+    };
     if (opts.apiKey) headers["X-API-Key"] = opts.apiKey;
 
     let bodyStr: string | undefined;

--- a/sdk/typescript/src/mail/resources/messages.ts
+++ b/sdk/typescript/src/mail/resources/messages.ts
@@ -88,7 +88,9 @@ export class MessagesResource {
    *   replied to. Threads the reply automatically.
    * @param options.attachments - Optional file attachments. Each entry must have
    *   `filename`, `contentType` (MIME type), and `contentBase64` (base64-encoded
-   *   file content). Max total size: 25 MB. Blocked: `.exe`, `.bat`, `.scr`.
+   *   file content). Max total size: 25 MB. Blocked: `.exe`, `.bat`, `.scr`. Set
+   *   `contentId` on an entry to render it inline in the HTML body instead of as
+   *   a download (see the field doc).
    * @param options.trackOpens - Embed an open-tracking pixel in the HTML body.
    *   Requires `bodyHtml`; a plain-text-only send with `trackOpens` is rejected
    *   with 422. Opens surface as `firstOpenedAt`/`openCount`; `openCount` is
@@ -109,6 +111,13 @@ export class MessagesResource {
         filename: string;
         contentType: string;
         contentBase64: string;
+        /**
+         * Render this part inline in the HTML body (referenced as
+         * `cid:<contentId>`, e.g. `<img src="cid:chart1">`) instead of as a
+         * download. Requires `bodyHtml`, an `image/*` `contentType`, and a
+         * unique id per send.
+         */
+        contentId?: string;
       }>;
       trackOpens?: boolean;
     },
@@ -127,11 +136,15 @@ export class MessagesResource {
       body["in_reply_to_message_id"] = options.inReplyToMessageId;
     }
     if (options.attachments !== undefined) {
-      body["attachments"] = options.attachments.map((a) => ({
-        filename: a.filename,
-        content_type: a.contentType,
-        content_base64: a.contentBase64,
-      }));
+      body["attachments"] = options.attachments.map((a) => {
+        const att: Record<string, unknown> = {
+          filename: a.filename,
+          content_type: a.contentType,
+          content_base64: a.contentBase64,
+        };
+        if (a.contentId !== undefined) att["content_id"] = a.contentId;
+        return att;
+      });
     }
     if (options.trackOpens) body["track_opens"] = true;
 
@@ -153,7 +166,7 @@ export class MessagesResource {
    * @param options.bodyText - Plain-text reply body.
    * @param options.bodyHtml - HTML reply body.
    * @param options.attachments - Optional file attachments. Same shape as
-   *   `send({ attachments })`.
+   *   `send({ attachments })`, including `contentId` for inline images.
    * @param options.replyTo - Optional Reply-To address.
    */
   async replyAll(
@@ -167,6 +180,8 @@ export class MessagesResource {
         filename: string;
         contentType: string;
         contentBase64: string;
+        /** Render inline in the HTML body (`cid:<contentId>`); requires `bodyHtml`, `image/*`, unique per reply. */
+        contentId?: string;
       }>;
       replyTo?: string;
     } = {},
@@ -176,11 +191,15 @@ export class MessagesResource {
     if (options.bodyText !== undefined) body["body_text"] = options.bodyText;
     if (options.bodyHtml !== undefined) body["body_html"] = options.bodyHtml;
     if (options.attachments !== undefined) {
-      body["attachments"] = options.attachments.map((a) => ({
-        filename: a.filename,
-        content_type: a.contentType,
-        content_base64: a.contentBase64,
-      }));
+      body["attachments"] = options.attachments.map((a) => {
+        const att: Record<string, unknown> = {
+          filename: a.filename,
+          content_type: a.contentType,
+          content_base64: a.contentBase64,
+        };
+        if (a.contentId !== undefined) att["content_id"] = a.contentId;
+        return att;
+      });
     }
     if (options.replyTo !== undefined) body["reply_to"] = options.replyTo;
 

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,0 +1,2 @@
+// Keep in sync with package.json "version".
+export const VERSION = "0.4.17";

--- a/sdk/typescript/tests/agent_identity.test.ts
+++ b/sdk/typescript/tests/agent_identity.test.ts
@@ -61,6 +61,7 @@ function mockInkbox() {
       forward: vi.fn(),
       list: vi.fn(),
       markRead: vi.fn(),
+      markUnread: vi.fn(),
       get: vi.fn(),
     },
     _threads: { get: vi.fn() },
@@ -222,6 +223,23 @@ describe("AgentIdentity mail helpers", () => {
   it("markEmailsRead throws when no mailbox", async () => {
     const identity = new AgentIdentity(makeData({ mailbox: null }), mockInkbox());
     await expect(identity.markEmailsRead(["msg-1"])).rejects.toThrow(InkboxError);
+  });
+
+  it("markEmailsUnread marks each message", async () => {
+    const ink = mockInkbox();
+    vi.mocked(ink._messages.markUnread).mockResolvedValue(undefined);
+    const identity = new AgentIdentity(makeData(), ink);
+
+    await identity.markEmailsUnread(["msg-1", "msg-2"]);
+
+    expect(ink._messages.markUnread).toHaveBeenCalledTimes(2);
+    expect(ink._messages.markUnread).toHaveBeenCalledWith(PARSED_MAILBOX.emailAddress, "msg-1");
+    expect(ink._messages.markUnread).toHaveBeenCalledWith(PARSED_MAILBOX.emailAddress, "msg-2");
+  });
+
+  it("markEmailsUnread throws when no mailbox", async () => {
+    const identity = new AgentIdentity(makeData({ mailbox: null }), mockInkbox());
+    await expect(identity.markEmailsUnread(["msg-1"])).rejects.toThrow(InkboxError);
   });
 
   it("getMessage delegates to messages resource", async () => {

--- a/sdk/typescript/tests/mail/messages.test.ts
+++ b/sdk/typescript/tests/mail/messages.test.ts
@@ -160,6 +160,28 @@ describe("MessagesResource.send", () => {
     const [, body] = vi.mocked(http.post).mock.calls[0] as [string, Record<string, unknown>];
     expect(body["track_opens"]).toBeUndefined();
   });
+
+  it("serializes content_id only on inline-image attachments", async () => {
+    const http = mockHttp();
+    vi.mocked(http.post).mockResolvedValue(RAW_MESSAGE);
+    const res = new MessagesResource(http);
+
+    await res.send(ADDR, {
+      to: ["a@example.com"],
+      subject: "Inline",
+      bodyHtml: '<img src="cid:chart">',
+      attachments: [
+        { filename: "chart.png", contentType: "image/png", contentBase64: "aGk=", contentId: "chart" },
+        { filename: "doc.pdf", contentType: "application/pdf", contentBase64: "cGRm" },
+      ],
+    });
+
+    const [, body] = vi.mocked(http.post).mock.calls[0] as [string, Record<string, unknown>];
+    expect(body["attachments"]).toEqual([
+      { filename: "chart.png", content_type: "image/png", content_base64: "aGk=", content_id: "chart" },
+      { filename: "doc.pdf", content_type: "application/pdf", content_base64: "cGRm" },
+    ]);
+  });
 });
 
 describe("MessagesResource.replyAll", () => {

--- a/sdk/typescript/tests/version.test.ts
+++ b/sdk/typescript/tests/version.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { VERSION } from "../src/version.js";
+
+describe("VERSION", () => {
+  it("matches package.json version (the User-Agent constant must not drift)", () => {
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
+});

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -205,22 +205,28 @@ All email commands are identity-scoped and require `-i <handle>`.
 inkbox email send -i <handle> \
   --to user@example.com \
   --subject "Hello" \
-  --body-html "<p>Hi</p>" \
+  --body-html '<p>Hi</p><img src="cid:chart">' \
+  --attach ./report.pdf \        # optional; repeatable file attachment
+  --inline-image chart=./chart.png \  # optional, repeatable; embeds <img src="cid:chart"> (needs --body-html, image/*)
   --track-opens                 # optional; embed a tracking pixel (needs --body-html)
 
-inkbox email forward <message-id> -i <handle> --to user@example.com --track-opens
+inkbox email reply-all <message-id> -i <handle> --body-html "<p>Thanks</p>" --attach ./notes.txt
+inkbox email forward <message-id> -i <handle> --to user@example.com --attach ./extra.pdf --track-opens
 
 inkbox email list -i <handle> --limit 10
 inkbox email get <message-id> -i <handle>   # fetching an inbound message marks it read
 inkbox email search -i <handle> -q "invoice"
 inkbox email unread -i <handle> --limit 10
 inkbox email mark-read <ids...> -i <handle>
+inkbox email mark-unread <ids...> -i <handle>
+inkbox email download-attachment <message-id> <filename> -i <handle>   # time-limited download URL
 inkbox email delete <message-id> -i <handle>
 inkbox email delete-thread <thread-id> -i <handle>
 inkbox email star <message-id> -i <handle>
 inkbox email unstar <message-id> -i <handle>
 inkbox email thread <thread-id> -i <handle>
 ```
+(`--inline-image` is send/reply-all only — forwards reject inline images.)
 
 Use `email search` only when the identity already has a mailbox assigned.
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -138,6 +138,11 @@ sent = identity.send_email(
         "filename": "report.pdf",
         "content_type": "application/pdf",
         "content_base64": "<base64>",
+    }, {
+        "filename": "chart.png",        # inline image: set content_id and
+        "content_type": "image/png",    # reference it from body_html as
+        "content_base64": "<base64>",   # <img src="cid:chart">. needs body_html
+        "content_id": "chart",          # + image/*, unique per send; not on forwards.
     }],
     track_opens=True,               # optional; embed a tracking pixel
 )
@@ -166,6 +171,7 @@ for msg in identity.iter_unread_emails():
 # Mark as read
 ids = [msg.id for msg in identity.iter_unread_emails()]
 identity.mark_emails_read(ids)
+identity.mark_emails_unread(ids)   # batch counterpart
 # Note: fetching a single inbound message by id (inkbox.messages.get) with
 # an API key marks it read server-side; iterating does not, so
 # mark_emails_read is the way to clear unread for list-only workflows.

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -137,6 +137,11 @@ const sent = await identity.sendEmail({
     filename: "report.pdf",
     contentType: "application/pdf",
     contentBase64: "<base64>",
+  }, {
+    filename: "chart.png",         // inline image: set contentId and reference
+    contentType: "image/png",      // it from bodyHtml as <img src="cid:chart">.
+    contentBase64: "<base64>",      // needs bodyHtml + image/*, unique per send;
+    contentId: "chart",            // not on forwards. Not counted in hasAttachments.
   }],
   trackOpens: true,                // optional; embed a tracking pixel
 });
@@ -167,6 +172,7 @@ for await (const msg of identity.iterUnreadEmails()) {
 const ids: string[] = [];
 for await (const msg of identity.iterUnreadEmails()) ids.push(msg.id);
 await identity.markEmailsRead(ids);
+await identity.markEmailsUnread(ids);   // batch counterpart
 // Note: fetching a single inbound message by id (inkbox.messages.get) with
 // an API key marks it read server-side; iterating does not, so
 // markEmailsRead is the way to clear unread for list-only workflows. isRead


### PR DESCRIPTION
Adds inline-image support and closes a few SDK/CLI parity gaps. Bumps all four packages to `0.4.17`.

- `messages.send`/`reply_all` (and identity `send_email`/`reply_all_email`) attachments accept `content_id` (TS `contentId`, Rust `Attachment.content_id`) to render an image inline in the HTML body via `cid:<content_id>`. Requires `body_html`, an `image/*` content type, and a unique id per send. Not supported on forwards.
- Adds `mark_emails_unread` (TS `markEmailsUnread`) to the identity across the TypeScript, Python, and Rust SDKs, the batch counterpart to `mark_emails_read`.
- CLI gains `--attach` on `email send`/`reply-all`/`forward` and `--inline-image <cid=path>` on `send`/`reply-all`, plus `email mark-unread` and `email download-attachment` commands.
- Tests, READMEs, skills, and the changelog updated.
