### PR TITLE
`0.4.18`: feat(tunnels); stop and don't reconnect when another client takes over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 
 ### Changed
 
-- **A tunnel keeps a single live client; a newer client takes over.** When another client connects to the same tunnel, the earlier client now stops and does **not** reconnect — previously it would redial, and two clients on one tunnel could bounce back and forth. Run one client per tunnel; for redundancy, use separate identities. The runtime reports a new `"superseded"` status through the status callback (`onStatus` / `on_status`) and ends with a distinct terminal outcome instead of retrying: TypeScript throws `TunnelSupersededError`, Python stops out of `serve()` / `wait()`, and Rust returns a terminal `Err` from `serve_forever`. A normal server redeploy still reconnects seamlessly, unchanged.
+- **A tunnel keeps a single live client; a newer client takes over.** When another client connects to the same tunnel, the earlier client now stops and does **not** reconnect; previously it would redial, and two clients on one tunnel could bounce back and forth. Run one client per tunnel; for redundancy, use separate identities. The runtime reports a new `"superseded"` status through the status callback (`onStatus` / `on_status`) and ends with a distinct terminal outcome instead of retrying: TypeScript throws `TunnelSupersededError`, Python raises `TunnelSupersededError` out of `serve()` / `wait()`, and Rust returns a terminal `Err` from `serve_forever`. A normal server redeploy still reconnects seamlessly, unchanged.
 
 ### Added
 
-- **`TunnelSupersededError`** (TypeScript) exported from the tunnels client alongside `TunnelAuthError`, thrown when another client takes over the tunnel — so an embedding app can notice, e.g., that an accidental second instance on the same identity went dark.
+- **`TunnelSupersededError`** is now a public, catchable error in both Python and TypeScript (raised out of `serve()` / `wait()` in Python, thrown in TypeScript); in Rust the terminal takeover is detectable via `InkboxError::is_tunnel_superseded()`. Catch it to notice a takeover, for example an accidental second instance on the same identity going dark, and react.
 
 ## 0.4.17 — Inline images, CLI attachments, and mark-unread
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.4.18 — One live client per tunnel
+
+### Changed
+
+- **A tunnel keeps a single live client; a newer client takes over.** When another client connects to the same tunnel, the earlier client now stops and does **not** reconnect — previously it would redial, and two clients on one tunnel could bounce back and forth. Run one client per tunnel; for redundancy, use separate identities. The runtime reports a new `"superseded"` status through the status callback (`onStatus` / `on_status`) and ends with a distinct terminal outcome instead of retrying: TypeScript throws `TunnelSupersededError`, Python stops out of `serve()` / `wait()`, and Rust returns a terminal `Err` from `serve_forever`. A normal server redeploy still reconnects seamlessly, unchanged.
+
+### Added
+
+- **`TunnelSupersededError`** (TypeScript) exported from the tunnels client alongside `TunnelAuthError`, thrown when another client takes over the tunnel — so an embedding app can notice, e.g., that an accidental second instance on the same identity went dark.
+
 ## 0.4.17 — Inline images, CLI attachments, and mark-unread
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.4.17",
+        "@inkbox/sdk": "^0.4.18",
         "commander": "^13.0.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.17",
+    "@inkbox/sdk": "^0.4.18",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -180,6 +180,7 @@ from inkbox.tunnels.exceptions import (
     TunnelNotProvisioned,
     TunnelRemoved,
     TunnelStateConflict,
+    TunnelSupersededError,
     TunnelTLSModeMismatch,
 )
 from inkbox.tunnels._validation import (
@@ -416,6 +417,7 @@ __all__ = [
     "TunnelNotProvisioned",
     "TunnelRemoved",
     "TunnelStateConflict",
+    "TunnelSupersededError",
     "TunnelTLSModeMismatch",
     "normalize_agent_handle",
     "validate_agent_handle",

--- a/sdk/python/inkbox/tunnels/__init__.py
+++ b/sdk/python/inkbox/tunnels/__init__.py
@@ -15,6 +15,7 @@ from inkbox.tunnels.exceptions import (
     TunnelNotProvisioned,
     TunnelRemoved,
     TunnelStateConflict,
+    TunnelSupersededError,
     TunnelTLSModeMismatch,
 )
 from inkbox.tunnels._validation import (
@@ -36,6 +37,7 @@ __all__ = [
     "TunnelNotProvisioned",
     "TunnelRemoved",
     "TunnelStateConflict",
+    "TunnelSupersededError",
     "TunnelTLSModeMismatch",
     "normalize_agent_handle",
     "validate_agent_handle",

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -495,8 +495,8 @@ class TunnelRuntime:
                 )
                 self._notify_status("closed")
                 raise
-            except _TunnelSupersededError:
-                self._stop_superseded()
+            except _TunnelSupersededError as e:
+                self._stop_superseded(e)
             except Exception:
                 # A takeover GOAWAY that lands mid-hello sets _superseded but
                 # surfaces as a plain connection error; go terminal here so we
@@ -799,8 +799,12 @@ class TunnelRuntime:
             return
         self._mark_superseded()
 
-    def _stop_superseded(self) -> NoReturn:
-        """Log, notify, and raise the terminal takeover error (no reconnect)."""
+    def _stop_superseded(self, err: TunnelSupersededError | None = None) -> NoReturn:
+        """Log, notify, and raise the terminal takeover error (no reconnect).
+
+        Re-raises the original error when given, so its message (which
+        channel/slot observed the takeover) survives to the caller.
+        """
         logger.warning(
             "tunnel taken over: another client connected to this tunnel, so "
             "this client is stopping and will not reconnect. If this is "
@@ -808,6 +812,8 @@ class TunnelRuntime:
             "(only one live connection per tunnel is kept).",
         )
         self._notify_status("superseded")
+        if err is not None:
+            raise err
         raise _TunnelSupersededError(
             "another client connected to this tunnel; not reconnecting",
         )

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -760,15 +760,11 @@ class TunnelRuntime:
     def _superseded_is_terminal(self, conn: _Connection) -> bool:
         """True iff a takeover signal on ``conn`` should stop the runtime.
 
-        Ignored on a draining / handoff / non-active connection: that is this
-        client's own make-before-break predecessor being replaced during a
-        reconnect, not an external client taking the tunnel over.
+        Ignored only for a conn we ourselves put into make-before-break drain
+        (our own predecessor, tracked in ``self._draining``). A not-yet-active
+        replacement mid-handoff is a real external takeover, so it stays terminal.
         """
-        return (
-            conn is self._active
-            and not conn.draining
-            and not self._handoff_in_flight
-        )
+        return conn not in self._draining
 
     def _mark_superseded(self) -> None:
         """Record the takeover; serve_forever will stop and not reconnect."""
@@ -795,7 +791,7 @@ class TunnelRuntime:
                 )
             return
         if not self._superseded_is_terminal(conn):
-            logger.info("takeover signal on a draining/handoff connection; ignoring")
+            logger.info("takeover signal on our own draining predecessor; ignoring")
             return
         self._mark_superseded()
 
@@ -1101,9 +1097,9 @@ class TunnelRuntime:
                 slot, status, reason, body_bytes,
             )
             # Another client took over this tunnel. Terminal, unless this is
-            # our own draining/handoff predecessor (a normal reconnect), where
-            # it is ignored. A drain uses a different reason and falls through
-            # to re-park below.
+            # our own draining predecessor (a normal reconnect), where it is
+            # ignored. A drain uses a different reason and falls through to
+            # re-park below.
             if reason == INTAKE_REASON_SUPERSEDED:
                 if self._superseded_is_terminal(conn):
                     raise _TunnelSupersededError(

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -120,9 +120,22 @@ WS_CLOSE_AGENT_TIMEOUT = 4504
 DEFAULT_INBOUND_BODY_BYTES = 32 * 1024 * 1024
 DEFAULT_OUTBOUND_BODY_BYTES = 32 * 1024 * 1024
 
+# Signals that another client connected to this tunnel and took over: this
+# client must stop and not reconnect. Delivered as a dedicated GOAWAY error
+# code (the reliable channel) plus matching reason strings on the GOAWAY debug
+# data and the intake / hello responses. Must stay in lockstep with the server.
+SUPERSEDED_GOAWAY_ERROR_CODE = 0x1201
+GOAWAY_REASON_SUPERSEDED = "superseded"
+INTAKE_REASON_SUPERSEDED = "intake-superseded"
+HELLO_REASON_SUPERSEDED = "hello-superseded"
+
 
 class _TunnelAuthError(RuntimeError):
     """Permanent auth failure from /_system/hello; do not retry."""
+
+
+class _TunnelSupersededError(RuntimeError):
+    """Another client connected to this tunnel and took over; stop, don't reconnect."""
 
 
 class _OwnerTokenInvalidError(RuntimeError):
@@ -188,6 +201,7 @@ class _Connection:
         "outstanding_ping_payload",
         "outstanding_ping_sent_at",
         "goaway_received",
+        "superseded",
     )
 
     def __init__(self, conn_id: int) -> None:
@@ -214,6 +228,8 @@ class _Connection:
         # Set once a GOAWAY (ConnectionTerminated) lands; the read loop
         # winds down because hyper-h2 is now CLOSED.
         self.goaway_received = False
+        # Set when this connection was taken over by another client.
+        self.superseded = False
 
     @property
     def live_bridges(self) -> int:
@@ -284,6 +300,9 @@ class TunnelRuntime:
         self._handoff_in_flight = False
         self._handoff_task: asyncio.Task[None] | None = None
         self._last_handoff_at = 0.0
+        # Set when another client took over this tunnel: serve_forever stops
+        # and does not reconnect. Distinct from a transient drop or a drain.
+        self._superseded = False
         # Wakes the supervisor when active is swapped mid-handoff.
         self._supervisor_wake: asyncio.Event = asyncio.Event()
         # Dispatch tasks are runtime-scoped (not per-connection): a
@@ -476,6 +495,15 @@ class TunnelRuntime:
                 )
                 self._notify_status("closed")
                 raise
+            except _TunnelSupersededError:
+                logger.warning(
+                    "tunnel taken over: another client connected to this tunnel, "
+                    "so this client is stopping and will not reconnect. If this is "
+                    "unexpected, check for a second instance running the same "
+                    "identity (only one live connection per tunnel is kept).",
+                )
+                self._notify_status("superseded")
+                raise
             except Exception:
                 consecutive_failures += 1
                 logger.exception(
@@ -529,6 +557,11 @@ class TunnelRuntime:
                     continue
                 if conn.read_task is None or conn.read_task.done():
                     break
+            # Another client took over this tunnel: stop, do not reconnect.
+            if self._superseded:
+                raise _TunnelSupersededError(
+                    "another client connected to this tunnel; not reconnecting",
+                )
         finally:
             await self._teardown_cold(conn)
 
@@ -718,6 +751,49 @@ class TunnelRuntime:
         with suppress(Exception):
             writer.close()
 
+    def _superseded_is_terminal(self, conn: _Connection) -> bool:
+        """True iff a takeover signal on ``conn`` should stop the runtime.
+
+        Ignored on a draining / handoff / non-active connection: that is this
+        client's own make-before-break predecessor being replaced during a
+        reconnect, not an external client taking the tunnel over.
+        """
+        return (
+            conn is self._active
+            and not conn.draining
+            and not self._handoff_in_flight
+        )
+
+    def _mark_superseded(self, conn: _Connection) -> None:
+        """Record that ``conn`` was taken over; serve_forever will stop."""
+        conn.superseded = True
+        self._superseded = True
+
+    def _maybe_mark_superseded_goaway(
+        self, conn: _Connection, error_code: int, reason: str | None,
+    ) -> None:
+        """Classify a non-zero GOAWAY: takeover (terminal) vs infra (reconnect).
+
+        The dedicated error code is authoritative (survives a lost debug
+        blob); the reason string is a belt cross-check. Any other non-zero
+        GOAWAY is an infra fault -> let the read loop end and reconnect cold.
+        """
+        is_takeover = (
+            error_code == SUPERSEDED_GOAWAY_ERROR_CODE
+            or reason == GOAWAY_REASON_SUPERSEDED
+        )
+        if not is_takeover:
+            if reason is None:
+                logger.warning(
+                    "non-zero GOAWAY (code=%s) without a reason; reconnecting",
+                    error_code,
+                )
+            return
+        if not self._superseded_is_terminal(conn):
+            logger.info("takeover signal on a draining/handoff connection; ignoring")
+            return
+        self._mark_superseded(conn)
+
     async def _open_connection(self, conn: _Connection) -> None:
         ctx = create_default_verify_context()
         ctx.set_alpn_protocols(["h2"])
@@ -813,6 +889,17 @@ class TunnelRuntime:
                 "(check the key matches the tunnel's identity scope, or use "
                 "an admin-scoped key in the tunnel's org)",
             )
+        # Displaced during hello: another client connected to this tunnel and
+        # won the race. Terminal (stop, don't reconnect) so we don't redial
+        # and boot the client that replaced us — unless this is our own
+        # draining/handoff predecessor, where it's just a transient retry.
+        if status == 409 and _hello_reason(body) == HELLO_REASON_SUPERSEDED:
+            if self._superseded_is_terminal(conn):
+                self._superseded = True
+                raise _TunnelSupersededError(
+                    "another client connected to this tunnel during hello",
+                )
+            raise RuntimeError("/_system/hello 409 on a draining conn; will retry")
         if status != 200:
             raise RuntimeError(
                 f"/_system/hello returned {status}; transient — will retry",
@@ -908,6 +995,12 @@ class TunnelRuntime:
                 envelope = await self._park_one_intake(conn, slot)
             except asyncio.CancelledError:
                 raise
+            except _TunnelSupersededError:
+                # Another client took over: force this conn down so the
+                # supervisor observes the terminal flag and stops (no reconnect).
+                self._mark_superseded(conn)
+                self._force_reconnect_conn(conn)
+                return
             except _OwnerTokenInvalidError:
                 logger.warning(
                     "intake slot %d: owner_token rejected; reconnecting", slot,
@@ -985,6 +1078,16 @@ class TunnelRuntime:
                 "/_system/intake slot=%d -> status=%s reason=%r body=%r",
                 slot, status, reason, body_bytes,
             )
+            # Another client took over this tunnel. Terminal, unless this is
+            # our own draining/handoff predecessor (a normal reconnect), where
+            # it is ignored. A drain uses a different reason and falls through
+            # to re-park below.
+            if reason == INTAKE_REASON_SUPERSEDED:
+                if self._superseded_is_terminal(conn):
+                    raise _TunnelSupersededError(
+                        f"slot={slot}: another client connected to this tunnel",
+                    )
+                return None
             if status == "401":
                 raise _OwnerTokenInvalidError(
                     f"slot={slot} status=401 reason={reason!r}",
@@ -1153,12 +1256,14 @@ class TunnelRuntime:
             # hyper-h2 flips the whole connection to CLOSED on GOAWAY
             # regardless of error code, so we cannot keep live bridges
             # running on this conn (unlike Node). A NO_ERROR (0) GOAWAY
-            # is the server's drain signal: hand off make-before-break
-            # instead of raising. A non-zero code is a real fault — let
-            # the read loop end and reconnect cold.
+            # is the drain signal: hand off make-before-break. A non-zero
+            # code is either a takeover (stop, don't reconnect) or a real
+            # fault (reconnect cold) — classified below.
             conn.goaway_received = True
             if event.error_code == 0 and conn is self._active:
                 self._begin_handoff(conn, reason=reason or "drain")
+            elif event.error_code != 0:
+                self._maybe_mark_superseded_goaway(conn, event.error_code, reason)
 
     # --- envelope dispatch --------------------------------------------------
 
@@ -2836,6 +2941,21 @@ def _parse_goaway_reason(debug: str) -> str | None:
     try:
         parsed = json.loads(debug)
     except (json.JSONDecodeError, ValueError):
+        return None
+    if isinstance(parsed, dict):
+        reason = parsed.get("reason")
+        if isinstance(reason, str):
+            return reason
+    return None
+
+
+def _hello_reason(body: bytes) -> str | None:
+    """Extract the ``reason`` from a hello response body (``{"reason": ...}``)."""
+    if not body:
+        return None
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
         return None
     if isinstance(parsed, dict):
         reason = parsed.get("reason")

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -30,7 +30,7 @@ import ssl
 import struct
 import time
 from contextlib import suppress
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 from uuid import UUID
 
 import h2.config
@@ -41,6 +41,7 @@ import h2.exceptions
 import h2.settings
 import httpx
 
+from inkbox.tunnels.exceptions import TunnelSupersededError
 from inkbox.tunnels.client._asgi import AsgiResponseTooLarge, invoke_asgi_http
 from inkbox.tunnels.client._bridge import (
     BRIDGE_CLEANUP_SEND_TIMEOUT_SEC,
@@ -134,8 +135,9 @@ class _TunnelAuthError(RuntimeError):
     """Permanent auth failure from /_system/hello; do not retry."""
 
 
-class _TunnelSupersededError(RuntimeError):
-    """Another client connected to this tunnel and took over; stop, don't reconnect."""
+# Public terminal takeover error, aliased to the internal name the runtime
+# raises everywhere. Apps catch the public class; the alias keeps churn low.
+_TunnelSupersededError = TunnelSupersededError
 
 
 class _OwnerTokenInvalidError(RuntimeError):
@@ -228,8 +230,6 @@ class _Connection:
         # Set once a GOAWAY (ConnectionTerminated) lands; the read loop
         # winds down because hyper-h2 is now CLOSED.
         self.goaway_received = False
-        # Set when this connection was taken over by another client.
-        self.superseded = False
 
     @property
     def live_bridges(self) -> int:
@@ -496,15 +496,13 @@ class TunnelRuntime:
                 self._notify_status("closed")
                 raise
             except _TunnelSupersededError:
-                logger.warning(
-                    "tunnel taken over: another client connected to this tunnel, "
-                    "so this client is stopping and will not reconnect. If this is "
-                    "unexpected, check for a second instance running the same "
-                    "identity (only one live connection per tunnel is kept).",
-                )
-                self._notify_status("superseded")
-                raise
+                self._stop_superseded()
             except Exception:
+                # A takeover GOAWAY that lands mid-hello sets _superseded but
+                # surfaces as a plain connection error; go terminal here so we
+                # don't reconnect and boot the client that replaced us.
+                if self._superseded:
+                    self._stop_superseded()
                 consecutive_failures += 1
                 logger.exception(
                     "tunnel runtime: connection error (#%d); reconnecting",
@@ -659,6 +657,12 @@ class TunnelRuntime:
             self._supervisor_wake.set()
         except asyncio.CancelledError:
             raise
+        except _TunnelSupersededError:
+            # External takeover during the handoff hello: _superseded is set,
+            # so end the old conn and wake the supervisor to stop terminally
+            # (no cold redial, which would boot the client that replaced us).
+            self._force_reconnect_conn(old_conn)
+            self._supervisor_wake.set()
         except Exception:
             logger.warning(
                 "tunnel runtime: handoff failed; reconnecting cold",
@@ -698,7 +702,9 @@ class TunnelRuntime:
                     with suppress(asyncio.CancelledError, Exception):
                         await rt
                 await self._close_connection_writer(conn)
-                if isinstance(exc, _TunnelAuthError):
+                # A rejected key or a takeover is terminal; never retry either
+                # (retrying a takeover would boot the client that replaced us).
+                if isinstance(exc, (_TunnelAuthError, _TunnelSupersededError)):
                     raise
                 if (time.monotonic() - start) > HANDOFF_REDIAL_BUDGET_SEC:
                     raise RuntimeError("handoff redial budget exhausted")
@@ -764,9 +770,8 @@ class TunnelRuntime:
             and not self._handoff_in_flight
         )
 
-    def _mark_superseded(self, conn: _Connection) -> None:
-        """Record that ``conn`` was taken over; serve_forever will stop."""
-        conn.superseded = True
+    def _mark_superseded(self) -> None:
+        """Record the takeover; serve_forever will stop and not reconnect."""
         self._superseded = True
 
     def _maybe_mark_superseded_goaway(
@@ -792,7 +797,20 @@ class TunnelRuntime:
         if not self._superseded_is_terminal(conn):
             logger.info("takeover signal on a draining/handoff connection; ignoring")
             return
-        self._mark_superseded(conn)
+        self._mark_superseded()
+
+    def _stop_superseded(self) -> NoReturn:
+        """Log, notify, and raise the terminal takeover error (no reconnect)."""
+        logger.warning(
+            "tunnel taken over: another client connected to this tunnel, so "
+            "this client is stopping and will not reconnect. If this is "
+            "unexpected, check for a second instance running the same identity "
+            "(only one live connection per tunnel is kept).",
+        )
+        self._notify_status("superseded")
+        raise _TunnelSupersededError(
+            "another client connected to this tunnel; not reconnecting",
+        )
 
     async def _open_connection(self, conn: _Connection) -> None:
         ctx = create_default_verify_context()
@@ -889,17 +907,15 @@ class TunnelRuntime:
                 "(check the key matches the tunnel's identity scope, or use "
                 "an admin-scoped key in the tunnel's org)",
             )
-        # Displaced during hello: another client connected to this tunnel and
-        # won the race. Terminal (stop, don't reconnect) so we don't redial
-        # and boot the client that replaced us — unless this is our own
-        # draining/handoff predecessor, where it's just a transient retry.
-        if status == 409 and _hello_reason(body) == HELLO_REASON_SUPERSEDED:
-            if self._superseded_is_terminal(conn):
-                self._superseded = True
-                raise _TunnelSupersededError(
-                    "another client connected to this tunnel during hello",
-                )
-            raise RuntimeError("/_system/hello 409 on a draining conn; will retry")
+        # Displaced during hello: a strictly-later hello (another client) won
+        # the tunnel. Always terminal, even mid-handoff: the server sends this
+        # only when a newer client has connected, so retrying would re-hello
+        # and boot the client that replaced us.
+        if status == 409 and _parse_reason_json(body) == HELLO_REASON_SUPERSEDED:
+            self._superseded = True
+            raise _TunnelSupersededError(
+                "another client connected to this tunnel during hello",
+            )
         if status != 200:
             raise RuntimeError(
                 f"/_system/hello returned {status}; transient — will retry",
@@ -998,7 +1014,7 @@ class TunnelRuntime:
             except _TunnelSupersededError:
                 # Another client took over: force this conn down so the
                 # supervisor observes the terminal flag and stops (no reconnect).
-                self._mark_superseded(conn)
+                self._mark_superseded()
                 self._force_reconnect_conn(conn)
                 return
             except _OwnerTokenInvalidError:
@@ -1246,7 +1262,7 @@ class TunnelRuntime:
                     debug = event.additional_data.decode("utf-8", errors="replace")
             except AttributeError:
                 pass
-            reason = _parse_goaway_reason(debug)
+            reason = _parse_reason_json(debug)
             # Log the parsed reason + length only; the raw debug field is
             # peer-controlled, so don't echo it verbatim at info level.
             logger.info(
@@ -2930,31 +2946,16 @@ class _BodyTooLarge(Exception):
     pass
 
 
-def _parse_goaway_reason(debug: str) -> str | None:
-    """Decode the GOAWAY debug data into a structured reason if present.
+def _parse_reason_json(data: bytes | str | None) -> str | None:
+    """Extract ``reason`` from a ``{"reason": ...}`` blob (GOAWAY debug or hello body).
 
-    The server may attach ``{"reason": "drain"}`` to a NO_ERROR GOAWAY.
-    The handoff behaves the same either way today; this is the seam an
-    app-level advance-notice would hang off of."""
-    if not debug:
+    ``json.loads`` accepts bytes or str, so one helper covers both. Returns
+    None on empty/unparseable input or a missing/non-string reason.
+    """
+    if not data:
         return None
     try:
-        parsed = json.loads(debug)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if isinstance(parsed, dict):
-        reason = parsed.get("reason")
-        if isinstance(reason, str):
-            return reason
-    return None
-
-
-def _hello_reason(body: bytes) -> str | None:
-    """Extract the ``reason`` from a hello response body (``{"reason": ...}``)."""
-    if not body:
-        return None
-    try:
-        parsed = json.loads(body.decode("utf-8"))
+        parsed = json.loads(data)
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
         return None
     if isinstance(parsed, dict):

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -706,6 +706,13 @@ class TunnelRuntime:
                 # (retrying a takeover would boot the client that replaced us).
                 if isinstance(exc, (_TunnelAuthError, _TunnelSupersededError)):
                     raise
+                # A takeover GOAWAY that landed mid-hello sets _superseded but
+                # surfaces here as a plain reset/status-0 error; stop now so we
+                # don't re-hello and boot the client that replaced us.
+                if self._superseded:
+                    raise _TunnelSupersededError(
+                        "another client connected to this tunnel during handoff",
+                    )
                 if (time.monotonic() - start) > HANDOFF_REDIAL_BUDGET_SEC:
                     raise RuntimeError("handoff redial budget exhausted")
                 jitter = backoff * BACKOFF_JITTER * (2 * random.random() - 1)

--- a/sdk/python/inkbox/tunnels/exceptions.py
+++ b/sdk/python/inkbox/tunnels/exceptions.py
@@ -52,3 +52,13 @@ class TunnelNotProvisioned(TunnelError):
     """Raised by :func:`connect` when no tunnel exists for the supplied
     name in the calling org. Tunnels are provisioned atomically as part
     of ``inkbox.create_identity(...)``."""
+
+
+class TunnelSupersededError(TunnelError):
+    """Another client connected to the same tunnel and took over.
+
+    Raised out of ``serve()`` / ``wait()`` when a newer client displaces this
+    one. Terminal by design: the client stops and does not reconnect. Run one
+    client per tunnel; use separate identities for redundancy. Catch this to
+    react to the takeover (alert, exit, fail over to another identity).
+    """

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -361,6 +361,40 @@ async def test_make_replacement_reraises_superseded_no_retry(monkeypatch):
     assert attempts["n"] == 1  # did NOT retry the doomed hello
 
 
+@pytest.mark.asyncio
+async def test_make_replacement_terminal_on_flag_set_plain_error(monkeypatch):
+    """Regression: a takeover GOAWAY landing mid-hello sets _superseded but the
+    hello fails with a PLAIN reset/status-0 error (not the typed exception).
+    The handoff helper must stop on the first attempt, not keep re-helloing
+    within the redial budget and repeatedly boot the client that replaced us."""
+    runtime = _make_runtime()
+    attempts = {"n": 0}
+
+    async def _open(conn):
+        return None
+
+    async def _read_loop(conn):
+        await asyncio.sleep(3600)
+
+    async def _hello(conn):
+        attempts["n"] += 1
+        runtime._superseded = True  # set by the read loop's GOAWAY handler
+        raise RuntimeError("connection reset during hello")  # plain, not typed
+
+    async def _close(conn):
+        return None
+
+    monkeypatch.setattr(runtime, "_open_connection", _open)
+    monkeypatch.setattr(runtime, "_read_loop", _read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", _hello)
+    monkeypatch.setattr(runtime, "_force_reconnect_conn", lambda c: None)
+    monkeypatch.setattr(runtime, "_close_connection_writer", _close)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime._make_replacement_connection()
+    assert attempts["n"] == 1  # stopped on the flag, did NOT redial
+
+
 def test_superseded_error_is_public_and_typed():
     """The terminal error is the public TunnelSupersededError (a TunnelError),
     reachable from inkbox and inkbox.tunnels, not a bare RuntimeError."""

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -6,6 +6,7 @@ make-before-break reconnect for an external takeover.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -17,7 +18,7 @@ from inkbox.tunnels.client._runtime import (
     SUPERSEDED_GOAWAY_ERROR_CODE,
     TunnelRuntime,
     _Connection,
-    _hello_reason,
+    _parse_reason_json,
     _TunnelSupersededError,
 )
 
@@ -61,7 +62,6 @@ async def test_superseded_goaway_on_active_marks_terminal():
         _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
     )
     assert runtime._superseded is True
-    assert conn.superseded is True
 
 
 @pytest.mark.asyncio
@@ -162,9 +162,9 @@ async def test_intake_loop_terminal_on_superseded(monkeypatch):
 
 
 def test_hello_reason_parses_body():
-    assert _hello_reason(b'{"reason":"hello-superseded"}') == HELLO_REASON_SUPERSEDED
-    assert _hello_reason(b"") is None
-    assert _hello_reason(b"not json") is None
+    assert _parse_reason_json(b'{"reason":"hello-superseded"}') == HELLO_REASON_SUPERSEDED
+    assert _parse_reason_json(b"") is None
+    assert _parse_reason_json(b"not json") is None
 
 
 @pytest.mark.asyncio
@@ -231,6 +231,95 @@ async def test_serve_forever_stops_and_surfaces_on_superseded(monkeypatch):
     # terminal status surfaced (not "reconnecting"/"closed"), no retry loop
     assert "superseded" in statuses
     assert "reconnecting" not in statuses
+
+
+@pytest.mark.asyncio
+async def test_serve_forever_terminal_when_flag_set_on_plain_error(monkeypatch):
+    """A takeover GOAWAY that lands mid-hello sets _superseded but the hello
+    fails with a PLAIN error; serve_forever must stop, not reconnect."""
+    runtime = _make_runtime()
+    statuses: list[str] = []
+    monkeypatch.setattr(runtime, "_notify_status", lambda s: statuses.append(s))
+
+    async def _run_once_plain_error():
+        runtime._superseded = True  # set by the read loop mid-hello
+        raise RuntimeError("connection closed during hello")
+
+    monkeypatch.setattr(runtime, "_run_once", _run_once_plain_error)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime.serve_forever()
+    assert "superseded" in statuses
+    assert "reconnecting" not in statuses
+
+
+@pytest.mark.asyncio
+async def test_hello_superseded_terminal_even_during_handoff(monkeypatch):
+    """hello-superseded is terminal even on a non-active/handoff connection, so
+    a handoff retry can't re-hello and boot the client that replaced us."""
+    runtime = _make_runtime()
+    _active_conn(runtime)  # a DIFFERENT active conn
+    runtime._handoff_in_flight = True
+    conn = _Connection(2)  # the replacement being helloed (not active)
+    conn.h2 = MagicMock()
+    conn.writer = MagicMock()
+    monkeypatch.setattr(runtime, "_open_stream_locked", lambda *a, **k: 1)
+
+    async def _flush(c):
+        return None
+
+    async def _await(sid, conn=None):
+        return 409, b'{"reason":"hello-superseded"}'
+
+    monkeypatch.setattr(runtime, "_flush_conn", _flush)
+    monkeypatch.setattr(runtime, "_await_response", _await)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime._send_hello(conn)
+    assert runtime._superseded is True
+
+
+@pytest.mark.asyncio
+async def test_make_replacement_reraises_superseded_no_retry(monkeypatch):
+    """A takeover during the handoff hello propagates terminally instead of
+    being retried within the redial budget."""
+    runtime = _make_runtime()
+    attempts = {"n": 0}
+
+    async def _open(conn):
+        return None
+
+    async def _read_loop(conn):
+        await asyncio.sleep(3600)
+
+    async def _hello(conn):
+        attempts["n"] += 1
+        raise _TunnelSupersededError("taken over during handoff")
+
+    async def _close(conn):
+        return None
+
+    monkeypatch.setattr(runtime, "_open_connection", _open)
+    monkeypatch.setattr(runtime, "_read_loop", _read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", _hello)
+    monkeypatch.setattr(runtime, "_force_reconnect_conn", lambda c: None)
+    monkeypatch.setattr(runtime, "_close_connection_writer", _close)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime._make_replacement_connection()
+    assert attempts["n"] == 1  # did NOT retry the doomed hello
+
+
+def test_superseded_error_is_public_and_typed():
+    """The terminal error is the public TunnelSupersededError (a TunnelError),
+    reachable from inkbox and inkbox.tunnels, not a bare RuntimeError."""
+    import inkbox
+    from inkbox.tunnels import TunnelSupersededError
+    from inkbox.tunnels.exceptions import TunnelError
+
+    assert _TunnelSupersededError is TunnelSupersededError
+    assert inkbox.TunnelSupersededError is TunnelSupersededError
+    assert issubclass(TunnelSupersededError, TunnelError)
 
 
 def test_guard_helper_matrix():

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -1,0 +1,244 @@
+"""
+Tests for the terminal "another client took over this tunnel" (superseded)
+path: the SDK must stop and not reconnect, and must NOT mistake its own
+make-before-break reconnect for an external takeover.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import h2.events
+import pytest
+
+from inkbox.tunnels.client._runtime import (
+    HELLO_REASON_SUPERSEDED,
+    SUPERSEDED_GOAWAY_ERROR_CODE,
+    TunnelRuntime,
+    _Connection,
+    _hello_reason,
+    _TunnelSupersededError,
+)
+
+
+def _make_runtime(**kwargs) -> TunnelRuntime:
+    base = dict(
+        tunnel_id=uuid4(),
+        api_key="ApiKey_test",
+        zone="inkboxwire.example",
+        public_host="my-agent.inkboxwire.example",
+        pool_size=1,
+        forward_to="http://127.0.0.1:1",
+        tls_terminator=None,
+    )
+    base.update(kwargs)
+    return TunnelRuntime(**base)
+
+
+def _goaway(error_code: int, debug: bytes | None) -> h2.events.ConnectionTerminated:
+    ev = h2.events.ConnectionTerminated()
+    ev.error_code = error_code
+    ev.last_stream_id = 0
+    ev.additional_data = debug
+    return ev
+
+
+def _active_conn(runtime: TunnelRuntime) -> _Connection:
+    conn = _Connection(1)
+    runtime._active = conn
+    return conn
+
+
+# ── GOAWAY classification ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_superseded_goaway_on_active_marks_terminal():
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    await runtime._handle_event(
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
+    )
+    assert runtime._superseded is True
+    assert conn.superseded is True
+
+
+@pytest.mark.asyncio
+async def test_superseded_code_is_authoritative_without_reason():
+    """The dedicated code alone is terminal even if the debug blob is lost."""
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    await runtime._handle_event(_goaway(SUPERSEDED_GOAWAY_ERROR_CODE, None), conn)
+    assert runtime._superseded is True
+
+
+@pytest.mark.asyncio
+async def test_superseded_reason_is_a_belt_for_other_nonzero_code():
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    await runtime._handle_event(_goaway(9, b'{"reason":"superseded"}'), conn)
+    assert runtime._superseded is True
+
+
+@pytest.mark.asyncio
+async def test_superseded_goaway_ignored_when_draining():
+    """A takeover signal on our own draining predecessor is not terminal."""
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    conn.draining = True
+    await runtime._handle_event(
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
+    )
+    assert runtime._superseded is False
+
+
+@pytest.mark.asyncio
+async def test_superseded_goaway_ignored_when_not_active():
+    runtime = _make_runtime()
+    _active_conn(runtime)
+    other = _Connection(2)  # not the active connection
+    await runtime._handle_event(
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), other,
+    )
+    assert runtime._superseded is False
+
+
+@pytest.mark.asyncio
+async def test_superseded_goaway_ignored_during_handoff():
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    runtime._handoff_in_flight = True
+    await runtime._handle_event(
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
+    )
+    assert runtime._superseded is False
+
+
+@pytest.mark.asyncio
+async def test_drain_goaway_hands_off_not_superseded(monkeypatch):
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        runtime, "_begin_handoff", lambda c, *, reason: calls.append(reason),
+    )
+    await runtime._handle_event(_goaway(0, b'{"reason":"drain"}'), conn)
+    assert runtime._superseded is False
+    assert calls == ["drain"]
+
+
+@pytest.mark.asyncio
+async def test_infra_goaway_different_reason_reconnects_not_terminal():
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    await runtime._handle_event(_goaway(2, b'{"reason":"internal"}'), conn)
+    assert runtime._superseded is False
+
+
+# ── intake channel ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intake_loop_terminal_on_superseded(monkeypatch):
+    """intake-superseded -> mark terminal + force the conn down (no reconnect)."""
+    runtime = _make_runtime()
+    runtime._h2 = MagicMock()  # truthy so the loop guard passes
+
+    async def _fake_park(conn=None, slot=0):
+        raise _TunnelSupersededError("slot=0: taken over")
+
+    monkeypatch.setattr(runtime, "_park_one_intake", _fake_park)
+    forced: list[int] = []
+    monkeypatch.setattr(
+        runtime, "_force_reconnect_conn", lambda conn: forced.append(1),
+    )
+    await runtime._intake_loop(0)
+    assert runtime._superseded is True
+    assert forced == [1]
+
+
+# ── hello channel ────────────────────────────────────────────────────────
+
+
+def test_hello_reason_parses_body():
+    assert _hello_reason(b'{"reason":"hello-superseded"}') == HELLO_REASON_SUPERSEDED
+    assert _hello_reason(b"") is None
+    assert _hello_reason(b"not json") is None
+
+
+@pytest.mark.asyncio
+async def test_hello_superseded_is_terminal(monkeypatch):
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    conn.h2 = MagicMock()
+    conn.writer = MagicMock()
+    monkeypatch.setattr(runtime, "_open_stream_locked", lambda *a, **k: 1)
+
+    async def _flush(c):
+        return None
+
+    async def _await(sid, conn=None):
+        return 409, b'{"reason":"hello-superseded"}'
+
+    monkeypatch.setattr(runtime, "_flush_conn", _flush)
+    monkeypatch.setattr(runtime, "_await_response", _await)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime._send_hello(conn)
+    assert runtime._superseded is True
+
+
+@pytest.mark.asyncio
+async def test_hello_generic_409_is_transient(monkeypatch):
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    conn.h2 = MagicMock()
+    conn.writer = MagicMock()
+    monkeypatch.setattr(runtime, "_open_stream_locked", lambda *a, **k: 1)
+
+    async def _flush(c):
+        return None
+
+    async def _await(sid, conn=None):
+        return 409, b'{"reason":"something-else"}'
+
+    monkeypatch.setattr(runtime, "_flush_conn", _flush)
+    monkeypatch.setattr(runtime, "_await_response", _await)
+
+    with pytest.raises(RuntimeError) as exc:
+        await runtime._send_hello(conn)
+    assert not isinstance(exc.value, _TunnelSupersededError)
+    assert runtime._superseded is False
+
+
+# ── serve_forever surfacing ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_serve_forever_stops_and_surfaces_on_superseded(monkeypatch):
+    runtime = _make_runtime()
+    statuses: list[str] = []
+    monkeypatch.setattr(runtime, "_notify_status", lambda s: statuses.append(s))
+
+    async def _boom():
+        raise _TunnelSupersededError("taken over")
+
+    monkeypatch.setattr(runtime, "_run_once", _boom)
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime.serve_forever()
+    # terminal status surfaced (not "reconnecting"/"closed"), no retry loop
+    assert "superseded" in statuses
+    assert "reconnecting" not in statuses
+
+
+def test_guard_helper_matrix():
+    runtime = _make_runtime()
+    conn = _active_conn(runtime)
+    assert runtime._superseded_is_terminal(conn) is True
+    conn.draining = True
+    assert runtime._superseded_is_terminal(conn) is False
+    conn.draining = False
+    runtime._handoff_in_flight = True
+    assert runtime._superseded_is_terminal(conn) is False

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -226,8 +226,10 @@ async def test_serve_forever_stops_and_surfaces_on_superseded(monkeypatch):
 
     monkeypatch.setattr(runtime, "_run_once", _boom)
 
-    with pytest.raises(_TunnelSupersededError):
+    with pytest.raises(_TunnelSupersededError) as exc_info:
         await runtime.serve_forever()
+    # the original error (with its channel/slot detail) is re-raised verbatim
+    assert "taken over" in str(exc_info.value)
     # terminal status surfaced (not "reconnecting"/"closed"), no retry loop
     assert "superseded" in statuses
     assert "reconnecting" not in statuses

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -15,10 +15,12 @@ import pytest
 
 from inkbox.tunnels.client._runtime import (
     HELLO_REASON_SUPERSEDED,
+    INTAKE_REASON_SUPERSEDED,
     SUPERSEDED_GOAWAY_ERROR_CODE,
     TunnelRuntime,
     _Connection,
     _parse_reason_json,
+    _StreamEvent,
     _TunnelSupersededError,
 )
 
@@ -87,6 +89,7 @@ async def test_superseded_goaway_ignored_when_draining():
     runtime = _make_runtime()
     conn = _active_conn(runtime)
     conn.draining = True
+    runtime._draining.add(conn)  # a real make-before-break predecessor
     await runtime._handle_event(
         _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
     )
@@ -94,25 +97,36 @@ async def test_superseded_goaway_ignored_when_draining():
 
 
 @pytest.mark.asyncio
-async def test_superseded_goaway_ignored_when_not_active():
+async def test_superseded_goaway_on_nonactive_replacement_is_terminal():
+    """Regression: a takeover on a non-active replacement (NOT a drain
+    predecessor) is terminal. Previously mis-suppressed by the non-active
+    guard, which let the runtime cold-reconnect and re-steal the tunnel."""
     runtime = _make_runtime()
     _active_conn(runtime)
-    other = _Connection(2)  # not the active connection
+    replacement = _Connection(2)  # not active, NOT in _draining
     await runtime._handle_event(
-        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), other,
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'),
+        replacement,
     )
-    assert runtime._superseded is False
+    assert runtime._superseded is True
 
 
 @pytest.mark.asyncio
-async def test_superseded_goaway_ignored_during_handoff():
+async def test_superseded_goaway_on_replacement_during_handoff_is_terminal():
+    """Regression (the real race): mid-handoff, old A is the draining
+    predecessor and B is the in-flight replacement. A superseded GOAWAY on B
+    (an external takeover) must be terminal, not swallowed as a self-handoff."""
     runtime = _make_runtime()
-    conn = _active_conn(runtime)
+    old_a = _active_conn(runtime)
+    old_a.draining = True
+    runtime._draining.add(old_a)
     runtime._handoff_in_flight = True
+    replacement = _Connection(2)  # B: not active, NOT in _draining
     await runtime._handle_event(
-        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'), conn,
+        _goaway(SUPERSEDED_GOAWAY_ERROR_CODE, b'{"reason":"superseded"}'),
+        replacement,
     )
-    assert runtime._superseded is False
+    assert runtime._superseded is True
 
 
 @pytest.mark.asyncio
@@ -137,6 +151,41 @@ async def test_infra_goaway_different_reason_reconnects_not_terminal():
 
 
 # ── intake channel ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intake_superseded_terminal_on_nonactive_replacement(monkeypatch):
+    """Regression: intake-superseded on a non-draining replacement conn (not
+    active, mid-handoff) is terminal. _park_one_intake must raise, not re-park.
+
+    An intake-superseded can't actually land while B's hello is in flight
+    (intakes only start after _start_serving), so this drives the intake
+    predicate directly rather than framing it as hello-in-flight.
+    """
+    runtime = _make_runtime()
+    _active_conn(runtime)  # a DIFFERENT active conn (old A)
+    runtime._handoff_in_flight = True
+    conn = _Connection(2)  # replacement B: not active, NOT in _draining
+    conn.owner_token = "owner_test"
+    conn.h2 = MagicMock()
+    conn.writer = MagicMock()
+    monkeypatch.setattr(runtime, "_open_stream_locked", lambda *a, **k: 7)
+
+    async def _flush(c):
+        return None
+
+    monkeypatch.setattr(runtime, "_flush_conn", _flush)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    conn.streams[7] = queue
+    await queue.put(_StreamEvent(
+        "headers",
+        headers=[(":status", "409"), ("inkbox-reason", INTAKE_REASON_SUPERSEDED)],
+    ))
+    await queue.put(_StreamEvent("end"))
+
+    with pytest.raises(_TunnelSupersededError):
+        await runtime._park_one_intake(conn, slot=0)
 
 
 @pytest.mark.asyncio
@@ -325,11 +374,16 @@ def test_superseded_error_is_public_and_typed():
 
 
 def test_guard_helper_matrix():
+    """Terminal for any conn except one we put into make-before-break drain."""
     runtime = _make_runtime()
     conn = _active_conn(runtime)
+    # active conn, not a drain predecessor -> terminal
     assert runtime._superseded_is_terminal(conn) is True
-    conn.draining = True
-    assert runtime._superseded_is_terminal(conn) is False
-    conn.draining = False
+    # a not-yet-active replacement (not in _draining) is also terminal, even
+    # while a handoff is in flight
+    replacement = _Connection(2)
     runtime._handoff_in_flight = True
+    assert runtime._superseded_is_terminal(replacement) is True
+    # only our own draining predecessor is ignored
+    runtime._draining.add(conn)
     assert runtime._superseded_is_terminal(conn) is False

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.15"
+version = "0.4.17"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -92,6 +92,16 @@ pub enum InkboxError {
     Decode(#[from] serde_json::Error),
 }
 
+impl InkboxError {
+    /// True iff this is the terminal "another client took over this tunnel"
+    /// error surfaced by a tunnel client's `serve_forever`. Terminal by
+    /// design: the client has stopped and will not reconnect. Lets callers
+    /// tell a takeover apart from a transient, reconnectable tunnel error.
+    pub fn is_tunnel_superseded(&self) -> bool {
+        matches!(self, InkboxError::Tunnel(m) if m.starts_with("tunnel-superseded:"))
+    }
+}
+
 /// The `detail` payload on an [`InkboxError::Api`]: either a human-readable
 /// string or a structured object, matching the Python `str | dict` union.
 #[derive(Debug, Clone)]

--- a/sdk/rust/src/tunnels/client/runtime.rs
+++ b/sdk/rust/src/tunnels/client/runtime.rs
@@ -265,7 +265,19 @@ impl TunnelRuntime {
 
         // Hello handshake — establishes the owner_token used to park intakes.
         // A displaced-during-hello loser returns the superseded tag here.
-        let active = self.send_hello(send).await?;
+        let active = match self.send_hello(send).await {
+            Ok(active) => active,
+            Err(e) => {
+                // A takeover GOAWAY can land mid-hello: the driver sets the
+                // flag while the hello itself fails as a plain transient error.
+                // Honor the flag so we stop instead of redialing and booting
+                // the client that replaced us.
+                if superseded.load(Ordering::SeqCst) {
+                    return Err(superseded_error("another client connected to this tunnel"));
+                }
+                return Err(e);
+            }
+        };
         let active = Arc::new(active);
         *self.active.lock().await = Some(active.clone());
         self.notify_status("connected");
@@ -821,7 +833,7 @@ fn superseded_error(msg: impl Into<String>) -> InkboxError {
 }
 
 fn is_superseded_error(err: &InkboxError) -> bool {
-    matches!(err, InkboxError::Tunnel(m) if m.starts_with("tunnel-superseded:"))
+    err.is_tunnel_superseded()
 }
 
 /// True iff a connection-driver `h2::Error` carries the dedicated superseded
@@ -886,6 +898,15 @@ mod tests {
         assert!(!is_superseded_error(&owner_token_invalid("x")));
         assert!(!is_auth_error(&superseded_error("x")));
         assert!(!is_owner_token_invalid(&superseded_error("x")));
+    }
+
+    #[test]
+    fn is_tunnel_superseded_is_public_and_structural() {
+        // Callers can distinguish a terminal takeover from a transient error
+        // structurally (no string matching on their side).
+        assert!(superseded_error("x").is_tunnel_superseded());
+        assert!(!transient("x").is_tunnel_superseded());
+        assert!(!tunnel_auth_error("x").is_tunnel_superseded());
     }
 
     #[test]

--- a/sdk/rust/src/tunnels/client/runtime.rs
+++ b/sdk/rust/src/tunnels/client/runtime.rs
@@ -283,9 +283,9 @@ impl TunnelRuntime {
             let conn = active.clone();
             let fd = force_down.clone();
             let sup = superseded.clone();
-            handles.push(tokio::spawn(
-                async move { me.intake_loop(conn, slot, fd, sup).await },
-            ));
+            handles.push(tokio::spawn(async move {
+                me.intake_loop(conn, slot, fd, sup).await
+            }));
         }
 
         // Supervise: return when the connection dies, a keepalive/owner-token
@@ -897,7 +897,9 @@ mod tests {
         assert!(is_superseded_goaway(&takeover));
 
         // Drain (NO_ERROR) and a generic backpressure code are NOT takeovers.
-        assert!(!is_superseded_goaway(&h2::Error::from(h2::Reason::NO_ERROR)));
+        assert!(!is_superseded_goaway(&h2::Error::from(
+            h2::Reason::NO_ERROR
+        )));
         assert!(!is_superseded_goaway(&h2::Error::from(
             h2::Reason::ENHANCE_YOUR_CALM
         )));

--- a/sdk/rust/src/tunnels/client/runtime.rs
+++ b/sdk/rust/src/tunnels/client/runtime.rs
@@ -61,9 +61,17 @@ pub const WS_CLOSE_AGENT_TIMEOUT: u16 = 4504;
 pub const DEFAULT_INBOUND_BODY_BYTES: usize = 32 * 1024 * 1024;
 pub const DEFAULT_OUTBOUND_BODY_BYTES: usize = 32 * 1024 * 1024;
 
+/// Signals that another client connected to this tunnel and took over: this
+/// client must stop and not reconnect. Delivered as a dedicated GOAWAY error
+/// code (the reliable channel this runtime keys on) plus matching reason
+/// strings on the intake / hello responses. Must stay in lockstep with the server.
+pub const SUPERSEDED_GOAWAY_ERROR_CODE: u32 = 0x1201;
+const INTAKE_REASON_SUPERSEDED: &str = "intake-superseded";
+const HELLO_REASON_SUPERSEDED: &str = "hello-superseded";
+
 /// Status strings passed to the `on_status` callback. Mirrors the Python
 /// status vocabulary (`"connecting"`, `"connected"`, `"reconnecting"`,
-/// `"closed"`).
+/// `"closed"`, `"superseded"`).
 pub type StatusCallback = Box<dyn Fn(&str) + Send + Sync>;
 
 /// Where inbound third-party traffic is forwarded.
@@ -198,6 +206,13 @@ impl TunnelRuntime {
                     self.notify_status("closed");
                     return Err(err);
                 }
+                // Another client connected to this tunnel and took over: stop
+                // and do not reconnect. Surface it terminally (like auth) so an
+                // accidental second instance on the same identity is visible.
+                Err(err) if is_superseded_error(&err) => {
+                    self.notify_status("superseded");
+                    return Err(err);
+                }
                 Err(_) => self.notify_status("reconnecting"),
             }
             if self.is_stopped() {
@@ -237,11 +252,19 @@ impl TunnelRuntime {
         // Fresh per connection so a stale signal can't kill the next one.
         let force_down = Arc::new(Notify::new());
 
+        // Reason channel: `force_down` is payloadless, so a takeover observed
+        // by the connection driver (GOAWAY code) or an intake loop (409 reason)
+        // is recorded here for the supervisor to read after the select.
+        let superseded = Arc::new(AtomicBool::new(false));
+
         // Dial + h2 handshake. The driver runs as a background task; when it
         // ends (GOAWAY / reset / TCP close) `conn_closed` fires.
-        let (send, conn_closed) = self.open_connection(force_down.clone()).await?;
+        let (send, conn_closed) = self
+            .open_connection(force_down.clone(), superseded.clone())
+            .await?;
 
         // Hello handshake — establishes the owner_token used to park intakes.
+        // A displaced-during-hello loser returns the superseded tag here.
         let active = self.send_hello(send).await?;
         let active = Arc::new(active);
         *self.active.lock().await = Some(active.clone());
@@ -259,8 +282,9 @@ impl TunnelRuntime {
             let me = self.clone();
             let conn = active.clone();
             let fd = force_down.clone();
+            let sup = superseded.clone();
             handles.push(tokio::spawn(
-                async move { me.intake_loop(conn, slot, fd).await },
+                async move { me.intake_loop(conn, slot, fd, sup).await },
             ));
         }
 
@@ -278,6 +302,10 @@ impl TunnelRuntime {
             h.abort();
         }
         *self.active.lock().await = None;
+        // Another client took over this tunnel: stop, do not reconnect.
+        if superseded.load(Ordering::SeqCst) {
+            return Err(superseded_error("another client connected to this tunnel"));
+        }
         if self.is_stopped() {
             Ok(())
         } else {
@@ -292,6 +320,7 @@ impl TunnelRuntime {
     async fn open_connection(
         self: &Arc<Self>,
         force_down: Arc<Notify>,
+        superseded: Arc<AtomicBool>,
     ) -> Result<(SendRequest<Bytes>, tokio::sync::oneshot::Receiver<()>)> {
         use tokio::net::TcpStream;
         use tokio_rustls::TlsConnector;
@@ -331,7 +360,14 @@ impl TunnelRuntime {
         let mut connection = connection;
         let ping_pong = connection.ping_pong();
         tokio::spawn(async move {
-            let _ = connection.await;
+            // Classify the close: a GOAWAY carrying the dedicated superseded
+            // code is a takeover (stop, don't reconnect). Rust reads only the
+            // code, so this is the reliable channel; any other close reconnects.
+            if let Err(e) = connection.await {
+                if is_superseded_goaway(&e) {
+                    superseded.store(true, Ordering::SeqCst);
+                }
+            }
             let _ = closed_tx.send(());
         });
         if let Some(mut pp) = ping_pong {
@@ -392,6 +428,21 @@ impl TunnelRuntime {
                  admin-scoped key in the tunnel's org)"
             )));
         }
+        // Displaced during hello: another client won the race for this tunnel.
+        // Terminal (stop, don't reconnect) so we don't redial and boot the
+        // client that replaced us. Rust reconnects cold-sequentially, so there
+        // is no draining predecessor to guard against.
+        if status == 409 {
+            let reason = serde_json::from_slice::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("reason").and_then(|r| r.as_str()).map(str::to_string))
+                .unwrap_or_default();
+            if reason == HELLO_REASON_SUPERSEDED {
+                return Err(superseded_error(
+                    "another client connected to this tunnel during hello",
+                ));
+            }
+        }
         if status != 200 {
             return Err(transient(format!(
                 "/_system/hello returned {status}; transient — will retry"
@@ -430,6 +481,7 @@ impl TunnelRuntime {
         conn: Arc<ActiveConn>,
         slot: usize,
         force_down: Arc<Notify>,
+        superseded: Arc<AtomicBool>,
     ) {
         while !self.is_stopped() {
             match self.park_one_intake(&conn, slot).await {
@@ -441,6 +493,13 @@ impl TunnelRuntime {
                     });
                 }
                 Ok(None) => continue,
+                // Another client took over: record it (force_down is
+                // payloadless) so the supervisor stops instead of reconnecting.
+                Err(e) if is_superseded_error(&e) => {
+                    superseded.store(true, Ordering::SeqCst);
+                    force_down.notify_one();
+                    return;
+                }
                 // The owner token is no longer valid (e.g. a sibling connection
                 // re-registered): force the supervisor down so it reconnects and
                 // re-hellos for a fresh token, then exit this slot.
@@ -477,6 +536,16 @@ impl TunnelRuntime {
         let body = read_body(resp.into_body(), self.cfg.max_inbound_body_bytes).await?;
 
         if status != 200 {
+            let reason = headers
+                .iter()
+                .find(|(k, _)| k == META_REASON)
+                .map(|(_, v)| v.as_str())
+                .unwrap_or("");
+            // Another client took over this tunnel: terminal (a drain uses a
+            // different reason and falls through to re-park as Ok(None)).
+            if reason == INTAKE_REASON_SUPERSEDED {
+                return Err(superseded_error(format!("intake slot={slot}: taken over")));
+            }
             if status == 401 {
                 return Err(owner_token_invalid(format!(
                     "intake slot={slot} status=401"
@@ -745,6 +814,23 @@ fn is_owner_token_invalid(err: &InkboxError) -> bool {
     matches!(err, InkboxError::Tunnel(m) if m.starts_with("owner-token-invalid:"))
 }
 
+/// Tag for a takeover: another client connected to this tunnel. The
+/// supervisor stops (does not reconnect) on this, like the auth failure.
+fn superseded_error(msg: impl Into<String>) -> InkboxError {
+    InkboxError::Tunnel(format!("tunnel-superseded: {}", msg.into()))
+}
+
+fn is_superseded_error(err: &InkboxError) -> bool {
+    matches!(err, InkboxError::Tunnel(m) if m.starts_with("tunnel-superseded:"))
+}
+
+/// True iff a connection-driver `h2::Error` carries the dedicated superseded
+/// GOAWAY code. Rust reads only the code (no debug bytes), so this is the
+/// reliable takeover channel on the connection itself.
+fn is_superseded_goaway(err: &h2::Error) -> bool {
+    err.reason() == Some(h2::Reason::from(SUPERSEDED_GOAWAY_ERROR_CODE))
+}
+
 /// Cheap pseudo-random in `[0, 1)` for backoff jitter (Python uses
 /// `random.random()`); derived from the clock nanos.
 fn pseudo_rand() -> f64 {
@@ -788,6 +874,33 @@ mod tests {
         assert!(is_auth_error(&tunnel_auth_error("nope")));
         assert!(!is_auth_error(&transient("transient")));
         assert!(is_owner_token_invalid(&owner_token_invalid("x")));
+    }
+
+    #[test]
+    fn superseded_error_classification() {
+        // A takeover is its own terminal reason, distinct from auth / transient
+        // / owner-token so the supervisor stops without reconnecting.
+        assert!(is_superseded_error(&superseded_error("x")));
+        assert!(!is_superseded_error(&transient("x")));
+        assert!(!is_superseded_error(&tunnel_auth_error("x")));
+        assert!(!is_superseded_error(&owner_token_invalid("x")));
+        assert!(!is_auth_error(&superseded_error("x")));
+        assert!(!is_owner_token_invalid(&superseded_error("x")));
+    }
+
+    #[test]
+    fn superseded_goaway_reads_the_dedicated_code() {
+        // Rust reads only the GOAWAY code, so the dedicated code is the reliable
+        // takeover channel. h2::Error::from(Reason) mirrors a received GOAWAY:
+        // reason() surfaces the code (the GOAWAY-then-close survival property).
+        let takeover = h2::Error::from(h2::Reason::from(SUPERSEDED_GOAWAY_ERROR_CODE));
+        assert!(is_superseded_goaway(&takeover));
+
+        // Drain (NO_ERROR) and a generic backpressure code are NOT takeovers.
+        assert!(!is_superseded_goaway(&h2::Error::from(h2::Reason::NO_ERROR)));
+        assert!(!is_superseded_goaway(&h2::Error::from(
+            h2::Reason::ENHANCE_YOUR_CALM
+        )));
     }
 
     #[tokio::test]

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/tunnels/client/_listener.ts
+++ b/sdk/typescript/src/tunnels/client/_listener.ts
@@ -10,7 +10,7 @@ import type { Tunnel } from "../types.js";
 import type { TunnelRuntime } from "./_runtime.js";
 
 export type TunnelStatusCallback = (
-  status: "connecting" | "connected" | "reconnecting" | "closed",
+  status: "connecting" | "connected" | "reconnecting" | "closed" | "superseded",
 ) => void;
 
 /**

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -363,7 +363,7 @@ export class TunnelRuntime {
           throw err;
         }
         if (err instanceof TunnelSupersededError) {
-          this.stopSuperseded();
+          this.stopSuperseded(err);
         }
         // A takeover GOAWAY that lands mid-hello sets `superseded` but surfaces
         // as a plain connection error; go terminal here so we don't reconnect
@@ -572,8 +572,12 @@ export class TunnelRuntime {
     this.superseded = true;
   }
 
-  /** Log, notify, and throw the terminal takeover error (no reconnect). */
-  private stopSuperseded(): never {
+  /**
+   * Log, notify, and throw the terminal takeover error (no reconnect).
+   * Rethrows the original error when given, so its message (which
+   * channel/slot observed the takeover) survives to the caller.
+   */
+  private stopSuperseded(err?: TunnelSupersededError): never {
     // eslint-disable-next-line no-console
     console.warn(
       "tunnel taken over: another client connected to this tunnel, so " +
@@ -582,9 +586,10 @@ export class TunnelRuntime {
         "identity (only one live connection per tunnel is kept).",
     );
     this.notifyStatus("superseded");
-    throw new TunnelSupersededError(
-      "another client connected to this tunnel; not reconnecting",
-    );
+    throw err ??
+      new TunnelSupersededError(
+        "another client connected to this tunnel; not reconnecting",
+      );
   }
 
   /**

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -111,10 +111,26 @@ export const POST_ACTIVE_WAIT_MS = 5_000;
 export const DEFAULT_INBOUND_BODY_BYTES = 32 * 1024 * 1024;
 export const DEFAULT_OUTBOUND_BODY_BYTES = 32 * 1024 * 1024;
 
+// Signals that another client connected to this tunnel and took over: this
+// client must stop and not reconnect. Delivered as a dedicated GOAWAY error
+// code (the reliable channel) plus matching reason strings on the GOAWAY debug
+// data and the intake / hello responses. Must stay in lockstep with the server.
+export const SUPERSEDED_GOAWAY_ERROR_CODE = 0x1201;
+export const GOAWAY_REASON_SUPERSEDED = "superseded";
+export const INTAKE_REASON_SUPERSEDED = "intake-superseded";
+export const HELLO_REASON_SUPERSEDED = "hello-superseded";
+
 export class TunnelAuthError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "TunnelAuthError";
+  }
+}
+
+export class TunnelSupersededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TunnelSupersededError";
   }
 }
 
@@ -152,8 +168,23 @@ function isSessionTerminalError(err: unknown): boolean {
   );
 }
 
+/** Extract a ``reason`` string from a JSON ``{"reason": ...}`` payload. */
+function parseReasonJson(buf: Buffer | undefined | null): string | null {
+  if (buf === undefined || buf === null || buf.length === 0) return null;
+  try {
+    const parsed: unknown = JSON.parse(buf.toString("utf-8"));
+    if (typeof parsed === "object" && parsed !== null) {
+      const reason = (parsed as { reason?: unknown }).reason;
+      if (typeof reason === "string") return reason;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 export type StatusCallback = (
-  status: "connecting" | "connected" | "reconnecting" | "closed",
+  status: "connecting" | "connected" | "reconnecting" | "closed" | "superseded",
 ) => void;
 
 /**
@@ -228,6 +259,8 @@ class Connection {
   responseDeadlineSeconds: number | null = null;
   // Stop parking new intakes once this conn has received GOAWAY.
   draining = false;
+  // Set when this connection was taken over by another client.
+  superseded = false;
   readonly streams = new Map<number, StreamBus>();
   readonly bridgeStreamIds = new Set<number>();
   pingHandle: NodeJS.Timeout | null = null;
@@ -278,6 +311,9 @@ export class TunnelRuntime {
   private wakeSupervisor: (() => void) | null = null;
 
   private stop = false;
+  // Set when another client took over this tunnel: serveForever stops and does
+  // not reconnect. Distinct from a transient drop or a drain.
+  private superseded = false;
   // Dispatch tasks are runtime-scoped (not per-connection): a handoff must
   // let an in-flight handler finish and post its reply on the NEW conn.
   private readonly tasks = new Set<Promise<unknown>>();
@@ -326,6 +362,17 @@ export class TunnelRuntime {
       } catch (err) {
         if (err instanceof TunnelAuthError) {
           this.notifyStatus("closed");
+          throw err;
+        }
+        if (err instanceof TunnelSupersededError) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "tunnel taken over: another client connected to this tunnel, so " +
+              "this client is stopping and will not reconnect. If this is " +
+              "unexpected, check for a second instance running the same " +
+              "identity (only one live connection per tunnel is kept).",
+          );
+          this.notifyStatus("superseded");
           throw err;
         }
         consecutiveFailures += 1;
@@ -461,6 +508,12 @@ export class TunnelRuntime {
         const session = conn.session;
         if (session === null || session.closed || session.destroyed) break;
       }
+      // Another client took over this tunnel: stop, do not reconnect.
+      if (this.superseded) {
+        throw new TunnelSupersededError(
+          "another client connected to this tunnel; not reconnecting",
+        );
+      }
     } finally {
       this.stopPingLoop(conn);
       conn.streams.clear();
@@ -503,6 +556,55 @@ export class TunnelRuntime {
     const w = this.wakeSupervisor;
     this.wakeSupervisor = null;
     if (w !== null) w();
+  }
+
+  // --- takeover (superseded) --------------------------------------------
+
+  /**
+   * True iff a takeover signal on `conn` should stop the runtime. Ignored on
+   * a draining / handoff / non-active connection: that is this client's own
+   * make-before-break predecessor being replaced, not an external takeover.
+   */
+  private supersededIsTerminal(conn: Connection): boolean {
+    return (
+      conn === this.active && !conn.draining && !this.handoffInFlight
+    );
+  }
+
+  /** Record that `conn` was taken over; the supervisor will stop (no reconnect). */
+  private markSuperseded(conn: Connection): void {
+    conn.superseded = true;
+    this.superseded = true;
+  }
+
+  /**
+   * Classify a non-zero GOAWAY: takeover (terminal) vs infra fault (reconnect).
+   * The dedicated code is authoritative; the reason is a belt cross-check.
+   */
+  private maybeMarkSupersededGoaway(
+    conn: Connection,
+    errorCode: number,
+    opaqueData: Buffer | undefined,
+  ): void {
+    const reason = parseReasonJson(opaqueData);
+    const isTakeover =
+      errorCode === SUPERSEDED_GOAWAY_ERROR_CODE ||
+      reason === GOAWAY_REASON_SUPERSEDED;
+    if (!isTakeover) {
+      if (reason === null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `tunnel runtime: non-zero GOAWAY (code=${errorCode}) without a reason; reconnecting`,
+        );
+      }
+      return;
+    }
+    if (!this.supersededIsTerminal(conn)) {
+      // eslint-disable-next-line no-console
+      console.info("tunnel runtime: takeover signal on a draining/handoff connection; ignoring");
+      return;
+    }
+    this.markSuperseded(conn);
   }
 
   // --- make-before-break handoff ----------------------------------------
@@ -627,18 +729,25 @@ export class TunnelRuntime {
       // eslint-disable-next-line no-console
       console.warn("tunnel runtime: h2 session error", err);
     });
-    session.on("goaway", (errorCode: number, lastStreamId: number) => {
-      // eslint-disable-next-line no-console
-      console.info(
-        `tunnel runtime: GOAWAY received error_code=${errorCode} last_stream_id=${lastStreamId}`,
-      );
-      // NO_ERROR GOAWAY is the server's drain signal: stand up a fresh
-      // connection make-before-break. A non-zero code is a real fault —
-      // let the session close and reconnect cold.
-      if (errorCode === 0) {
-        this.beginHandoff(conn);
-      }
-    });
+    session.on(
+      "goaway",
+      (errorCode: number, lastStreamId: number, opaqueData?: Buffer) => {
+        // eslint-disable-next-line no-console
+        console.info(
+          `tunnel runtime: GOAWAY received error_code=${errorCode} last_stream_id=${lastStreamId}`,
+        );
+        // NO_ERROR GOAWAY is the drain signal: stand up a fresh connection
+        // make-before-break. A non-zero code is either a takeover (stop, don't
+        // reconnect) or a real fault (reconnect cold) — classified below. Set
+        // the takeover flag here so it wins over the 'error'/'close' reconnect
+        // path, which the same GOAWAY also drives.
+        if (errorCode === 0) {
+          this.beginHandoff(conn);
+        } else {
+          this.maybeMarkSupersededGoaway(conn, errorCode, opaqueData);
+        }
+      },
+    );
     // Watch the underlying TCP/TLS socket directly. Node's h2 client
     // sometimes loses the connection without emitting ``error`` or
     // ``close`` on the session itself — the underlying socket reliably
@@ -737,6 +846,21 @@ export class TunnelRuntime {
       throw new TunnelAuthError(
         `${ControlPaths.HELLO} returned ${status}; the API key was rejected (check the key matches the tunnel's identity scope, or use an admin-scoped key in the tunnel's org)`,
       );
+    }
+    // Displaced during hello: another client won the race for this tunnel.
+    // Terminal (stop, don't reconnect) so we don't redial and boot the client
+    // that replaced us — unless this is our own draining/handoff predecessor.
+    if (
+      status === 409 &&
+      parseReasonJson(body) === HELLO_REASON_SUPERSEDED
+    ) {
+      if (this.supersededIsTerminal(conn)) {
+        this.superseded = true;
+        throw new TunnelSupersededError(
+          "another client connected to this tunnel during hello",
+        );
+      }
+      throw new Error(`${ControlPaths.HELLO} 409 on a draining conn; will retry`);
     }
     if (status !== 200) {
       throw new Error(
@@ -898,6 +1022,13 @@ export class TunnelRuntime {
       try {
         envelope = await this.parkOneIntake(conn, slot);
       } catch (err) {
+        if (err instanceof TunnelSupersededError) {
+          // Another client took over: force this conn down so the supervisor
+          // observes the terminal flag and stops (no reconnect).
+          this.markSuperseded(conn);
+          try { conn.session?.destroy(); } catch { /* swallow */ }
+          return;
+        }
         if (err instanceof OwnerTokenInvalidError) {
           // eslint-disable-next-line no-console
           console.warn(
@@ -993,6 +1124,17 @@ export class TunnelRuntime {
       console.warn(
         `${ControlPaths.INTAKE} slot=${slot} -> status=${status} reason=${reason}`,
       );
+      // Another client took over this tunnel. Terminal, unless this is our own
+      // draining/handoff predecessor (a normal reconnect). A drain uses a
+      // different reason and falls through to re-park below.
+      if (reason === INTAKE_REASON_SUPERSEDED) {
+        if (this.supersededIsTerminal(conn)) {
+          throw new TunnelSupersededError(
+            `slot=${slot}: another client connected to this tunnel`,
+          );
+        }
+        return null;
+      }
       if (status === "401") {
         throw new OwnerTokenInvalidError(
           `slot=${slot} status=401 reason=${reason}`,
@@ -2126,7 +2268,8 @@ export class TunnelRuntime {
     | "connecting"
     | "connected"
     | "reconnecting"
-    | "closed"): void {
+    | "closed"
+    | "superseded"): void {
     if (this.onStatus !== undefined) {
       try {
         this.onStatus(status);

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -259,8 +259,6 @@ class Connection {
   responseDeadlineSeconds: number | null = null;
   // Stop parking new intakes once this conn has received GOAWAY.
   draining = false;
-  // Set when this connection was taken over by another client.
-  superseded = false;
   readonly streams = new Map<number, StreamBus>();
   readonly bridgeStreamIds = new Set<number>();
   pingHandle: NodeJS.Timeout | null = null;
@@ -365,15 +363,13 @@ export class TunnelRuntime {
           throw err;
         }
         if (err instanceof TunnelSupersededError) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            "tunnel taken over: another client connected to this tunnel, so " +
-              "this client is stopping and will not reconnect. If this is " +
-              "unexpected, check for a second instance running the same " +
-              "identity (only one live connection per tunnel is kept).",
-          );
-          this.notifyStatus("superseded");
-          throw err;
+          this.stopSuperseded();
+        }
+        // A takeover GOAWAY that lands mid-hello sets `superseded` but surfaces
+        // as a plain connection error; go terminal here so we don't reconnect
+        // and boot the client that replaced us.
+        if (this.superseded) {
+          this.stopSuperseded();
         }
         consecutiveFailures += 1;
         // eslint-disable-next-line no-console
@@ -571,10 +567,24 @@ export class TunnelRuntime {
     );
   }
 
-  /** Record that `conn` was taken over; the supervisor will stop (no reconnect). */
-  private markSuperseded(conn: Connection): void {
-    conn.superseded = true;
+  /** Record the takeover; the supervisor will stop and not reconnect. */
+  private markSuperseded(): void {
     this.superseded = true;
+  }
+
+  /** Log, notify, and throw the terminal takeover error (no reconnect). */
+  private stopSuperseded(): never {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "tunnel taken over: another client connected to this tunnel, so " +
+        "this client is stopping and will not reconnect. If this is " +
+        "unexpected, check for a second instance running the same " +
+        "identity (only one live connection per tunnel is kept).",
+    );
+    this.notifyStatus("superseded");
+    throw new TunnelSupersededError(
+      "another client connected to this tunnel; not reconnecting",
+    );
   }
 
   /**
@@ -604,7 +614,7 @@ export class TunnelRuntime {
       console.info("tunnel runtime: takeover signal on a draining/handoff connection; ignoring");
       return;
     }
-    this.markSuperseded(conn);
+    this.markSuperseded();
   }
 
   // --- make-before-break handoff ----------------------------------------
@@ -640,13 +650,21 @@ export class TunnelRuntime {
       // Supervisor was watching oldConn; wake it to follow newConn.
       this.signalSupervisor();
     } catch (err) {
-      // Redial budget exhausted (or auth failure): give up on
-      // make-before-break and fall to the cold reconnect path by forcing
-      // the old session closed so the supervisor returns.
-      // eslint-disable-next-line no-console
-      console.warn("tunnel runtime: handoff failed; reconnecting cold", err);
-      try { oldConn.session?.destroy(); } catch { /* swallow */ }
-      this.signalSupervisor();
+      if (err instanceof TunnelSupersededError) {
+        // External takeover during the handoff hello: `superseded` is set, so
+        // end the old conn and wake the supervisor to stop terminally (no cold
+        // redial, which would boot the client that replaced us).
+        try { oldConn.session?.destroy(); } catch { /* swallow */ }
+        this.signalSupervisor();
+      } else {
+        // Redial budget exhausted (or auth failure): give up on
+        // make-before-break and fall to the cold reconnect path by forcing
+        // the old session closed so the supervisor returns.
+        // eslint-disable-next-line no-console
+        console.warn("tunnel runtime: handoff failed; reconnecting cold", err);
+        try { oldConn.session?.destroy(); } catch { /* swallow */ }
+        this.signalSupervisor();
+      }
     } finally {
       this.handoffInFlight = false;
       this.handoffPromise = null;
@@ -668,7 +686,11 @@ export class TunnelRuntime {
         return conn;
       } catch (err) {
         try { await this.closeConnection(conn); } catch { /* swallow */ }
-        if (err instanceof TunnelAuthError) throw err;
+        // A rejected key or a takeover is terminal; never retry either
+        // (retrying a takeover would boot the client that replaced us).
+        if (err instanceof TunnelAuthError || err instanceof TunnelSupersededError) {
+          throw err;
+        }
         if (Date.now() - start > HANDOFF_REDIAL_BUDGET_MS) {
           throw new Error("handoff redial budget exhausted");
         }
@@ -736,11 +758,10 @@ export class TunnelRuntime {
         console.info(
           `tunnel runtime: GOAWAY received error_code=${errorCode} last_stream_id=${lastStreamId}`,
         );
-        // NO_ERROR GOAWAY is the drain signal: stand up a fresh connection
-        // make-before-break. A non-zero code is either a takeover (stop, don't
-        // reconnect) or a real fault (reconnect cold) — classified below. Set
-        // the takeover flag here so it wins over the 'error'/'close' reconnect
-        // path, which the same GOAWAY also drives.
+        // NO_ERROR GOAWAY = drain (make-before-break handoff). A non-zero code
+        // is a takeover (stop) or a real fault (reconnect cold), classified
+        // below; setting the takeover flag here wins over the 'error'/'close'
+        // reconnect path that the same GOAWAY also drives.
         if (errorCode === 0) {
           this.beginHandoff(conn);
         } else {
@@ -847,20 +868,18 @@ export class TunnelRuntime {
         `${ControlPaths.HELLO} returned ${status}; the API key was rejected (check the key matches the tunnel's identity scope, or use an admin-scoped key in the tunnel's org)`,
       );
     }
-    // Displaced during hello: another client won the race for this tunnel.
-    // Terminal (stop, don't reconnect) so we don't redial and boot the client
-    // that replaced us — unless this is our own draining/handoff predecessor.
+    // Displaced during hello: a strictly-later hello (another client) won the
+    // tunnel. Always terminal, even mid-handoff: the server sends this only
+    // when a newer client has connected, so retrying would re-hello and boot
+    // the client that replaced us.
     if (
       status === 409 &&
       parseReasonJson(body) === HELLO_REASON_SUPERSEDED
     ) {
-      if (this.supersededIsTerminal(conn)) {
-        this.superseded = true;
-        throw new TunnelSupersededError(
-          "another client connected to this tunnel during hello",
-        );
-      }
-      throw new Error(`${ControlPaths.HELLO} 409 on a draining conn; will retry`);
+      this.superseded = true;
+      throw new TunnelSupersededError(
+        "another client connected to this tunnel during hello",
+      );
     }
     if (status !== 200) {
       throw new Error(
@@ -1025,7 +1044,7 @@ export class TunnelRuntime {
         if (err instanceof TunnelSupersededError) {
           // Another client took over: force this conn down so the supervisor
           // observes the terminal flag and stops (no reconnect).
-          this.markSuperseded(conn);
+          this.markSuperseded();
           try { conn.session?.destroy(); } catch { /* swallow */ }
           return;
         }

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -557,14 +557,13 @@ export class TunnelRuntime {
   // --- takeover (superseded) --------------------------------------------
 
   /**
-   * True iff a takeover signal on `conn` should stop the runtime. Ignored on
-   * a draining / handoff / non-active connection: that is this client's own
-   * make-before-break predecessor being replaced, not an external takeover.
+   * True iff a takeover signal on `conn` should stop the runtime. Ignored only
+   * for a conn we ourselves put into make-before-break drain (our own
+   * predecessor, tracked in `this.draining`); a not-yet-active replacement
+   * mid-handoff is a real external takeover, so it stays terminal.
    */
   private supersededIsTerminal(conn: Connection): boolean {
-    return (
-      conn === this.active && !conn.draining && !this.handoffInFlight
-    );
+    return !this.draining.has(conn);
   }
 
   /** Record the takeover; the supervisor will stop and not reconnect. */
@@ -616,7 +615,7 @@ export class TunnelRuntime {
     }
     if (!this.supersededIsTerminal(conn)) {
       // eslint-disable-next-line no-console
-      console.info("tunnel runtime: takeover signal on a draining/handoff connection; ignoring");
+      console.info("tunnel runtime: takeover signal on our own draining predecessor; ignoring");
       return;
     }
     this.markSuperseded();
@@ -1149,8 +1148,8 @@ export class TunnelRuntime {
         `${ControlPaths.INTAKE} slot=${slot} -> status=${status} reason=${reason}`,
       );
       // Another client took over this tunnel. Terminal, unless this is our own
-      // draining/handoff predecessor (a normal reconnect). A drain uses a
-      // different reason and falls through to re-park below.
+      // draining predecessor (a normal reconnect). A drain uses a different
+      // reason and falls through to re-park below.
       if (reason === INTAKE_REASON_SUPERSEDED) {
         if (this.supersededIsTerminal(conn)) {
           throw new TunnelSupersededError(

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -695,6 +695,14 @@ export class TunnelRuntime {
         if (err instanceof TunnelAuthError || err instanceof TunnelSupersededError) {
           throw err;
         }
+        // A takeover GOAWAY that landed mid-hello set `superseded` but surfaced
+        // here as a plain reset/status-0 error; stop now so we don't re-hello
+        // and boot the client that replaced us.
+        if (this.superseded) {
+          throw new TunnelSupersededError(
+            "another client connected to this tunnel during handoff",
+          );
+        }
         if (Date.now() - start > HANDOFF_REDIAL_BUDGET_MS) {
           throw new Error("handoff redial budget exhausted");
         }

--- a/sdk/typescript/src/tunnels/client/index.ts
+++ b/sdk/typescript/src/tunnels/client/index.ts
@@ -65,7 +65,7 @@ export {
   WsProtocolMismatch,
   WsServerDraining,
 } from "./_ws.js";
-export { TunnelAuthError } from "./_runtime.js";
+export { TunnelAuthError, TunnelSupersededError } from "./_runtime.js";
 
 /** Default tunnel zone — used when neither the server nor the state file specifies one. */
 export const PROD_ZONE = "inkboxwire.com";

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.4.17";
+export const VERSION = "0.4.18";

--- a/sdk/typescript/tests/tunnels/fake_h2_server.ts
+++ b/sdk/typescript/tests/tunnels/fake_h2_server.ts
@@ -76,7 +76,7 @@ export interface FakeH2Server {
   sessionCount(): number;
   /** Total `/_system/hello` POSTs seen since start. */
   helloCount(): number;
-  injectGoaway(errorCode?: number): void;
+  injectGoaway(errorCode?: number, opaqueData?: Buffer): void;
   injectRstStream(streamId: number, errorCode: number): void;
   receivedHelloHeaders(): http2.IncomingHttpHeaders | null;
   receivedIntakePosts(): Array<{ slot: number; ownerToken: string }>;
@@ -212,11 +212,9 @@ export async function startFakeH2Server(
         ":status": computed.status,
         "content-type": "application/json",
       });
-      if (computed.status === 200) {
-        stream.end(JSON.stringify(computed.body));
-      } else {
-        stream.end();
-      }
+      // Write the body on every status so non-200 responses (e.g. a
+      // terminal hello with a reason) carry their JSON payload.
+      stream.end(JSON.stringify(computed.body));
       return;
     }
     if (path === "/_system/intake") {
@@ -344,10 +342,13 @@ export async function startFakeH2Server(
     helloCount() {
       return helloCounter;
     },
-    injectGoaway(errorCode = http2.constants.NGHTTP2_NO_ERROR) {
+    injectGoaway(
+      errorCode = http2.constants.NGHTTP2_NO_ERROR,
+      opaqueData?: Buffer,
+    ) {
       for (const session of sessions) {
         try {
-          session.goaway(errorCode);
+          session.goaway(errorCode, undefined, opaqueData);
         } catch {
           /* swallow */
         }

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -111,6 +111,8 @@ describe("TunnelRuntime — superseded (takeover) is terminal", () => {
     const runtime = makeRuntime();
     const servePromise = runtime.serveForever();
     await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+    // The original error's channel detail survives stopSuperseded's rethrow.
+    await expect(servePromise).rejects.toThrow(/during hello/);
     // Displaced hello does not redial and boot the winner.
     expect(fakeServer.helloCount()).toBe(1);
   }, 15_000);

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -126,6 +126,48 @@ describe("TunnelRuntime — superseded (takeover) is terminal", () => {
     const servePromise = runtime.serveForever();
     await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
   }, 15_000);
+
+  it("goes terminal when the flag is set but the error is plain (mid-hello GOAWAY)", async () => {
+    // A takeover GOAWAY landing mid-hello sets `superseded` but the hello
+    // fails with a plain error; serveForever must stop, not reconnect.
+    const statuses: string[] = [];
+    const runtime = makeRuntime((s) => statuses.push(s)) as unknown as {
+      superseded: boolean;
+      runOnce: () => Promise<void>;
+      serveForever: () => Promise<void>;
+    };
+    runtime.runOnce = async () => {
+      runtime.superseded = true;
+      throw new Error("connection closed during hello");
+    };
+    await expect(runtime.serveForever()).rejects.toBeInstanceOf(TunnelSupersededError);
+    expect(statuses).toContain("superseded");
+    expect(statuses).not.toContain("reconnecting");
+  });
+
+  it("makeReplacementConnection re-raises a takeover without retrying", async () => {
+    // A takeover during the handoff hello propagates terminally instead of
+    // being retried within the redial budget (which would boot the winner).
+    let attempts = 0;
+    const runtime = makeRuntime() as unknown as {
+      openConnection: (c: unknown) => Promise<void>;
+      sendHello: (c: unknown) => Promise<void>;
+      startServing: (c: unknown) => void;
+      closeConnection: (c: unknown) => Promise<void>;
+      makeReplacementConnection: () => Promise<unknown>;
+    };
+    runtime.openConnection = async () => undefined;
+    runtime.closeConnection = async () => undefined;
+    runtime.startServing = () => undefined;
+    runtime.sendHello = async () => {
+      attempts += 1;
+      throw new TunnelSupersededError("taken over during handoff");
+    };
+    await expect(
+      runtime.makeReplacementConnection(),
+    ).rejects.toBeInstanceOf(TunnelSupersededError);
+    expect(attempts).toBe(1);
+  });
 });
 
 describe("TunnelRuntime — takeover guard (deploy make-before-break)", () => {

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -170,6 +170,34 @@ describe("TunnelRuntime — superseded (takeover) is terminal", () => {
     ).rejects.toBeInstanceOf(TunnelSupersededError);
     expect(attempts).toBe(1);
   });
+
+  it("makeReplacementConnection stops on the superseded flag despite a plain error", async () => {
+    // A takeover GOAWAY landing mid-hello sets `superseded` but the hello fails
+    // with a plain reset error (not the typed one). The handoff helper must
+    // stop on the first attempt, not keep re-helloing within the redial budget
+    // and repeatedly boot the client that replaced us.
+    let attempts = 0;
+    const runtime = makeRuntime() as unknown as {
+      openConnection: (c: unknown) => Promise<void>;
+      sendHello: (c: unknown) => Promise<void>;
+      startServing: (c: unknown) => void;
+      closeConnection: (c: unknown) => Promise<void>;
+      makeReplacementConnection: () => Promise<unknown>;
+      superseded: boolean;
+    };
+    runtime.openConnection = async () => undefined;
+    runtime.closeConnection = async () => undefined;
+    runtime.startServing = () => undefined;
+    runtime.sendHello = async () => {
+      attempts += 1;
+      runtime.superseded = true; // set by the read loop's GOAWAY handler
+      throw new Error("connection reset during hello"); // plain, not typed
+    };
+    await expect(
+      runtime.makeReplacementConnection(),
+    ).rejects.toBeInstanceOf(TunnelSupersededError);
+    expect(attempts).toBe(1);
+  });
 });
 
 describe("TunnelRuntime — takeover guard (deploy make-before-break)", () => {

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -173,12 +173,14 @@ describe("TunnelRuntime — superseded (takeover) is terminal", () => {
 });
 
 describe("TunnelRuntime — takeover guard (deploy make-before-break)", () => {
-  it("ignores a takeover signal on a draining / handoff / non-active conn", () => {
-    // Reach the private guard directly: a takeover on our own draining
-    // predecessor (or during a handoff) must NOT be treated as terminal.
+  it("is terminal for any conn except our own draining predecessor", () => {
+    // Reach the private guard directly. Only a conn we put into make-before-
+    // break drain (tracked in `draining`) is ignored; a not-yet-active
+    // replacement mid-handoff is a real external takeover and stays terminal.
     const runtime = makeRuntime() as unknown as {
       active: unknown;
       handoffInFlight: boolean;
+      draining: Set<unknown>;
       supersededIsTerminal: (c: unknown) => boolean;
       maybeMarkSupersededGoaway: (
         c: unknown,
@@ -187,25 +189,37 @@ describe("TunnelRuntime — takeover guard (deploy make-before-break)", () => {
       ) => void;
       superseded: boolean;
     };
-    const conn = { draining: false } as { draining: boolean };
-    runtime.active = conn;
+    const active = { draining: false } as { draining: boolean };
+    runtime.active = active;
     runtime.handoffInFlight = false;
-    expect(runtime.supersededIsTerminal(conn)).toBe(true);
+    // active conn, not a drain predecessor -> terminal
+    expect(runtime.supersededIsTerminal(active)).toBe(true);
 
-    conn.draining = true;
-    expect(runtime.supersededIsTerminal(conn)).toBe(false);
-
-    conn.draining = false;
+    // a not-yet-active replacement (not in `draining`) is terminal, even
+    // while a handoff is in flight (regression: previously swallowed)
+    const replacement = { draining: false };
     runtime.handoffInFlight = true;
-    expect(runtime.supersededIsTerminal(conn)).toBe(false);
+    expect(runtime.supersededIsTerminal(replacement)).toBe(true);
 
-    const other = { draining: false };
-    expect(runtime.supersededIsTerminal(other)).toBe(false); // not the active conn
+    // only our own draining predecessor is ignored
+    runtime.draining.add(active);
+    expect(runtime.supersededIsTerminal(active)).toBe(false);
 
-    // A superseded GOAWAY on the draining predecessor leaves us NOT terminal.
-    runtime.handoffInFlight = false;
-    conn.draining = true;
-    runtime.maybeMarkSupersededGoaway(conn, SUPERSEDED_GOAWAY_ERROR_CODE, SUPERSEDED_DEBUG);
+    // A superseded GOAWAY on the draining predecessor leaves us NOT terminal...
+    runtime.maybeMarkSupersededGoaway(
+      active,
+      SUPERSEDED_GOAWAY_ERROR_CODE,
+      SUPERSEDED_DEBUG,
+    );
     expect(runtime.superseded).toBe(false);
+
+    // ...but the same GOAWAY on the in-flight replacement IS terminal. The
+    // intake-superseded path shares this same predicate, so it is covered too.
+    runtime.maybeMarkSupersededGoaway(
+      replacement,
+      SUPERSEDED_GOAWAY_ERROR_CODE,
+      SUPERSEDED_DEBUG,
+    );
+    expect(runtime.superseded).toBe(true);
   });
 });

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -1,0 +1,167 @@
+/**
+ * tests/tunnels/runtime_superseded.test.ts
+ *
+ * Terminal "another client took over this tunnel" (superseded) behavior:
+ * the runtime must stop and NOT reconnect, keying on the dedicated GOAWAY
+ * code / distinct intake + hello reasons, while never mistaking its own
+ * make-before-break reconnect for an external takeover.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as http2 from "node:http2";
+import * as tls from "node:tls";
+import {
+  SUPERSEDED_GOAWAY_ERROR_CODE,
+  TunnelRuntime,
+  TunnelSupersededError,
+} from "../../src/tunnels/client/_runtime.js";
+import { startFakeH2Server, type FakeH2Server } from "./fake_h2_server.js";
+
+let fakeServer: FakeH2Server;
+
+beforeEach(async () => {
+  fakeServer = await startFakeH2Server();
+});
+
+afterEach(async () => {
+  await fakeServer.close();
+});
+
+function makeRuntime(onStatus?: (s: string) => void): TunnelRuntime {
+  return new TunnelRuntime({
+    tunnelId: "11111111-1111-1111-1111-111111111111",
+    apiKey: "ApiKey_test",
+    zone: fakeServer.authority,
+    publicHost: "my-agent.example.com",
+    poolSize: null,
+    dispatch: { forwardTo: "http://127.0.0.1:1" },
+    onStatus,
+    http2Connect: (authority, options) =>
+      http2.connect(authority, {
+        ...(options as object),
+        rejectUnauthorized: false,
+        ca: undefined,
+      } as tls.ConnectionOptions & http2.SecureClientSessionOptions),
+  });
+}
+
+function helloOk(): void {
+  fakeServer.setHelloResponse(200, {
+    owner_token: "tok-1",
+    default_pool_size: 1,
+    response_deadline_seconds: 30,
+    intake_idle_seconds: 600,
+  });
+}
+
+const SUPERSEDED_DEBUG = Buffer.from('{"reason":"superseded"}');
+
+describe("TunnelRuntime — superseded (takeover) is terminal", () => {
+  it("stops and does not reconnect on a superseded GOAWAY (code + reason)", async () => {
+    helloOk();
+    const statuses: string[] = [];
+    const runtime = makeRuntime((s) => statuses.push(s));
+    const servePromise = runtime.serveForever();
+
+    await fakeServer.awaitNextIntakePost(3000);
+    expect(fakeServer.helloCount()).toBe(1);
+
+    fakeServer.injectGoaway(SUPERSEDED_GOAWAY_ERROR_CODE, SUPERSEDED_DEBUG);
+
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+    expect(statuses).toContain("superseded");
+    // No cold redial after a takeover.
+    expect(fakeServer.helloCount()).toBe(1);
+  }, 15_000);
+
+  it("is terminal on the dedicated code alone (debug blob lost)", async () => {
+    helloOk();
+    const runtime = makeRuntime();
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(3000);
+
+    fakeServer.injectGoaway(SUPERSEDED_GOAWAY_ERROR_CODE); // no opaque data
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+  }, 15_000);
+
+  it("reconnects (not terminal) on a non-superseded non-zero GOAWAY", async () => {
+    helloOk();
+    const statuses: string[] = [];
+    const runtime = makeRuntime((s) => statuses.push(s));
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(3000);
+
+    // An infra GOAWAY (not the dedicated code, no superseded reason).
+    fakeServer.injectGoaway(2, Buffer.from('{"reason":"internal"}'));
+
+    // The runtime redials rather than stopping (not terminal).
+    const start = Date.now();
+    while (fakeServer.helloCount() < 2 && Date.now() - start < 5000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(fakeServer.helloCount()).toBeGreaterThanOrEqual(2);
+    expect(statuses).not.toContain("superseded");
+
+    await runtime.aclose();
+    await servePromise.catch(() => undefined);
+  }, 15_000);
+
+  it("is terminal when displaced during hello (409 hello-superseded)", async () => {
+    fakeServer.setHelloResponse(409, { reason: "hello-superseded" });
+    const runtime = makeRuntime();
+    const servePromise = runtime.serveForever();
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+    // Displaced hello does not redial and boot the winner.
+    expect(fakeServer.helloCount()).toBe(1);
+  }, 15_000);
+
+  it("is terminal on a 409 intake-superseded response", async () => {
+    helloOk();
+    fakeServer.setIntakeResponse({
+      status: 409,
+      headers: [["inkbox-reason", "intake-superseded"]],
+      body: Buffer.from(""),
+    });
+    const runtime = makeRuntime();
+    const servePromise = runtime.serveForever();
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+  }, 15_000);
+});
+
+describe("TunnelRuntime — takeover guard (deploy make-before-break)", () => {
+  it("ignores a takeover signal on a draining / handoff / non-active conn", () => {
+    // Reach the private guard directly: a takeover on our own draining
+    // predecessor (or during a handoff) must NOT be treated as terminal.
+    const runtime = makeRuntime() as unknown as {
+      active: unknown;
+      handoffInFlight: boolean;
+      supersededIsTerminal: (c: unknown) => boolean;
+      maybeMarkSupersededGoaway: (
+        c: unknown,
+        code: number,
+        d: Buffer | undefined,
+      ) => void;
+      superseded: boolean;
+    };
+    const conn = { draining: false } as { draining: boolean };
+    runtime.active = conn;
+    runtime.handoffInFlight = false;
+    expect(runtime.supersededIsTerminal(conn)).toBe(true);
+
+    conn.draining = true;
+    expect(runtime.supersededIsTerminal(conn)).toBe(false);
+
+    conn.draining = false;
+    runtime.handoffInFlight = true;
+    expect(runtime.supersededIsTerminal(conn)).toBe(false);
+
+    const other = { draining: false };
+    expect(runtime.supersededIsTerminal(other)).toBe(false); // not the active conn
+
+    // A superseded GOAWAY on the draining predecessor leaves us NOT terminal.
+    runtime.handoffInFlight = false;
+    conn.draining = true;
+    runtime.maybeMarkSupersededGoaway(conn, SUPERSEDED_GOAWAY_ERROR_CODE, SUPERSEDED_DEBUG);
+    expect(runtime.superseded).toBe(false);
+  });
+});


### PR DESCRIPTION
When another client connects to the same tunnel, the earlier client now stops and does not reconnect. Previously it would redial, and two clients on one tunnel could bounce back and forth. Run one client per tunnel; use separate identities for redundancy.

- New `"superseded"` runtime status plus a distinct terminal outcome in all three tunnel clients (Python, TypeScript, Rust). TypeScript exports `TunnelSupersededError`; Python stops out of `serve()` / `wait()`; Rust returns a terminal error from `serve_forever`.
- A normal server redeploy still reconnects seamlessly.
- Tests added for each runtime; SDKs + CLI bumped to `0.4.18`.
