### PR TITLE
fix: make O_NOFOLLOW conditional for Windows compatibility (#111)

### DIFF
--- a/sdk/python/inkbox/tunnels/client/_state.py
+++ b/sdk/python/inkbox/tunnels/client/_state.py
@@ -120,7 +120,7 @@ def write_private_file(target: Path, content: bytes) -> None:
     if target.exists() or target.is_symlink():
         _atomic_write(target, content)
         return
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(target, flags, 0o600)
     try:
         os.write(fd, content)


### PR DESCRIPTION
Summary

Fixes AttributeError: module 'os' has no attribute 'O_NOFOLLOW' when the Python SDK writes private tunnel state files on Windows.

os.O_NOFOLLOW is a POSIX-only flag and is not defined in Python's os module on Windows. The fix conditionally includes the flag only when available, matching the cross-platform pattern already used in the TypeScript SDK.

---
Changes

- sdk/python/inkbox/tunnels/client/_state.py:123 — Use getattr(os, "O_NOFOLLOW", 0) instead of directly referencing os.O_NOFOLLOW

# Before
flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW

# After
flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)

---
Testing

- Verified the original AttributeError no longer occurs on Windows
- Ran targeted test: test_write_private_file_creates_with_0600 — now proceeds past file creation (fails on separate Windows permission assertion, pre-existing)
- Full test suite: 948 pass, 7 pre-existing Windows-specific failures unchanged (POSIX mode assertions, symlink privileges, connect() POSIX guard)

---
Rationale

- Prevents crash on Windows before any file operation
- Preserves security behavior on POSIX (symlink refusal via O_NOFOLLOW)
- Consistent with TypeScript SDK: fs.constants.O_NOFOLLOW ?? 0
- Minimal, focused change — single line, no behavioral change on Linux/macOS

---
Related

Closes #111