### PR TITLE
CLI: support shared iMessage-line call origination

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ inkbox email list -i my-agent --limit 10
 # Place a phone call
 inkbox phone call -i my-agent --to +15551234567
 
+# Or call over an existing shared iMessage connection (no dedicated number)
+inkbox phone call -i my-agent --to +15551234567 \
+  --origination shared_imessage_number
+
 # Send a text message (SMS/MMS; comma-separate --to for groups)
 inkbox text send -i my-agent --to +15551234567 --text "Hi from my agent!"
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -204,6 +204,8 @@ inkbox phone call -i <handle>                # Place an outbound call
   --hosted                                   #   Let Inkbox Voice AI drive the call
                                              #     (requires --reason; conflicts with --ws-url)
   --reason <text>                            #   Voice AI's task brief — what to accomplish
+  --origination <origin>                     #   dedicated_number (default) or
+                                             #     shared_imessage_number
 
 inkbox phone calls -i <handle>               # List calls
   --limit <n>                                #   Max results (default: 50)
@@ -234,6 +236,11 @@ inkbox phone hosted-agent set -i <handle>    # Set it — full replace: an omitt
   --model <model>                            #   Model override
   --instructions <text>                      #   Per-identity steering prompt
 ```
+
+Shared origination uses the identity's active iMessage-line assignment and
+does not require a dedicated phone number. The recipient must already have a
+shared iMessage connection to the identity; otherwise the call fails with
+`409 no_shared_connection`.
 
 ### text
 

--- a/cli/src/commands/phone.ts
+++ b/cli/src/commands/phone.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { CallMode, IncomingCallAction } from "@inkbox/sdk";
+import { CallMode, CallOrigin, IncomingCallAction } from "@inkbox/sdk";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
@@ -10,6 +10,7 @@ interface PlaceCallCommandOptions {
   wsUrl?: string;
   hosted?: boolean;
   reason?: string;
+  origination?: CallOrigin;
 }
 
 interface PlaceCallOptions {
@@ -17,6 +18,7 @@ interface PlaceCallOptions {
   clientWebsocketUrl?: string;
   mode?: CallMode;
   reason?: string;
+  origination?: CallOrigin;
 }
 
 export function buildPlaceCallOptions(
@@ -42,6 +44,9 @@ export function buildPlaceCallOptions(
     callOptions.mode = CallMode.HOSTED_AGENT;
     callOptions.reason = cmdOpts.reason;
   }
+  if (cmdOpts.origination) {
+    callOptions.origination = cmdOpts.origination;
+  }
   return { callOptions };
 }
 
@@ -58,6 +63,10 @@ export function registerPhoneCommands(program: Command): void {
     .option("--ws-url <url>", "WebSocket URL (wss://) for audio bridging")
     .option("--hosted", "Let Inkbox Voice AI drive the call (requires --reason)")
     .option("--reason <text>", "Voice AI's task brief — what to accomplish")
+    .option(
+      "--origination <origin>",
+      "Call origin: dedicated_number or shared_imessage_number",
+    )
     .action(
       withErrorHandler(async function (
         this: Command,
@@ -78,6 +87,7 @@ export function registerPhoneCommands(program: Command): void {
             id: call.id,
             from: call.localPhoneNumber,
             to: call.remotePhoneNumber,
+            origin: call.origin,
             status: call.status,
             mode: call.mode,
             reason: call.reason,

--- a/cli/tests/phone-command.test.mjs
+++ b/cli/tests/phone-command.test.mjs
@@ -14,27 +14,60 @@ test("buildPlaceCallOptions builds a plain client-driven call", () => {
   });
 });
 
-test("buildPlaceCallOptions forwards the ws url on client-driven calls", () => {
+test("buildPlaceCallOptions forwards the ws url and origination on client-driven calls", () => {
   const result = buildPlaceCallOptions({
     identity: "support-bot",
     to: "+15551234567",
     wsUrl: "wss://agent.example.com/ws",
+    origination: "shared_imessage_number",
   });
 
   assert.deepEqual(result, {
     callOptions: {
       toNumber: "+15551234567",
       clientWebsocketUrl: "wss://agent.example.com/ws",
+      origination: "shared_imessage_number",
     },
   });
 });
 
-test("buildPlaceCallOptions builds a hosted call with mode and reason", () => {
+test("buildPlaceCallOptions forwards shared iMessage origination", () => {
+  const result = buildPlaceCallOptions({
+    identity: "support-bot",
+    to: "+15551234567",
+    origination: "shared_imessage_number",
+  });
+
+  assert.deepEqual(result, {
+    callOptions: {
+      toNumber: "+15551234567",
+      origination: "shared_imessage_number",
+    },
+  });
+});
+
+test("buildPlaceCallOptions forwards explicit dedicated origination", () => {
+  const result = buildPlaceCallOptions({
+    identity: "support-bot",
+    to: "+15551234567",
+    origination: "dedicated_number",
+  });
+
+  assert.deepEqual(result, {
+    callOptions: {
+      toNumber: "+15551234567",
+      origination: "dedicated_number",
+    },
+  });
+});
+
+test("buildPlaceCallOptions builds a shared hosted call with mode and reason", () => {
   const result = buildPlaceCallOptions({
     identity: "support-bot",
     to: "+15551234567",
     hosted: true,
     reason: "Book a cleaning next week, mornings preferred",
+    origination: "shared_imessage_number",
   });
 
   assert.deepEqual(result, {
@@ -42,6 +75,7 @@ test("buildPlaceCallOptions builds a hosted call with mode and reason", () => {
       toNumber: "+15551234567",
       mode: "hosted_agent",
       reason: "Book a cleaning next week, mornings preferred",
+      origination: "shared_imessage_number",
     },
   });
 });

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -242,6 +242,7 @@ All phone commands are identity-scoped and require `-i <handle>`.
 ```bash
 inkbox phone call -i <handle> --to +15551234567 --ws-url wss://example.com/ws
 inkbox phone call -i <handle> --to +15551234567 --hosted --reason "Confirm tomorrow's 3pm appointment"
+inkbox phone call -i <handle> --to +15551234567 --origination shared_imessage_number
 inkbox phone calls -i <handle> --limit 10 --offset 0
 inkbox phone hangup <call-id> -i <handle>
 inkbox phone transcripts <call-id> -i <handle>
@@ -252,7 +253,14 @@ inkbox phone hosted-agent get -i <handle>
 inkbox phone hosted-agent set -i <handle> --voice <voice> --model <model> --instructions <text>
 ```
 
-Before placing a call, confirm the destination number and the websocket URL (or the `--reason` task brief for Voice AI calls) with the user.
+Before placing a call, confirm the destination number, origination, and the
+websocket URL (or the `--reason` task brief for Voice AI calls) with the user.
+
+`--origination` selects `dedicated_number` (the default) or
+`shared_imessage_number`. Shared-line calls use the identity's iMessage-line
+assignment and do not require a dedicated phone number. The recipient must
+already have a shared iMessage connection to the identity; otherwise the call
+fails with `409 no_shared_connection`.
 
 `--hosted` places a call Inkbox Voice AI drives end to end
 — no WebSocket, no code. It requires `--reason` (the agent's task brief)


### PR DESCRIPTION
## Problem

The SDKs can place calls through either an identity's dedicated number or its shared iMessage-line assignment, but `inkbox phone call` exposed only the default dedicated-number path. Identities without a dedicated number therefore could not place shared-line calls through the CLI even though the underlying SDK already supported them.

## Changes

- add `--origination <origin>` to `inkbox phone call`
- forward `dedicated_number` and `shared_imessage_number` to `AgentIdentity.placeCall()`
- preserve existing behavior when the option is omitted, allowing the SDK to default to `dedicated_number`
- include the server-returned `origin` in immediate call output; this makes shared calls understandable when `from` is null because the shared line is intentionally not exposed
- document the flag in the root quickstart, CLI README, and CLI agent skill
- document that shared origination needs an existing shared iMessage connection and otherwise returns `409 no_shared_connection`
- update the agent skill to confirm origination before placing a billable call

## Supported combinations

The option is forwarded independently of who drives the call, so it works with:

- the default client-driven call flow
- `--ws-url` audio bridging
- `--hosted --reason ...` Inkbox Voice AI calls

Example:

```bash
inkbox phone call -i my-agent --to +15551234567 \
  --origination shared_imessage_number
```

## Validation behavior

The CLI keeps its existing shape-only validation model. Hosted/reason/WebSocket conflicts still fail locally, while origination policy and unknown values remain server-validated and surface as normal API errors. This avoids duplicating server policy in the CLI.

## Tests

Added coverage for:

- omitted origination preserving the existing default path
- explicit `dedicated_number` forwarding
- `shared_imessage_number` forwarding
- shared origination with `--ws-url`
- shared origination with hosted Voice AI mode and reason
- existing hosted/reason/WebSocket conflict behavior

Verified locally with the repository's declared runtime:

- Node.js `v22.23.1`
- `npm test`: 42 passed, 0 failed
- TypeScript build: passed
- CLI `phone call --help`: new option rendered correctly
- `git diff --check`: passed

A live call was not placed because it requires a real shared assignment and creates a billable external side effect. Identity routing for shared origination is already covered by the SDK's `AgentIdentity.placeCall()` tests.

## Release scope

This PR does not bump package versions or changelogs. The repository releases Python, TypeScript, CLI, and Rust packages in lockstep, so release metadata is left to the coordinated maintainer release.

Closes #91