### PR TITLE
Bump the two missed lockfile self-entries to 0.4.23

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.4.22"
+version = "0.4.23"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Stacked on #103. The 0.4.22 → 0.4.23 lockstep bump there missed two lockfile self-entries:

- `sdk/python/uv.lock` — the `inkbox` package's own entry (`source = { editable = "." }`)
- `cli/package-lock.json` — the linked `../sdk/typescript` (`@inkbox/sdk`) entry

Both now read 0.4.23; with this, no 0.4.22 remains anywhere outside changelog history.