### PR TITLE
SDKs: add blocked_spam_filter to SmsDeliveryStatus (0.4.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.4.20 — Recognize spam-filter-blocked texts
+
+### Fixed
+
+- **`SmsDeliveryStatus` gains `blocked_spam_filter`.** The server persists this status on outbound texts blocked pre-carrier by the Inkbox outbound spam filter, and listing or fetching a conversation containing such a row crashed the Python SDK (`ValueError: 'blocked_spam_filter' is not a valid SmsDeliveryStatus`) and failed deserialization in Rust. All three SDKs now carry the variant. It appears on stored rows only (`texts.list` / `texts.get`); delivery webhooks never fire for blocked sends.
+
 ## 0.4.19 — Inbound email body on webhooks
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.4.19",
+    "@inkbox/sdk": "^0.4.20",
     "commander": "^13.0.0"
   },
   "devDependencies": {

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.4.19";
+export const CLI_VERSION = "0.4.20";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -51,6 +51,9 @@ class SmsDeliveryStatus(StrEnum):
     DELIVERY_FAILED = "delivery_failed"
     DELIVERY_UNCONFIRMED = "delivery_unconfirmed"
     SENDING_FAILED = "sending_failed"
+    # Blocked pre-carrier by the Inkbox outbound spam filter; appears on
+    # stored rows (list/get), never on delivery webhooks.
+    BLOCKED_SPAM_FILTER = "blocked_spam_filter"
 
 
 class TextMessageOrigin(StrEnum):

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.4.19"
+version = "0.4.20"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/sample_data.py
+++ b/sdk/python/tests/sample_data.py
@@ -108,6 +108,29 @@ TEXT_MESSAGE_MMS_DICT = {
     "updated_at": "2026-03-09T00:12:00Z",
 }
 
+TEXT_MESSAGE_SPAM_BLOCKED_DICT = {
+    "id": "dddd4444-0000-0000-0000-0000000000ee",
+    "direction": "outbound",
+    "local_phone_number": "+18335794607",
+    "remote_phone_number": "+15551234567",
+    "text": "**Bold** reads as bot traffic",
+    "type": "sms",
+    "media": None,
+    "is_read": True,
+    "delivery_status": "blocked_spam_filter",
+    "origin": "user_initiated",
+    "error_code": "inkbox_spam_filter",
+    "error_detail": "Markdown formatting reads as bot traffic in SMS.",
+    "sent_at": None,
+    "delivered_at": None,
+    "failed_at": "2026-03-09T00:12:00Z",
+    "conversation_id": "eeee1111-0000-0000-0000-000000000001",
+    "sender_phone_number": None,
+    "recipients": None,
+    "created_at": "2026-03-09T00:12:00Z",
+    "updated_at": "2026-03-09T00:12:00Z",
+}
+
 TEXT_MESSAGE_OUTBOUND_QUEUED_DICT = {
     "id": "dddd4444-0000-0000-0000-0000000000ff",
     "direction": "outbound",

--- a/sdk/python/tests/test_texts.py
+++ b/sdk/python/tests/test_texts.py
@@ -14,6 +14,7 @@ from sample_data import (
     TEXT_MESSAGE_GROUP_DICT,
     TEXT_MESSAGE_MMS_DICT,
     TEXT_MESSAGE_OUTBOUND_QUEUED_DICT,
+    TEXT_MESSAGE_SPAM_BLOCKED_DICT,
 )
 from inkbox.phone.types import SmsDeliveryStatus, TextMessageOrigin
 
@@ -134,6 +135,15 @@ class TestTextsList:
             params={"limit": 50, "offset": 0, "is_blocked": True},
         )
         assert texts[0].is_blocked is True
+
+    def test_hydrates_spam_filter_blocked_row(self, client, transport):
+        """A pre-carrier spam-filter block must not crash list() hydration."""
+        transport.get.return_value = [TEXT_MESSAGE_SPAM_BLOCKED_DICT]
+
+        texts = client._texts.list(NUM_ID)
+
+        assert texts[0].delivery_status is SmsDeliveryStatus.BLOCKED_SPAM_FILTER
+        assert texts[0].error_code == "inkbox_spam_filter"
 
     def test_is_blocked_false(self, client, transport):
         """is_blocked=False keeps admin/JWT view clean of blocked spam."""

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -116,6 +116,9 @@ pub enum SmsDeliveryStatus {
     DeliveryFailed,
     DeliveryUnconfirmed,
     SendingFailed,
+    /// Blocked pre-carrier by the Inkbox outbound spam filter; appears on
+    /// stored rows (list/get), never on delivery webhooks.
+    BlockedSpamFilter,
 }
 
 /// Whether a text was user-initiated or an internal auto-reply.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -46,6 +46,11 @@ export enum SmsDeliveryStatus {
   DELIVERY_FAILED = "delivery_failed",
   DELIVERY_UNCONFIRMED = "delivery_unconfirmed",
   SENDING_FAILED = "sending_failed",
+  /**
+   * Blocked pre-carrier by the Inkbox outbound spam filter; appears on
+   * stored rows (list/get), never on delivery webhooks.
+   */
+  BLOCKED_SPAM_FILTER = "blocked_spam_filter",
 }
 
 /** Whether a text was user-initiated or an internal auto-reply. */

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.4.19";
+export const VERSION = "0.4.20";


### PR DESCRIPTION
## What

The server persists `delivery_status=blocked_spam_filter` on outbound texts blocked pre-carrier by the Inkbox outbound spam filter, but no SDK enum included the value. Consequences today:

- **Python**: `texts.list(...)` / `texts.get(...)` over a conversation containing a blocked row raises `ValueError: 'blocked_spam_filter' is not a valid SmsDeliveryStatus` — the client crashes on data the server legitimately returns. (Found via a live CI failure in the Hermes plugin's delivery-retry suite, confirmed against production data.)
- **Rust**: same rows fail serde deserialization.
- **TypeScript**: no runtime failure, but the enum is incomplete.

## Change

- Add the variant to `SmsDeliveryStatus` in all three SDKs, documented as appearing on stored rows only — delivery webhooks never fire for blocked sends, so the webhook wire types (`SmsDeliveryStatusWire`) are intentionally unchanged.
- Python regression test: hydrating a spam-blocked row through `texts.list()`.
- Lockstep version bump 0.4.19 → 0.4.20 (`@inkbox/sdk`, `inkbox` PyPI, `inkbox` crates.io, `@inkbox/cli`) + CHANGELOG entry.

Once 0.4.20 is on PyPI, the hermes-agent-plugin live suite can raise its `inkbox>=` floor so its CI installs an enum-complete SDK (inkbox-ai/hermes-agent-plugin#45 currently works around this with a best-effort lookup).