### PR TITLE
fix(python-sdk): handle missing os.O_NOFOLLOW on Windows in tunnel st…

### DIFF
--- a/sdk/python/inkbox/tunnels/client/_state.py
+++ b/sdk/python/inkbox/tunnels/client/_state.py
@@ -120,7 +120,7 @@ def write_private_file(target: Path, content: bytes) -> None:
     if target.exists() or target.is_symlink():
         _atomic_write(target, content)
         return
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(target, flags, 0o600)
     try:
         os.write(fd, content)

--- a/sdk/python/tests/test_tunnels_data_plane.py
+++ b/sdk/python/tests/test_tunnels_data_plane.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import os
 import stat as _stat
+import sys
 from pathlib import Path
 
 import pytest
+
+_posix_only = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX file-mode and symlink tests do not apply on Windows",
+)
 
 from inkbox.tunnels.client._envelope import parse_envelope
 from inkbox.tunnels.client._state import (
@@ -236,6 +242,7 @@ def test_save_and_load_state_roundtrip(tmp_path: Path):
     assert loaded == entry
 
 
+@_posix_only
 def test_state_file_is_chmod_0600(tmp_path: Path):
     entry = StateEntry(
         tunnel_id="abc", name="my-agent",
@@ -249,6 +256,7 @@ def test_state_file_is_chmod_0600(tmp_path: Path):
     assert mode == 0o600
 
 
+@_posix_only
 def test_state_dir_mode_0700(tmp_path: Path):
     state_dir = tmp_path / "tunnel"
     ensure_private_state_dir(state_dir)
@@ -267,6 +275,7 @@ def test_load_state_returns_none_for_corrupt(tmp_path: Path):
     assert load_state(state_dir) is None
 
 
+@_posix_only
 def test_symlinked_state_dir_is_refused(tmp_path: Path):
     real = tmp_path / "real"
     real.mkdir()
@@ -277,6 +286,7 @@ def test_symlinked_state_dir_is_refused(tmp_path: Path):
         ensure_private_state_dir(link)
 
 
+@_posix_only
 def test_write_private_file_creates_with_0600(tmp_path: Path):
     target = tmp_path / "private.pem"
     write_private_file(target, b"secret bytes")

--- a/sdk/python/tests/test_tunnels_listener_validation.py
+++ b/sdk/python/tests/test_tunnels_listener_validation.py
@@ -8,10 +8,18 @@ URL-validation step let us through.
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from inkbox.tunnels.client import _listener
 from inkbox.tunnels.client._listener import connect
+
+
+_posix_only = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="connect() is POSIX-only; _check_posix() blocks on Windows",
+)
 
 
 class _FakeInkbox:
@@ -29,6 +37,7 @@ def _patch_bootstrap_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_listener, "bootstrap", _stub)
 
 
+@_posix_only
 def test_forward_to_https_loopback_passes(monkeypatch: pytest.MonkeyPatch):
     """https:// loopback flows through validation cleanly."""
     _patch_bootstrap_raises(monkeypatch)
@@ -40,6 +49,7 @@ def test_forward_to_https_loopback_passes(monkeypatch: pytest.MonkeyPatch):
         )
 
 
+@_posix_only
 def test_forward_to_http_loopback_passes(monkeypatch: pytest.MonkeyPatch):
     """http:// loopback passes synchronous validation."""
     _patch_bootstrap_raises(monkeypatch)
@@ -51,6 +61,7 @@ def test_forward_to_http_loopback_passes(monkeypatch: pytest.MonkeyPatch):
         )
 
 
+@_posix_only
 def test_forward_to_callable_passes(monkeypatch: pytest.MonkeyPatch):
     """An ASGI callable as `forward_to` is accepted (no URL-only guard)."""
     _patch_bootstrap_raises(monkeypatch)


### PR DESCRIPTION
## Summary

This PR fixes an `AttributeError` that occurs on Windows when the Python SDK attempts to write private tunnel state files.

The root cause is a direct reference to `os.O_NOFOLLOW`, which is a POSIX-only constant and is not defined on Windows. This change makes the implementation platform-safe while preserving the existing security behavior on POSIX systems.

**Closes #111**

---

## What Changed

### `sdk/python/inkbox/tunnels/client/_state.py`

Replaced the direct reference to `os.O_NOFOLLOW` with a safe `getattr` fallback, mirroring the approach already used by the TypeScript SDK (`fs.constants.O_NOFOLLOW ?? 0`).

```diff
- flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW
+ flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
```

**Behavior**

- **Linux / macOS (POSIX):** `O_NOFOLLOW` is still applied, so behavior remains unchanged.
- **Windows:** Falls back to `0`, preventing the `AttributeError` while allowing the file operation to proceed normally.

---

### `sdk/python/tests/test_tunnels_data_plane.py`

Added a reusable `@_posix_only` marker (`pytest.mark.skipif`) to skip tests that rely on POSIX-specific filesystem behavior unavailable on Windows.

| Test | Reason for skipping on Windows |
|------|--------------------------------|
| `test_state_file_is_chmod_0600` | Windows does not enforce POSIX file permission bits (`chmod 0600`). |
| `test_state_dir_mode_0700` | Windows does not enforce POSIX directory permission bits. |
| `test_symlinked_state_dir_is_refused` | `os.symlink()` typically requires elevated privileges on Windows. |
| `test_write_private_file_creates_with_0600` | Windows does not enforce POSIX file mode bits. |

---

### `sdk/python/tests/test_tunnels_listener_validation.py`

Added the same `@_posix_only` marker to tests that invoke `connect()`.

The data-plane implementation is intentionally POSIX-only, and `connect()` raises `NotImplementedError` on Windows. These tests are therefore not applicable on Windows.

---

## Test Results

```text
40 passed, 7 skipped, 0 failed
```

All skipped tests are intentionally POSIX-only and continue to run successfully on Linux and macOS CI.

---

## Why This Change?

- Prevents an `AttributeError` on Windows.
- Preserves the existing security behavior on POSIX platforms.
- Keeps the Python SDK consistent with the TypeScript SDK implementation.
- Improves cross-platform compatibility without changing behavior on supported POSIX systems.

---

## Related

- Mirrors the TypeScript SDK implementation:

```ts
fs.constants.O_NOFOLLOW ?? 0
```

- No behavior change on POSIX platforms.
- No new dependencies introduced.