### PR TITLE
SDK 0.4.18: dedicated_imessage_number call origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.4.18 — Dedicated iMessage-line call origin
+
+### Added
+
+- **`dedicated_imessage_number` call origin.** `CallOrigin` gains a third value (TS `CallOrigin.DEDICATED_IMESSAGE_NUMBER`, Rust `CallOrigin::DedicatedImessageNumber`) for calls that ride a single-org iMessage line bound to one agent identity. Unlike `shared_imessage_number` (which hides the line), a `dedicated_imessage_number` call surfaces its `local_phone_number`. Inbound `Call` objects now deserialize this origin across the TypeScript, Python, and Rust SDKs.
+
 ## 0.4.17 — Inline images, CLI attachments, and mark-unread
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.4.17",
+        "@inkbox/sdk": "^0.4.18",
         "commander": "^13.0.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.17",
+    "@inkbox/sdk": "^0.4.18",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -65,11 +65,14 @@ class CallOrigin(StrEnum):
 
     ``dedicated_number`` uses the identity's own provisioned phone number;
     ``shared_imessage_number`` rides the shared iMessage service line, in
-    which case the call has no dedicated ``local_phone_number``.
+    which case the call has no dedicated ``local_phone_number``;
+    ``dedicated_imessage_number`` rides a single-org iMessage line bound to one
+    agent, which does surface its ``local_phone_number``.
     """
 
     DEDICATED_NUMBER = "dedicated_number"
     SHARED_IMESSAGE_NUMBER = "shared_imessage_number"
+    DEDICATED_IMESSAGE_NUMBER = "dedicated_imessage_number"
 
 
 class IncomingCallAction(StrEnum):

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -139,14 +139,17 @@ pub enum CallOrigin {
     #[default]
     DedicatedNumber,
     SharedImessageNumber,
+    DedicatedImessageNumber,
 }
 
 impl CallOrigin {
-    /// The wire string value (`"dedicated_number"` / `"shared_imessage_number"`).
+    /// The wire string value (`"dedicated_number"` / `"shared_imessage_number"`
+    /// / `"dedicated_imessage_number"`).
     pub fn as_str(&self) -> &'static str {
         match self {
             CallOrigin::DedicatedNumber => "dedicated_number",
             CallOrigin::SharedImessageNumber => "shared_imessage_number",
+            CallOrigin::DedicatedImessageNumber => "dedicated_imessage_number",
         }
     }
 }

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -65,6 +65,7 @@ export enum TextMessageOrigin {
 export enum CallOrigin {
   DEDICATED_NUMBER = "dedicated_number",
   SHARED_IMESSAGE_NUMBER = "shared_imessage_number",
+  DEDICATED_IMESSAGE_NUMBER = "dedicated_imessage_number",
 }
 
 /** What happens when a call comes in for an agent identity. */


### PR DESCRIPTION
## Summary

Adds a third `CallOrigin` value, `dedicated_imessage_number`, across the Python, TypeScript, and Rust SDKs, so inbound `Call` objects that ride a single-org iMessage line (bound to one agent identity) deserialize. Unlike `shared_imessage_number`, this origin surfaces its `local_phone_number`.

Rust adds the `CallOrigin::DedicatedImessageNumber` variant + `as_str` arm — without it, deserializing the new wire value would fail. Versions move **0.4.17 → 0.4.18** in lockstep (Python/TS/CLI/Rust + lockfiles) with a CHANGELOG entry.

Server companion (introduces the origin + the dedicated line): inkbox-ai/servers#319