### PR TITLE
0.5.11: Make webhook contact names nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.5.11 — Nullable webhook contact names
+
+### Changed
+
+- `WebhookContact.name` and `WebhookMailContact.name` are now nullable across
+  Python, TypeScript, and Rust. A contact created automatically from an inbound
+  message carries an `id` and `memories` before it has a name, and the field is
+  `None`/`null` in that case rather than repeating the phone number or email
+  address the contact was matched on.
+- Python, TypeScript, Rust, and CLI versions moved in lockstep to 0.5.11; the
+  CLI now depends on `@inkbox/sdk` `^0.5.11`.
+
+### Compatibility
+
+- **Source-breaking for Rust and TypeScript consumers that read
+  `contact.name` as a non-optional value.** Rust `name` becomes
+  `Option<String>`, so matches and struct literals must handle `None`;
+  TypeScript `name` becomes `string | null`, so a strict `null` check is
+  required before using it. Python's `TypedDict` widens to `str | None`, which
+  type checkers will flag at the use site.
+- Rust deserialization of these payloads previously failed outright on a null
+  `name`; it now parses. Upgrade if your receiver handles inbound calls, texts,
+  iMessage, or mail webhooks.
+- Guard the field before addressing anyone by name. It never falls back to the
+  identifier, which is the point: a missing name should read as unknown, not as
+  a phone number.
+
 ## 0.5.10 — Tunnel disconnect timestamps
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.5.10",
+        "@inkbox/sdk": "^0.5.11",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.5.10",
+    "@inkbox/sdk": "^0.5.11",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.5.10";
+export const CLI_VERSION = "0.5.11";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1287,6 +1287,12 @@ first, in `memories`; use `match.get("memories", [])` for replayed
 payloads that predate contact memories. This is separate from the
 optional conversation `context`.
 
+`name` is `None` when the contact has no name on file -- a contact
+created automatically from an inbound message has an `id` and
+`memories` before anyone gives it a name. It never falls back to the
+phone number or email address, so guard it before addressing someone
+by name.
+
 On inbound `message.received`, `data["message"]` carries the plain-text
 `body`: the whole message when it fits the size cap, otherwise a prefix
 with `body_truncated: true` and `body_state: "truncated"` (else

--- a/sdk/python/inkbox/webhooks.py
+++ b/sdk/python/inkbox/webhooks.py
@@ -117,7 +117,9 @@ class WebhookContact(TypedDict):
     ``inkbox.contacts.get()`` to hydrate.
     """
     id: str
-    name: str
+    # None when the contact has no name on file. Never falls back to the
+    # phone number or email address.
+    name: str | None
     # Active memories, newest first; optional only for older replays.
     memories: NotRequired[list[str]]
 
@@ -280,7 +282,9 @@ class WebhookMailContact(TypedDict):
     bucket: MailContactBucket
     address: str
     id: str
-    name: str
+    # None when the contact has no name on file. Never falls back to the
+    # email address.
+    name: str | None
     # Active memories, newest first; optional only for older replays.
     memories: NotRequired[list[str]]
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.5.10"
+version = "0.5.11"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/webhooks/types.rs
+++ b/sdk/rust/src/webhooks/types.rs
@@ -150,7 +150,10 @@ pub struct RateLimitInfoWire {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebhookContact {
     pub id: String,
-    pub name: String,
+    /// The contact's name, or `None` when the contact has no name on file.
+    /// Never falls back to the phone number or email address.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Active contact memories, newest first. Defaults empty for older replays.
     #[serde(default)]
     pub memories: Vec<String>,
@@ -376,7 +379,10 @@ pub struct WebhookMailContact {
     pub bucket: MailContactBucket,
     pub address: String,
     pub id: String,
-    pub name: String,
+    /// The contact's name, or `None` when the contact has no name on file.
+    /// Never falls back to the email address.
+    #[serde(default)]
+    pub name: Option<String>,
     /// Active contact memories, newest first. Defaults empty for older replays.
     #[serde(default)]
     pub memories: Vec<String>,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1314,6 +1314,12 @@ Every resolved contact carries active memory text, newest first, in
 predate contact memories. This is separate from the optional
 conversation `context`.
 
+`name` is `null` when the contact has no name on file — a contact
+created automatically from an inbound message has an `id` and
+`memories` before anyone gives it a name. It never falls back to the
+phone number or email address, so guard it before addressing someone
+by name.
+
 Phone-text payloads carry several fields for group sends:
 
 - `text_message.recipients` — `null` on inbound, a one-element list

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.5.10";
+export const VERSION = "0.5.11";

--- a/sdk/typescript/src/webhooks/types.ts
+++ b/sdk/typescript/src/webhooks/types.ts
@@ -78,7 +78,11 @@ export type HangupReasonWire =
  */
 export interface WebhookContact {
   id: string;
-  name: string;
+  /**
+   * The contact's name, or null when the contact has no name on file.
+   * Never falls back to the phone number or email address.
+   */
+  name: string | null;
   /** Active memories, newest first; optional only for older replays. */
   memories?: string[];
 }
@@ -239,7 +243,11 @@ export interface WebhookMailContact {
   bucket: MailContactBucket;
   address: string;
   id: string;
-  name: string;
+  /**
+   * The contact's name, or null when the contact has no name on file.
+   * Never falls back to the email address.
+   */
+  name: string | null;
   /** Active memories, newest first; optional only for older replays. */
   memories?: string[];
 }


### PR DESCRIPTION
## Summary

`WebhookContact.name` and `WebhookMailContact.name` are now nullable in the Python, TypeScript, and Rust SDKs.

A contact created automatically from an inbound message carries an `id` and `memories` before anyone gives it a name. The API reports that name as `null` rather than repeating the phone number or email address the contact was matched on, so a receiver that reads `contact.name` gets an explicit "unknown" instead of an identifier that reads like a name.

All four packages move to **0.5.11** in lockstep.

## Why this matters most for Rust

Rust typed the field as `String`, so a payload with a null `name` failed to deserialize outright — the whole webhook, not just the field. Anyone handling inbound call, text, iMessage, or mail webhooks in Rust should upgrade.

TypeScript and Python typed it as non-nullable, which is a type-level inaccuracy rather than a runtime failure.

## Changes

| Package | Before | After |
|---|---|---|
| Rust | `pub name: String` | `pub name: Option<String>` (with `#[serde(default)]`) |
| TypeScript | `name: string` | `name: string \| null` |
| Python | `name: str` | `name: str \| None` |

Both READMEs document the nullability and the guidance not to fall back to the identifier. `CHANGELOG.md` carries the 0.5.11 entry.

## Compatibility

Source-breaking for Rust and TypeScript consumers that read `contact.name` as a non-optional value:

- Rust matches and struct literals must handle `None`.
- TypeScript needs a null check before use.
- Python's `TypedDict` widens, so type checkers flag the use site rather than the compiler.

Guard the field before addressing anyone by name. It deliberately does not fall back to the identifier: a missing name should read as unknown, not as a phone number.

## Verification

- Rust: `cargo fmt --check` clean, `cargo clippy --all-targets` clean, 214 tests + 2 doc-tests pass.
- Python: 975 passed, 3 skipped.
- TypeScript: `tsc --noEmit` clean, 996 passed, 3 skipped.
- CLI: 73 passed, 11 failing — the same 11 that fail on `main`, unrelated to this change.
- Lockstep version test passes across all four `package.json` / `pyproject.toml` / `Cargo.toml` files and their lock files.
