### PR TITLE
Retry test-org bootstrap/cleanup in SDK integration tests

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -161,7 +161,8 @@ jobs:
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
         run: |
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
               "text": "⚠️ Python SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -246,7 +247,8 @@ jobs:
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
         run: |
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
               "text": "⚠️ TypeScript SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -330,7 +332,8 @@ jobs:
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
         run: |
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
             -H 'Content-Type: application/json' \
             -d '{
               "text": "⚠️ CLI integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -39,16 +39,63 @@ export function loadConfig(): CliIntegrationConfig {
   };
 }
 
+// Gateway-level statuses only: the request provably never completed at the app,
+// so replaying it can't double-create an org. A bare 500 is deliberately absent.
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const MAX_ATTEMPTS = 4;
+const BACKOFF_MS = 2_000;
+
+async function postWithRetry(
+  url: string,
+  init: RequestInit,
+  description: string,
+): Promise<Response> {
+  // Hosted CI runners throw the occasional TLS/TCP reset on the way out. These
+  // calls sit in suite-wide setup/teardown, so one reset would otherwise take
+  // down the entire run.
+  let lastError = "";
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetch(url, init);
+      if (!RETRYABLE_STATUS.has(resp.status)) return resp;
+      lastError = `HTTP ${resp.status}: ${(await resp.text()).slice(0, 200)}`;
+    } catch (err) {
+      // undici surfaces everything as "fetch failed"; the real reason (ECONNRESET,
+      // TLS handshake, DNS) is only on .cause.
+      lastError = err instanceof Error
+        ? `${err.name}: ${err.message}${err.cause instanceof Error ? ` (${err.cause.message})` : ""}`
+        : String(err);
+    }
+
+    if (attempt === MAX_ATTEMPTS) break;
+
+    const delay = BACKOFF_MS * 2 ** (attempt - 1);
+    console.warn(
+      `[cli-integration] ⚠ ${description} failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${lastError} — retrying in ${delay}ms`,
+    );
+    await new Promise((r) => setTimeout(r, delay));
+  }
+
+  throw new Error(
+    `${description} failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`,
+  );
+}
+
 export async function bootstrapTestOrg(config: CliIntegrationConfig): Promise<BootstrapResult> {
   const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
-  const resp = await fetch(`${apiUrl}/testing/create-test-user-organization`, {
-    method: "POST",
-    headers: {
-      "X-Interservice-Secret": config.interserviceSecret,
-      "Content-Type": "application/json",
+  const resp = await postWithRetry(
+    `${apiUrl}/testing/create-test-user-organization`,
+    {
+      method: "POST",
+      headers: {
+        "X-Interservice-Secret": config.interserviceSecret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ create_api_key: true }),
     },
-    body: JSON.stringify({ create_api_key: true }),
-  });
+    "bootstrap test org",
+  );
   if (!resp.ok) {
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
   }
@@ -77,14 +124,18 @@ export async function cleanupTestOrg(
   if (extraCleanupOrgIds && extraCleanupOrgIds.length > 0) {
     account.created_provisional_org_ids = extraCleanupOrgIds;
   }
-  const resp = await fetch(`${apiUrl}/testing/cleanup-test-user-organization`, {
-    method: "POST",
-    headers: {
-      "X-Interservice-Secret": config.interserviceSecret,
-      "Content-Type": "application/json",
+  const resp = await postWithRetry(
+    `${apiUrl}/testing/cleanup-test-user-organization`,
+    {
+      method: "POST",
+      headers: {
+        "X-Interservice-Secret": config.interserviceSecret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ accounts: [account] }),
     },
-    body: JSON.stringify({ accounts: [account] }),
-  });
+    "cleanup test org",
+  );
   if (!resp.ok) {
     throw new Error(`Cleanup failed: ${resp.status} ${await resp.text()}`);
   }

--- a/tests/integration/python/conftest.py
+++ b/tests/integration/python/conftest.py
@@ -62,14 +62,65 @@ class SdkIntegrationContext:
         # Omit when empty to stay compatible with servers predating the field.
         if self.extra_cleanup_org_ids:
             account["created_provisional_org_ids"] = self.extra_cleanup_org_ids
-        resp = httpx.post(
+        resp = post_with_retry(
             f"{api_url}/testing/cleanup-test-user-organization",
             headers={"X-Interservice-Secret": self.config.interservice_secret},
             json={"accounts": [account]},
             timeout=self.config.http_timeout,
+            description="cleanup test org",
         )
         resp.raise_for_status()
         return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Retrying transport
+# ---------------------------------------------------------------------------
+
+# Gateway-level statuses only: the request provably never reached the app, so
+# replaying it can't double-create an org. A bare 500 is deliberately absent.
+RETRYABLE_STATUS = frozenset({429, 502, 503, 504})
+MAX_ATTEMPTS = 4
+BACKOFF_SECONDS = 2.0
+
+
+def post_with_retry(
+    url: str,
+    *,
+    headers: dict[str, str],
+    json: dict[str, Any],
+    timeout: float,
+    description: str,
+) -> httpx.Response:
+    # Hosted CI runners throw the occasional TLS/TCP reset on the way out. These
+    # calls sit in session-scoped setup/teardown, so one reset would otherwise
+    # take down the entire suite.
+    last_error = ""
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            resp = httpx.post(url, headers=headers, json=json, timeout=timeout)
+        except httpx.TransportError as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        else:
+            if resp.status_code not in RETRYABLE_STATUS:
+                return resp
+            last_error = f"HTTP {resp.status_code}: {resp.text[:200]}"
+
+        if attempt == MAX_ATTEMPTS:
+            break
+
+        delay = BACKOFF_SECONDS * 2 ** (attempt - 1)
+        print(
+            f"[sdk-integration] ⚠ {description} failed "
+            f"(attempt {attempt}/{MAX_ATTEMPTS}): {last_error} — retrying in {delay:.0f}s",
+            flush=True,
+        )
+        time.sleep(delay)
+
+    raise RuntimeError(
+        f"{description} failed after {MAX_ATTEMPTS} attempts. Last error: {last_error}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -103,11 +154,12 @@ def sdk_context(sdk_integration_config: SdkIntegrationConfig) -> Generator[SdkIn
     api_url = f"{cfg.base_url.rstrip('/')}/api/v1"
 
     # Bootstrap a fresh test user + org (with API key) via the testing subapp
-    resp = httpx.post(
+    resp = post_with_retry(
         f"{api_url}/testing/create-test-user-organization",
         headers={"X-Interservice-Secret": cfg.interservice_secret},
         json={"create_api_key": True},
         timeout=cfg.http_timeout,
+        description="bootstrap test org",
     )
     resp.raise_for_status()
     data = resp.json()

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -45,16 +45,63 @@ export function loadConfig(): SdkIntegrationConfig {
   };
 }
 
+// Gateway-level statuses only: the request provably never completed at the app,
+// so replaying it can't double-create an org. A bare 500 is deliberately absent.
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const MAX_ATTEMPTS = 4;
+const BACKOFF_MS = 2_000;
+
+async function postWithRetry(
+  url: string,
+  init: RequestInit,
+  description: string,
+): Promise<Response> {
+  // Hosted CI runners throw the occasional TLS/TCP reset on the way out. These
+  // calls sit in globalSetup/teardown, so one reset would otherwise take down
+  // the entire run.
+  let lastError = "";
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetch(url, init);
+      if (!RETRYABLE_STATUS.has(resp.status)) return resp;
+      lastError = `HTTP ${resp.status}: ${(await resp.text()).slice(0, 200)}`;
+    } catch (err) {
+      // undici surfaces everything as "fetch failed"; the real reason (ECONNRESET,
+      // TLS handshake, DNS) is only on .cause.
+      lastError = err instanceof Error
+        ? `${err.name}: ${err.message}${err.cause instanceof Error ? ` (${err.cause.message})` : ""}`
+        : String(err);
+    }
+
+    if (attempt === MAX_ATTEMPTS) break;
+
+    const delay = BACKOFF_MS * 2 ** (attempt - 1);
+    console.warn(
+      `[sdk-integration] ⚠ ${description} failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${lastError} — retrying in ${delay}ms`,
+    );
+    await new Promise((r) => setTimeout(r, delay));
+  }
+
+  throw new Error(
+    `${description} failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`,
+  );
+}
+
 export async function bootstrapTestOrg(config: SdkIntegrationConfig): Promise<BootstrapResult> {
   const apiUrl = `${config.baseUrl.replace(/\/$/, "")}/api/v1`;
-  const resp = await fetch(`${apiUrl}/testing/create-test-user-organization`, {
-    method: "POST",
-    headers: {
-      "X-Interservice-Secret": config.interserviceSecret,
-      "Content-Type": "application/json",
+  const resp = await postWithRetry(
+    `${apiUrl}/testing/create-test-user-organization`,
+    {
+      method: "POST",
+      headers: {
+        "X-Interservice-Secret": config.interserviceSecret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ create_api_key: true }),
     },
-    body: JSON.stringify({ create_api_key: true }),
-  });
+    "bootstrap test org",
+  );
   if (!resp.ok) {
     throw new Error(`Bootstrap failed: ${resp.status} ${await resp.text()}`);
   }
@@ -83,14 +130,18 @@ export async function cleanupTestOrg(
   if (extraCleanupOrgIds && extraCleanupOrgIds.length > 0) {
     account.created_provisional_org_ids = extraCleanupOrgIds;
   }
-  const resp = await fetch(`${apiUrl}/testing/cleanup-test-user-organization`, {
-    method: "POST",
-    headers: {
-      "X-Interservice-Secret": config.interserviceSecret,
-      "Content-Type": "application/json",
+  const resp = await postWithRetry(
+    `${apiUrl}/testing/cleanup-test-user-organization`,
+    {
+      method: "POST",
+      headers: {
+        "X-Interservice-Secret": config.interserviceSecret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ accounts: [account] }),
     },
-    body: JSON.stringify({ accounts: [account] }),
-  });
+    "cleanup test org",
+  );
   if (!resp.ok) {
     throw new Error(`Cleanup failed: ${resp.status} ${await resp.text()}`);
   }


### PR DESCRIPTION
## Why

Scheduled run [29304879804](https://github.com/inkbox-ai/inkbox/actions/runs/29304879804) failed with:

```
httpx.ConnectError: [Errno 104] Connection reset by peer
  conftest.py:106: in sdk_context
```

**Beta was healthy.** The evidence:

- Only 1 of the 6 matrix jobs failed. The other five hit the same beta API in the same seconds and passed.
- The API server logged exactly **five** `POST /api/v1/testing/create-test-user-organization → 200 OK` between 04:00:59 and 04:01:06. Five landed, five passed. The sixth never arrived.
- ECS was at steady state (2/2 tasks, no deploy since the day before). The ALB logged **zero** rejected connections and **zero** client-TLS errors that minute while serving 81 new connections. No WAF anywhere.
- The clincher: after the tests failed, the "Notify Google Chat" step in that same job `curl`ed the Chat webhook — a completely unrelated host — and *also* died with **exit 35 (SSL connect error)**, 150ms later. Same runner, two unrelated destinations, two TLS handshake failures inside one second.

So: a transient TLS/TCP reset on the GitHub runner's egress. Unavoidable — but the blast radius wasn't.

That bootstrap POST was a **single-shot request inside a session-scoped fixture**, so one unlucky reset took down the entire suite and paged the team with a false alarm. The TypeScript and CLI harnesses had the same shape (bare `fetch`, no retry).

## What changed

- **All three harnesses** (`python/conftest.py`, `typescript/helpers.ts`, `cli/helpers.ts`): `bootstrapTestOrg` / `cleanupTestOrg` now go through a `postWithRetry` helper — 4 attempts, exponential backoff (2s → 4s → 8s).
- **Retry policy is deliberately narrow.** Only transport errors and gateway statuses (`429/502/503/504`) are replayed. A bare `500` is *not* retried: those can mean a create partially landed, and replaying would orphan a second org. A `4xx` fails fast, as before.
- **Cleanup retries too**, so a blip during teardown no longer leaks a test org.
- **The notify `curl` gets `--retry 5 --retry-all-errors --max-time 30`** — it hit the same transient, which is why the failure alert was never actually delivered to Chat.
- TS error logging now unwraps `err.cause`, since undici reports every network fault as a useless `TypeError: fetch failed`. Now you get `fetch failed (connect ECONNRESET ...)`.

## Verification

Exercised the retry against a local server that RSTs connections via `SO_LINGER(0)` — the same TCP-reset failure mode the runner hit, not a mock.

Python:
- 2 resets → recovers, returns a usable org ✅
- resets forever → clean `RuntimeError` after 4 attempts (no hang) ✅
- retryable gateway status → recovers ✅
- `400` → returns immediately in 5ms, **not** retried (no double-create) ✅

TypeScript: 2 resets → recovered after 6.08s with the expected 2s/4s backoff ✅

Both TS harnesses typecheck clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)