### PR TITLE
Extend integration email delivery timeout

### DIFF
--- a/tests/integration/cli/helpers.ts
+++ b/tests/integration/cli/helpers.ts
@@ -34,7 +34,7 @@ export function loadConfig(): CliIntegrationConfig {
     interserviceSecret,
     environment,
     verbose: process.env.SDK_INTEGRATION_VERBOSE === "1",
-    pollTimeoutMs: 240_000,
+    pollTimeoutMs: 600_000,
     pollIntervalMs: 5_000,
   };
 }

--- a/tests/integration/cli/vitest.config.ts
+++ b/tests/integration/cli/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 300_000,
+    testTimeout: 660_000,
     include: ["**/*.test.ts"],
   },
 });

--- a/tests/integration/typescript/helpers.ts
+++ b/tests/integration/typescript/helpers.ts
@@ -40,7 +40,7 @@ export function loadConfig(): SdkIntegrationConfig {
     environment,
     verbose: process.env.SDK_INTEGRATION_VERBOSE === "1",
     httpTimeout: 60_000,
-    pollTimeout: 240_000,
+    pollTimeout: 600_000,
     pollInterval: 5_000,
   };
 }

--- a/tests/integration/typescript/vitest.config.ts
+++ b/tests/integration/typescript/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 300_000,
+    testTimeout: 660_000,
     include: ["**/*.test.ts"],
     // One bootstrap per `vitest run`, shared across every test file in this dir
     globalSetup: ["./globalSetup.ts"],


### PR DESCRIPTION
## Decisions

- **Email delivery timeout:** Allow 10 minutes because live delivery can exceed the previous 4-minute polling window.
- **Test runner ceiling:** Allow 11 minutes so the polling timeout can complete before Vitest terminates the test.

## Changes

- Increase TypeScript SDK integration email polling from 4 to 10 minutes.
- Increase CLI integration email polling from 4 to 10 minutes.
- Raise both suites' per-test timeout to 11 minutes.

## Verification

- `git diff --check`
- Targeted TypeScript compilation of the changed helpers and Vitest configs with Node typings
- Live integration coverage will run in CI.