### PR TITLE
Fix exact-version CLI publishing

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,11 +18,13 @@ Each package has its own `publish.sh`: **dry run by default**, `--prod` to publi
 | `sdk/python/pyproject.toml` (+ `uv.lock` self-entry — run `uv lock`) | `version` |
 | `sdk/typescript/package.json` (+ `package-lock.json` self-version) | `version` |
 | `sdk/typescript/src/version.ts` | `VERSION` (User-Agent constant; unit-tested against package.json) |
-| `cli/package.json` (+ `package-lock.json`) | `version` **and** the `@inkbox/sdk` dependency → `^<new version>` |
+| `cli/package.json` (+ `package-lock.json`) | `version` **and** the `@inkbox/sdk` dependency → exact `<new version>` |
 | `cli/src/client.ts` | `CLI_VERSION` (User-Agent constant) |
 | `sdk/rust/Cargo.toml` (+ `Cargo.lock` `inkbox` entry) | `version` |
 
-The CLI declares `@inkbox/sdk: ^<version>` and `cli/publish.sh` refuses to publish unless that matches `sdk/typescript`'s version — so bump it too.
+The CLI pins `@inkbox/sdk` to the exact release version, and `cli/publish.sh`
+refuses to publish unless that matches the TypeScript SDK version — so bump all
+three values together.
 
 ## 2. Update the changelog
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "inkbox": "./dist/index.js"
+    "inkbox": "dist/index.js"
   },
   "files": [
     "dist",
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/inkbox-ai/inkbox",
+    "url": "git+https://github.com/inkbox-ai/inkbox.git",
     "directory": "cli"
   },
   "homepage": "https://inkbox.ai",

--- a/cli/publish.sh
+++ b/cli/publish.sh
@@ -17,11 +17,10 @@ fi
 
 CLI_SDK_DEP="$(node -p "require('$REPO_ROOT/cli/package.json').dependencies['@inkbox/sdk']")"
 SDK_VERSION="$(node -p "require('$REPO_ROOT/sdk/typescript/package.json').version")"
-EXPECTED_CLI_SDK_DEP="^${SDK_VERSION}"
 
-if [[ "$CLI_SDK_DEP" != "$EXPECTED_CLI_SDK_DEP" ]]; then
+if [[ "$CLI_SDK_DEP" != "$SDK_VERSION" ]]; then
   echo "Error: cli/package.json depends on @inkbox/sdk@$CLI_SDK_DEP, but sdk/typescript/package.json is version $SDK_VERSION."
-  echo "Expected cli/package.json to declare @inkbox/sdk as $EXPECTED_CLI_SDK_DEP before publishing."
+  echo "Expected cli/package.json to pin @inkbox/sdk exactly to $SDK_VERSION before publishing."
   exit 1
 fi
 


### PR DESCRIPTION
## Decisions

- **Dependency policy:** Keep the CLI pinned to the exact TypeScript SDK release and validate exact equality because all packages publish in lockstep.

## Changes

- Updates the CLI publish guard to accept the exact SDK version declared by the package.
- Updates release documentation to require exact-version CLI dependency pins.
- Normalizes the CLI binary and repository metadata so npm publishes without auto-corrections.

## Verification

- `bash -n cli/publish.sh` — passed.
- `(cd cli && ./publish.sh)` — build and npm dry-run publish passed for `@inkbox/cli@0.4.26` with no metadata warnings.
- `git diff --check` — passed.