### PR TITLE
Restore CLI SDK caret range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 
 ### Changed
 
-- Version bumped to 0.4.26 across `@inkbox/sdk` (TypeScript), `inkbox` (Python), `@inkbox/cli`, and `inkbox` (Rust). The CLI pins exactly `@inkbox/sdk` 0.4.26 so the packages install and release in lockstep; it has no new dedicated-number commands in this release.
+- Version bumped to 0.4.26 across `@inkbox/sdk` (TypeScript), `inkbox` (Python), `@inkbox/cli`, and `inkbox` (Rust). The CLI depends on `@inkbox/sdk` `^0.4.26`; it has no new dedicated-number commands in this release.
 
 ### Compatibility and rollout
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- CLI version moved in lockstep with `@inkbox/sdk` 0.4.26 and pins that exact SDK version. This release adds no new CLI commands; dedicated iMessage number management is available through the SDKs.
+- CLI version moved in lockstep with `@inkbox/sdk` 0.4.26 and depends on `^0.4.26`. This release adds no new CLI commands; dedicated iMessage number management is available through the SDKs.
 
 ## 0.4.25 — Proxy support (HTTP_PROXY / HTTPS_PROXY / NO_PROXY)
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.26",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "0.4.26",
+        "@inkbox/sdk": "^0.4.26",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "0.4.26",
+    "@inkbox/sdk": "^0.4.26",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/tests/version.test.mjs
+++ b/cli/tests/version.test.mjs
@@ -24,7 +24,7 @@ test("CLI_VERSION matches package.json version (the User-Agent constant must not
   assert.equal(CLI_VERSION, pkg.version);
 });
 
-test("all packages share one version and the CLI pins that exact SDK version", () => {
+test("all packages share one version and the CLI targets that SDK release", () => {
   const cliPackage = readJson("../package.json");
   const cliLock = readJson("../package-lock.json");
   const typescriptPackage = readJson("../../sdk/typescript/package.json");
@@ -34,11 +34,14 @@ test("all packages share one version and the CLI pins that exact SDK version", (
   assert.equal(typescriptPackage.version, cliPackage.version);
   assert.equal(pythonVersion, cliPackage.version);
   assert.equal(rustVersion, cliPackage.version);
-  assert.equal(cliPackage.dependencies["@inkbox/sdk"], cliPackage.version);
+  assert.equal(
+    cliPackage.dependencies["@inkbox/sdk"],
+    `^${cliPackage.version}`,
+  );
   assert.equal(cliLock.packages[""].version, cliPackage.version);
   assert.equal(
     cliLock.packages[""].dependencies["@inkbox/sdk"],
-    cliPackage.version,
+    `^${cliPackage.version}`,
   );
   assert.equal(
     cliLock.packages["../sdk/typescript"].version,


### PR DESCRIPTION
## Decisions

- **CLI dependency range:** Use `^0.4.26` for `@inkbox/sdk` so the CLI manifest matches the published package and the existing release guard.

## Changes

- Changes the CLI SDK dependency and lockfile entry to `^0.4.26`.
- Updates the lockstep version assertion for the caret range.
- Corrects the root and CLI changelogs to describe the published dependency.

## Verification

- `npm test` in `cli/` — 40 passed.
- `./publish.sh` passed dependency validation and reached npm; the registry correctly rejected the dry run because `@inkbox/cli@0.4.26` is already published.
- `npm view @inkbox/cli@0.4.26` confirms the live package uses `@inkbox/sdk: ^0.4.26` and exposes the `inkbox` binary.
- `git diff --check` — passed.