### PR TITLE
release: Voice AI authority inheritance in 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.5.9 — Voice AI authority inheritance
+
+### Changed
+
+- Voice AI outbound calls now treat an omitted authority mode as “use the
+  identity's saved Voice AI authority.” Python, TypeScript, Rust, and the CLI
+  continue to omit the wire field unless the caller supplies an override.
+- Explicit `contact_scoped` remains a safe per-call downscope. Explicit `yolo`
+  requires an admin credential only when it exceeds the identity's saved
+  authority.
+- Documentation, command help, and exact-wire tests now distinguish an omitted
+  inherited default from an explicit override.
+- Python, TypeScript, Rust, and CLI versions moved in lockstep to 0.5.9; the CLI
+  now depends on `@inkbox/sdk` `^0.5.9`.
+
+### Compatibility and rollout
+
+- Existing method signatures and wire names are unchanged. Older API versions
+  may still resolve an omitted authority as `contact_scoped`; use an explicit
+  override when targeting mixed API versions.
+
 ## 0.5.8 — Hosted-agent authority and voicemail detection
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ inkbox phone call -i my-agent --to +15551234567
 inkbox phone call -i my-agent --to +15551234567 \
   --origination shared_imessage_number
 
-# Give one hosted-agent call broader authority (requires an admin API key).
+# Override one Voice AI call to use broader authority. This requires an admin
+# API key unless the identity's saved authority is already yolo.
 inkbox phone call -i my-agent --to +15551234567 \
   --hosted --reason "Coordinate the appointment and send confirmations." \
   --authority-mode yolo

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.9 — Voice AI authority inheritance
+
+### Changed
+
+- `inkbox phone call --hosted` omits the authority override unless
+  `--authority-mode` is supplied, allowing the call to inherit the identity's
+  saved Voice AI authority.
+- `--authority-mode contact_scoped` explicitly downscopes one call.
+  `--authority-mode yolo` requires an admin credential only when it exceeds the
+  saved authority.
+- CLI version moved in lockstep to 0.5.9 and now depends on `@inkbox/sdk`
+  `^0.5.9`.
+
+### Compatibility
+
+- Command names and flags are unchanged. Older API versions may still resolve an
+  omitted authority as `contact_scoped`.
+
 ## 0.5.8 — Hosted-agent authority and voicemail detection
 
 ### Added

--- a/cli/README.md
+++ b/cli/README.md
@@ -203,8 +203,8 @@ inkbox phone call -i <handle>                # Place an outbound call
   --hosted                                   #   Let Inkbox Voice AI drive the call
                                              #     (requires --reason; conflicts with --ws-url)
   --reason <text>                            #   Voice AI's task brief — what to accomplish
-  --authority-mode <mode>                    #   contact_scoped (default) or yolo;
-                                             #     yolo requires --hosted and an admin API key
+  --authority-mode <mode>                    #   Optional contact_scoped or yolo override;
+                                             #     omit to inherit the saved Voice AI authority
   --no-voicemail-detection                   #   Stay connected after voicemail is detected
   --origination <origin>                     #   dedicated_number (default) or
                                              #     shared_imessage_number or
@@ -243,7 +243,7 @@ inkbox phone hosted-agent set -i <handle>    # Set it — full replace: an omitt
   --model <model>                            #   Model override
   --instructions <text>                      #   Per-identity steering prompt
 
-inkbox phone hosted-agent authority-mode yolo -i <handle>  # Future incoming calls; admin API key
+inkbox phone hosted-agent authority-mode yolo -i <handle>  # Saved inbound/outbound default; admin API key
 ```
 
 Shared origination uses the identity's active iMessage-line assignment and

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.5.8",
+        "@inkbox/sdk": "^0.5.9",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.5.8",
+    "@inkbox/sdk": "^0.5.9",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.5.8";
+export const CLI_VERSION = "0.5.9";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/phone.ts
+++ b/cli/src/commands/phone.ts
@@ -103,7 +103,7 @@ export function registerPhoneCommands(program: Command): void {
     .option("--reason <text>", "Voice AI's task brief — what to accomplish")
     .option(
       "--authority-mode <mode>",
-      "Hosted-agent authority: contact_scoped or yolo; yolo requires an admin API key",
+      "Voice AI authority override: contact_scoped or yolo; omit to inherit the saved default",
     )
     .option(
       "--origination <origin>",
@@ -434,7 +434,7 @@ export function registerPhoneCommands(program: Command): void {
 
   hostedAgent
     .command("authority-mode <mode>")
-    .description("Set authority for future incoming hosted calls (admin API key)")
+    .description("Set the saved authority for future Voice AI calls (admin API key)")
     .requiredOption("-i, --identity <handle>", "Agent identity handle")
     .action(
       withErrorHandler(async function (

--- a/cli/tests/phone-command.test.mjs
+++ b/cli/tests/phone-command.test.mjs
@@ -182,7 +182,7 @@ test("buildPlaceCallOptions rejects an unknown origination", () => {
   });
 });
 
-test("buildPlaceCallOptions builds a shared hosted call with mode and reason", () => {
+test("buildPlaceCallOptions omits authority so hosted calls inherit the saved default", () => {
   const result = buildPlaceCallOptions({
     identity: "support-bot",
     to: "+15551234567",
@@ -201,23 +201,25 @@ test("buildPlaceCallOptions builds a shared hosted call with mode and reason", (
   });
 });
 
-test("buildPlaceCallOptions forwards yolo authority on a hosted call", () => {
-  const result = buildPlaceCallOptions({
-    identity: "support-bot",
-    to: "+15551234567",
-    hosted: true,
-    reason: "Coordinate the appointment",
-    authorityMode: "yolo",
-  });
-
-  assert.deepEqual(result, {
-    callOptions: {
-      toNumber: "+15551234567",
-      mode: "hosted_agent",
+test("buildPlaceCallOptions forwards explicit authority overrides", () => {
+  for (const authorityMode of ["contact_scoped", "yolo"]) {
+    const result = buildPlaceCallOptions({
+      identity: "support-bot",
+      to: "+15551234567",
+      hosted: true,
       reason: "Coordinate the appointment",
-      hostedAgentAuthorityMode: "yolo",
-    },
-  });
+      authorityMode,
+    });
+
+    assert.deepEqual(result, {
+      callOptions: {
+        toNumber: "+15551234567",
+        mode: "hosted_agent",
+        reason: "Coordinate the appointment",
+        hostedAgentAuthorityMode: authorityMode,
+      },
+    });
+  }
 });
 
 test("buildPlaceCallOptions rejects authority without --hosted", () => {

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.9 — Voice AI authority inheritance
+
+### Changed
+
+- `calls.place()` and `identity.place_call()` continue to omit
+  `hosted_agent_authority_mode` when it is `None`, allowing Voice AI outbound
+  calls to inherit the identity's saved Voice AI authority.
+- Explicit `contact_scoped` downscopes one call. Explicit `yolo` requires an
+  admin credential only when it exceeds the saved authority.
+- Package version moved in lockstep to 0.5.9.
+
+### Compatibility
+
+- Method signatures and wire names are unchanged. Older API versions may still
+  resolve an omitted authority as `contact_scoped`.
+
 ## 0.5.8 — Hosted-agent authority and voicemail detection
 
 ### Added

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -365,21 +365,28 @@ call = identity.place_call(
 )
 print(call.status, call.rate_limit.calls_remaining)
 
-# Let the hosted agent work beyond the current caller for this call.
-# Requesting yolo authority requires an admin API key.
+# Let Voice AI handle the call using this identity's saved authority.
 from inkbox import CallMode, HostedAgentAuthorityMode, VoicemailDetection
 
 hosted_call = identity.place_call(
     to_number="+15551234567",
     mode=CallMode.HOSTED_AGENT,
     reason="Coordinate the appointment and send confirmations.",
-    hosted_agent_authority_mode=HostedAgentAuthorityMode.YOLO,
     voicemail_detection=VoicemailDetection.DISABLED,
 )
 
-# Set the mode for future incoming calls with an admin API key. Outbound calls
-# select authority per call.
+# Set the saved default for future inbound and outbound Voice AI calls.
+# Changing the saved default requires an admin API key.
 identity.set_hosted_agent_authority_mode(HostedAgentAuthorityMode.YOLO)
+
+# Per-call overrides are optional. contact_scoped always downscopes. yolo
+# requires an admin credential unless the saved authority is already yolo.
+scoped_call = identity.place_call(
+    to_number="+15551234567",
+    mode=CallMode.HOSTED_AGENT,
+    reason="Confirm only this caller's appointment.",
+    hosted_agent_authority_mode=HostedAgentAuthorityMode.CONTACT_SCOPED,
+)
 
 # List calls (paginated)
 calls = identity.list_calls(limit=10, offset=0)

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -718,8 +718,11 @@ class AgentIdentity:
             client_websocket_url: WebSocket URL (wss://) for audio bridging.
             mode: Who drives the call. Defaults to ``client_websocket``.
                 See :class:`CallMode`.
-            hosted_agent_authority_mode: Hosted-agent authority for this call.
-                Omit for the server's ``contact_scoped`` default.
+            hosted_agent_authority_mode: Voice AI authority override.
+                Omit to inherit this identity's saved Voice AI authority.
+                Explicit ``contact_scoped`` downscopes the call. Explicit
+                ``yolo`` requires an admin credential unless the saved
+                authority is already ``yolo``.
             voicemail_detection: Whether to hang up when voicemail is detected.
                 Omit for the server's ``enabled`` default.
             reason: Voice AI's task brief for the call. Required
@@ -859,10 +862,10 @@ class AgentIdentity:
         self,
         authority_mode: HostedAgentAuthorityMode | str,
     ) -> HostedAgentConfig:
-        """Set authority for future incoming hosted calls with an admin API key.
+        """Set the saved Voice AI authority with an admin API key.
 
-        Outbound calls select authority independently with
-        ``hosted_agent_authority_mode``.
+        Incoming calls use this value. Outbound calls inherit it when
+        ``hosted_agent_authority_mode`` is omitted.
         """
         return self._inkbox._hosted_agent.set_authority_mode(
             agent_identity_id=self.id,

--- a/sdk/python/inkbox/phone/resources/calls.py
+++ b/sdk/python/inkbox/phone/resources/calls.py
@@ -177,7 +177,7 @@ class CallsResource:
                 Omit to inherit the identity's saved Voice AI authority.
                 Explicit ``contact_scoped`` downscopes the call. Explicit
                 ``yolo`` requires an admin credential unless the saved
-                authority is already ``yolo``. Valid only with
+                authority is already ``yolo``. ``yolo`` is valid only with
                 ``mode=hosted_agent``; invalid combinations surface the
                 server's 422 response.
             voicemail_detection: Whether to hang up when voicemail is detected.

--- a/sdk/python/inkbox/phone/resources/calls.py
+++ b/sdk/python/inkbox/phone/resources/calls.py
@@ -173,10 +173,13 @@ class CallsResource:
             client_websocket_url: WebSocket URL (wss://) for audio bridging.
             mode: Who drives the call. Defaults to ``client_websocket``.
                 See :class:`CallMode`.
-            hosted_agent_authority_mode: Hosted-agent authority for this call.
-                Omit for the server's ``contact_scoped`` default. ``yolo`` is
-                valid only with ``mode=hosted_agent``; invalid combinations
-                surface the server's 422 response.
+            hosted_agent_authority_mode: Voice AI authority override.
+                Omit to inherit the identity's saved Voice AI authority.
+                Explicit ``contact_scoped`` downscopes the call. Explicit
+                ``yolo`` requires an admin credential unless the saved
+                authority is already ``yolo``. Valid only with
+                ``mode=hosted_agent``; invalid combinations surface the
+                server's 422 response.
             voicemail_detection: Whether to hang up when voicemail is detected.
                 Omit for the server's ``enabled`` default.
             reason: Voice AI's task brief for the call — what to

--- a/sdk/python/inkbox/phone/resources/hosted_agent.py
+++ b/sdk/python/inkbox/phone/resources/hosted_agent.py
@@ -82,10 +82,11 @@ class HostedAgentConfigResource:
         agent_identity_id: UUID | str,
         authority_mode: HostedAgentAuthorityMode | str,
     ) -> HostedAgentConfig:
-        """Set authority for an identity's future incoming hosted calls.
+        """Set an identity's saved Voice AI authority.
 
-        This privileged operation requires an admin API key. Outbound calls
-        select authority independently.
+        This privileged operation requires an admin API key. Incoming calls
+        use this value, and outbound calls inherit it when they omit a per-call
+        override.
         """
         mode = (
             authority_mode.value

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.5.8"
+version = "0.5.9"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_calls.py
+++ b/sdk/python/tests/test_calls.py
@@ -405,11 +405,12 @@ class TestCallsPlace:
 
 
 class TestCallsPlaceHosted:
-    def test_hosted_mode_and_reason_forwarded(self, client, transport):
+    def test_omitted_authority_inherits_saved_default(self, client, transport):
         transport.post.return_value = {
             **PHONE_CALL_DICT,
             "mode": "hosted_agent",
             "reason": "Book a cleaning next week, mornings preferred",
+            "hosted_agent_authority_mode": "yolo",
         }
 
         call = client._calls.place(
@@ -431,24 +432,37 @@ class TestCallsPlaceHosted:
         )
         assert call.mode == "hosted_agent"
         assert call.reason == "Book a cleaning next week, mornings preferred"
+        assert call.hosted_agent_authority_mode is HostedAgentAuthorityMode.YOLO
 
-    def test_yolo_authority_forwarded_and_parsed(self, client, transport):
+    @pytest.mark.parametrize(
+        "authority_mode",
+        [
+            HostedAgentAuthorityMode.CONTACT_SCOPED,
+            HostedAgentAuthorityMode.YOLO,
+        ],
+    )
+    def test_explicit_authority_override_forwarded_and_parsed(
+        self,
+        client,
+        transport,
+        authority_mode,
+    ):
         transport.post.return_value = {
             **PHONE_CALL_DICT,
             "mode": "hosted_agent",
-            "hosted_agent_authority_mode": "yolo",
+            "hosted_agent_authority_mode": authority_mode.value,
         }
 
         call = client._calls.place(
             to_number="+15551234567",
             mode=CallMode.HOSTED_AGENT,
-            hosted_agent_authority_mode=HostedAgentAuthorityMode.YOLO,
+            hosted_agent_authority_mode=authority_mode,
             reason="Coordinate the appointment",
         )
 
         _, kwargs = transport.post.call_args
-        assert kwargs["json"]["hosted_agent_authority_mode"] == "yolo"
-        assert call.hosted_agent_authority_mode is HostedAgentAuthorityMode.YOLO
+        assert kwargs["json"]["hosted_agent_authority_mode"] == authority_mode.value
+        assert call.hosted_agent_authority_mode is authority_mode
 
     def test_string_mode_passed_verbatim(self, client, transport):
         """A raw string mode is forwarded as-is (no enum coercion)."""

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -52,24 +52,32 @@ fn main() -> inkbox::Result<()> {
 }
 ```
 
-### Hosted-agent authority
+### Voice AI authority
 
-Hosted-agent calls default to contact-scoped authority. Requesting broader
-authority for one hosted call, or setting it for future incoming calls,
-requires an admin API key. Outbound calls always select authority per call:
+Voice AI calls inherit the identity's saved authority when no per-call override
+is supplied. An explicit `ContactScoped` override always downscopes the call.
+An explicit `Yolo` override requires an admin credential unless the saved
+authority is already `Yolo`. Changing the saved default requires an admin API
+key:
 
 ```rust
 use inkbox::phone::{CallOrigin, HostedAgentAuthorityMode};
 
-let call = identity.place_hosted_call_with_authority(
+let call = identity.place_hosted_call(
     "+15551234567",
     CallOrigin::DedicatedNumber,
     "Coordinate the appointment and send confirmations.",
-    HostedAgentAuthorityMode::Yolo,
 )?;
 
 identity.set_hosted_agent_authority_mode(
     HostedAgentAuthorityMode::Yolo,
+)?;
+
+let scoped_call = identity.place_hosted_call_with_authority(
+    "+15551234567",
+    CallOrigin::DedicatedNumber,
+    "Confirm only this caller's appointment.",
+    HostedAgentAuthorityMode::ContactScoped,
 )?;
 ```
 

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -796,9 +796,10 @@ impl AgentIdentity {
         )
     }
 
-    /// Set authority for future incoming hosted calls with an admin API key.
+    /// Set the saved Voice AI authority with an admin API key.
     ///
-    /// Outbound calls select authority independently.
+    /// Incoming calls use this value. Outbound calls inherit it when the
+    /// placement options omit `authority_mode`.
     pub fn set_hosted_agent_authority_mode(
         &self,
         authority_mode: HostedAgentAuthorityMode,

--- a/sdk/rust/src/phone/resources/calls.rs
+++ b/sdk/rust/src/phone/resources/calls.rs
@@ -768,9 +768,9 @@ mod tests {
     }
 
     #[test]
-    fn place_hosted_sends_mode_and_reason() {
+    fn place_hosted_omits_authority_and_parses_inherited_default() {
         let server = MockServer::start();
-        // Exact json_body match: hosted body carries mode + reason, no ws key.
+        // Exact body omits authority; the resolved response may still be Yolo.
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/api/v1/phone/place-call")
@@ -785,6 +785,7 @@ mod tests {
                 let mut v = placed_json("dedicated_number", json!("+15550001111"));
                 v["mode"] = json!("hosted_agent");
                 v["reason"] = json!("Book a cleaning next week, mornings preferred");
+                v["hosted_agent_authority_mode"] = json!("yolo");
                 v
             });
         });
@@ -803,6 +804,10 @@ mod tests {
         assert_eq!(
             placed.call.reason.as_deref(),
             Some("Book a cleaning next week, mornings preferred")
+        );
+        assert_eq!(
+            placed.call.hosted_agent_authority_mode,
+            HostedAgentAuthorityMode::Yolo
         );
     }
 
@@ -845,6 +850,42 @@ mod tests {
             placed.call.hosted_agent_authority_mode,
             HostedAgentAuthorityMode::Yolo
         );
+    }
+
+    #[test]
+    fn place_hosted_with_authority_sends_contact_scoped() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/phone/place-call")
+                .json_body(json!({
+                    "to_number": "+15550002222",
+                    "origination": "dedicated_number",
+                    "mode": "hosted_agent",
+                    "reason": "Confirm this caller's appointment",
+                    "hosted_agent_authority_mode": "contact_scoped",
+                    "from_number": "+15550001111"
+                }));
+            then.status(200).json_body({
+                let mut v = placed_json("dedicated_number", json!("+15550001111"));
+                v["mode"] = json!("hosted_agent");
+                v
+            });
+        });
+
+        client(&server)
+            .calls()
+            .place_hosted_with_authority(
+                "+15550002222",
+                CallOrigin::DedicatedNumber,
+                Some("+15550001111"),
+                None,
+                "Confirm this caller's appointment",
+                HostedAgentAuthorityMode::ContactScoped,
+            )
+            .unwrap();
+
+        mock.assert();
     }
 
     #[test]

--- a/sdk/rust/src/phone/resources/hosted_agent.rs
+++ b/sdk/rust/src/phone/resources/hosted_agent.rs
@@ -73,10 +73,11 @@ impl HostedAgentConfigResource {
         Ok(serde_json::from_value(data)?)
     }
 
-    /// Set authority for an identity's future incoming hosted calls.
+    /// Set an identity's saved Voice AI authority.
     ///
-    /// This privileged operation requires an admin API key. Outbound calls
-    /// select authority independently.
+    /// This privileged operation requires an admin API key. Incoming calls use
+    /// this value, and outbound calls inherit it when they omit a per-call
+    /// override.
     pub fn set_authority_mode(
         &self,
         agent_identity_id: &str,

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -189,7 +189,11 @@ pub struct CallPlacementOptions {
 /// Optional controls for an Inkbox Voice AI outbound call.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HostedCallPlacementOptions {
-    /// Omit to use the per-call `contact_scoped` default.
+    /// Omit to inherit the identity's saved Voice AI authority.
+    ///
+    /// An explicit `ContactScoped` downscopes the call. An explicit `Yolo`
+    /// requires an admin credential unless the saved authority is already
+    /// `Yolo`.
     pub authority_mode: Option<HostedAgentAuthorityMode>,
     /// Omit to retain the server default (`enabled`).
     pub voicemail_detection: Option<VoicemailDetection>,

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.9 — Voice AI authority inheritance
+
+### Changed
+
+- `calls.place()` and `identity.placeCall()` continue to omit
+  `hostedAgentAuthorityMode` when it is `undefined`, allowing Voice AI outbound
+  calls to inherit the identity's saved Voice AI authority.
+- Explicit `contact_scoped` downscopes one call. Explicit `yolo` requires an
+  admin credential only when it exceeds the saved authority.
+- Package version moved in lockstep to 0.5.9.
+
+### Compatibility
+
+- Method signatures and wire names are unchanged. Older API versions may still
+  resolve an omitted authority as `contact_scoped`.
+
 ## 0.5.8 — Hosted-agent authority and voicemail detection
 
 ### Added

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -388,20 +388,27 @@ const call = await identity.placeCall({
 });
 console.log(call.status, call.rateLimit.callsRemaining);
 
-// Let the hosted agent work beyond the current caller for this call.
-// Requesting yolo authority requires an admin API key.
+// Let Voice AI handle the call using this identity's saved authority.
 const hostedCall = await identity.placeCall({
   toNumber: "+15551234567",
   mode: CallMode.HOSTED_AGENT,
   reason: "Coordinate the appointment and send confirmations.",
-  hostedAgentAuthorityMode: HostedAgentAuthorityMode.YOLO,
   voicemailDetection: VoicemailDetection.DISABLED,
 });
 
-// Set the mode for future incoming calls with an admin API key. Outbound calls
-// select authority per call.
+// Set the saved default for future inbound and outbound Voice AI calls.
+// Changing the saved default requires an admin API key.
 await identity.setHostedAgentAuthorityMode({
   authorityMode: HostedAgentAuthorityMode.YOLO,
+});
+
+// Per-call overrides are optional. CONTACT_SCOPED always downscopes. YOLO
+// requires an admin credential unless the saved authority is already YOLO.
+const scopedCall = await identity.placeCall({
+  toNumber: "+15551234567",
+  mode: CallMode.HOSTED_AGENT,
+  reason: "Confirm only this caller's appointment.",
+  hostedAgentAuthorityMode: HostedAgentAuthorityMode.CONTACT_SCOPED,
 });
 
 // List calls (paginated)

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -570,8 +570,10 @@ export class AgentIdentity {
    *   `dedicated_number`.
    * @param options.clientWebsocketUrl - WebSocket URL (wss://) for audio bridging.
    * @param options.mode - Who drives the call. Defaults to `client_websocket`.
-   * @param options.hostedAgentAuthorityMode - Hosted-agent authority. Defaults
-   *   to `contact_scoped`.
+   * @param options.hostedAgentAuthorityMode - Voice AI authority override.
+   *   Omit to inherit this identity's saved Voice AI authority. Explicit
+   *   `contact_scoped` downscopes the call. Explicit `yolo` requires an admin
+   *   credential unless the saved authority is already `yolo`.
    * @param options.voicemailDetection - Whether to hang up when voicemail is
    *   detected. Omit for the server's `enabled` default.
    * @param options.reason - Voice AI's task brief for the call.
@@ -687,8 +689,9 @@ export class AgentIdentity {
   }
 
   /**
-   * Set authority for future incoming hosted calls with an admin API key.
-   * Outbound calls select authority independently with `hostedAgentAuthorityMode`.
+   * Set the saved Voice AI authority with an admin API key.
+   * Incoming calls use this value. Outbound calls inherit it when
+   * `hostedAgentAuthorityMode` is omitted.
    */
   async setHostedAgentAuthorityMode(options: {
     authorityMode: HostedAgentAuthorityMode;

--- a/sdk/typescript/src/phone/resources/calls.ts
+++ b/sdk/typescript/src/phone/resources/calls.ts
@@ -144,8 +144,11 @@ export class CallsResource {
    * @param options.agentIdentityId - UUID of the placing identity (iMessage origination).
    * @param options.clientWebsocketUrl - WebSocket URL (wss://) for audio bridging.
    * @param options.mode - Who drives the call. Defaults to `client_websocket`.
-   * @param options.hostedAgentAuthorityMode - Hosted-agent authority. Defaults
-   *   to `contact_scoped`; `yolo` is valid only with `hosted_agent`.
+   * @param options.hostedAgentAuthorityMode - Voice AI authority override.
+   *   Omit to inherit the identity's saved Voice AI authority. Explicit
+   *   `contact_scoped` downscopes the call. Explicit `yolo` requires an admin
+   *   credential unless the saved authority is already `yolo`. Valid only with
+   *   `mode=hosted_agent`.
    * @param options.voicemailDetection - Whether to hang up when voicemail is
    *   detected. Omit for the server's `enabled` default.
    * @param options.reason - Voice AI's task brief for the call.

--- a/sdk/typescript/src/phone/resources/calls.ts
+++ b/sdk/typescript/src/phone/resources/calls.ts
@@ -147,8 +147,8 @@ export class CallsResource {
    * @param options.hostedAgentAuthorityMode - Voice AI authority override.
    *   Omit to inherit the identity's saved Voice AI authority. Explicit
    *   `contact_scoped` downscopes the call. Explicit `yolo` requires an admin
-   *   credential unless the saved authority is already `yolo`. Valid only with
-   *   `mode=hosted_agent`.
+   *   credential unless the saved authority is already `yolo`. `yolo` is
+   *   valid only with `mode=hosted_agent`.
    * @param options.voicemailDetection - Whether to hang up when voicemail is
    *   detected. Omit for the server's `enabled` default.
    * @param options.reason - Voice AI's task brief for the call.

--- a/sdk/typescript/src/phone/resources/hostedAgent.ts
+++ b/sdk/typescript/src/phone/resources/hostedAgent.ts
@@ -76,10 +76,11 @@ export class HostedAgentConfigResource {
   }
 
   /**
-   * Set authority for an identity's future incoming hosted calls.
+   * Set an identity's saved Voice AI authority.
    *
-   * This privileged operation requires an admin API key. Outbound calls
-   * select authority independently.
+   * This privileged operation requires an admin API key. Incoming calls use
+   * this value, and outbound calls inherit it when they omit a per-call
+   * override.
    */
   async setAuthorityMode(options: {
     agentIdentityId: string;

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -266,7 +266,7 @@ export interface PhoneCall {
   mode: string;
   /** Outbound Voice AI task brief; `null` on inbound and client-driven calls. */
   reason: string | null;
-  /** Hosted-agent authority. Defaults to `contact_scoped`. */
+  /** Resolved Voice AI authority. Missing legacy values parse as `contact_scoped`. */
   hostedAgentAuthorityMode: HostedAgentAuthorityMode;
   /** Whether voicemail detection ran. Defaults to `enabled`. */
   voicemailDetection: VoicemailDetection;

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.5.8";
+export const VERSION = "0.5.9";

--- a/sdk/typescript/tests/phone/calls.test.ts
+++ b/sdk/typescript/tests/phone/calls.test.ts
@@ -381,12 +381,13 @@ describe("CallsResource.place", () => {
 });
 
 describe("CallsResource.place hosted_agent mode", () => {
-  it("sends mode=hosted_agent with the reason brief", async () => {
+  it("omits authority so the server inherits the saved default", async () => {
     const http = mockHttp();
     vi.mocked(http.post).mockResolvedValue({
       ...RAW_PHONE_CALL_WITH_RATE_LIMIT,
       mode: "hosted_agent",
       reason: "Book a cleaning next week, mornings preferred",
+      hosted_agent_authority_mode: "yolo",
     });
     const res = new CallsResource(http);
 
@@ -406,14 +407,18 @@ describe("CallsResource.place hosted_agent mode", () => {
     });
     expect(call.mode).toBe("hosted_agent");
     expect(call.reason).toBe("Book a cleaning next week, mornings preferred");
+    expect(call.hostedAgentAuthorityMode).toBe(HostedAgentAuthorityMode.YOLO);
   });
 
-  it("forwards yolo authority on a hosted-agent call", async () => {
+  it.each([
+    HostedAgentAuthorityMode.CONTACT_SCOPED,
+    HostedAgentAuthorityMode.YOLO,
+  ])("forwards explicit %s authority on a hosted-agent call", async (authorityMode) => {
     const http = mockHttp();
     vi.mocked(http.post).mockResolvedValue({
       ...RAW_PHONE_CALL_WITH_RATE_LIMIT,
       mode: "hosted_agent",
-      hosted_agent_authority_mode: "yolo",
+      hosted_agent_authority_mode: authorityMode,
     });
     const res = new CallsResource(http);
 
@@ -421,7 +426,7 @@ describe("CallsResource.place hosted_agent mode", () => {
       toNumber: "+15551234567",
       fromNumber: "+18335794607",
       mode: CallMode.HOSTED_AGENT,
-      hostedAgentAuthorityMode: HostedAgentAuthorityMode.YOLO,
+      hostedAgentAuthorityMode: authorityMode,
       reason: "Coordinate the appointment",
     });
 
@@ -429,8 +434,8 @@ describe("CallsResource.place hosted_agent mode", () => {
       string,
       Record<string, unknown>,
     ];
-    expect(body["hosted_agent_authority_mode"]).toBe("yolo");
-    expect(call.hostedAgentAuthorityMode).toBe(HostedAgentAuthorityMode.YOLO);
+    expect(body["hosted_agent_authority_mode"]).toBe(authorityMode);
+    expect(call.hostedAgentAuthorityMode).toBe(authorityMode);
   });
 
   it("forwards a hosted_agent call with ws-url instead of client-gating (server 422s)", async () => {


### PR DESCRIPTION
## Executive Summary

This release documents Voice AI authority inheritance and advances every package to 0.5.9.

- Hosted outbound calls omit the authority field unless the caller supplies an override.
- Explicit `contact_scoped` and `yolo` values remain supported as per-call overrides.
- Python, TypeScript, Rust, and CLI versions and dependency metadata move in lockstep.

## Description

The existing Python, TypeScript, Rust, and CLI serializers already preserve omission of the optional authority field. This change makes that contract explicit in docstrings, command help, READMEs, changelogs, and exact-wire tests: omission inherits the identity’s saved Voice AI authority, while an explicit value overrides one call.

Release metadata moves from 0.5.8 to 0.5.9 across manifests, lockfiles, user-agent constants, and the CLI dependency on `@inkbox/sdk`. No package has been published.

## Reason

Public guidance previously described omission as a fixed `contact_scoped` default. The API now treats omission as inheritance, so the SDK and CLI must preserve that distinction and describe it accurately.

## Decisions

- **API shape:** Kept all existing methods, flags, enums, and wire names because optional serialization already expresses inheritance correctly.
- **Compatibility:** Kept missing or null response parsing as `contact_scoped` so older call records remain readable.
- **Release scope:** Bumped all four packages to 0.5.9 because this repository releases Python, TypeScript, Rust, and the CLI in lockstep.

## Testing

- Python `calls.place()` and `AgentIdentity.place_call()`: 971 passed, 3 skipped, 88.60% total coverage; Ruff, lock validation, wheel/sdist build, and Twine checks passed.
- TypeScript `calls.place()` and `AgentIdentity.placeCall()`: 992 passed, 3 skipped, 86.48% line coverage; build, consumer bundle verification, and package inspection passed.
- Rust `place_hosted*()` methods: 213 default-feature tests and 275 all-feature tests passed; formatting, clippy with warnings denied, crate packaging, and publish dry-run passed.
- CLI `inkbox phone call --hosted [--authority-mode ...]`: 83 passed; build and package inspection passed.
- Final package contents were checked for unintended credential files, environment identifiers, and private repository references.