### PR TITLE
Expose paired call correlation across SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, and `inkbox` (Rust, crates.io).
 
+## 0.5.13 — Paired call correlation
+
+### Added
+
+- Python, TypeScript, and Rust call records expose the nullable opaque pair ID
+  shared by related managed call legs.
+- Call listings accept that pair ID as a filter while retaining identity-scoped
+  authorization, allowing each participant to select its own leg precisely.
+- Inbound and lifecycle webhook types accept the pair ID, and `inkbox phone
+  calls` exposes `--paired-call-id`.
+
+### Changed
+
+- Python, TypeScript, Rust, and CLI versions moved in lockstep to 0.5.13; the
+  CLI now depends on `@inkbox/sdk` `^0.5.13`.
+
+### Compatibility and rollout
+
+- Missing and null pair IDs parse as `None`/`null`, covering external calls,
+  calls created before pairing support, older API responses, and webhook
+  replays.
+- Existing list calls are wire-identical unless the new filter is supplied.
+  TypeScript and Rust callers that construct `PhoneCall` values directly must
+  add `pairedCallId: null` or `paired_call_id: None`.
+- Deploy the additive API field and filter before relying on pair-based lookup;
+  older SDK versions ignore the additional response field.
+
 ## 0.5.12 — Bidirectional A2A contexts
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.5.12",
+        "@inkbox/sdk": "^0.5.13",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.5.12",
+    "@inkbox/sdk": "^0.5.13",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.5.12";
+export const CLI_VERSION = "0.5.13";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/phone.ts
+++ b/cli/src/commands/phone.ts
@@ -152,6 +152,7 @@ export function registerPhoneCommands(program: Command): void {
     .requiredOption("-i, --identity <handle>", "Agent identity handle")
     .option("--limit <n>", "Max results", "50")
     .option("--offset <n>", "Pagination offset", "0")
+    .option("--paired-call-id <uuid>", "Only the call leg matching this pair ID")
     .option("--start-datetime <date>", "Only calls with created_at >= this date/instant")
     .option("--end-datetime <date>", "Only calls with created_at <= this date (bare date is whole-day inclusive)")
     .option("--tz <zone>", "IANA timezone for bare/zone-less dates (default UTC)")
@@ -162,6 +163,7 @@ export function registerPhoneCommands(program: Command): void {
           identity: string;
           limit: string;
           offset: string;
+          pairedCallId?: string;
           startDatetime?: string;
           endDatetime?: string;
           tz?: string;
@@ -173,6 +175,7 @@ export function registerPhoneCommands(program: Command): void {
         const calls = await identity.listCalls({
           limit: parseInt(cmdOpts.limit, 10),
           offset: parseInt(cmdOpts.offset, 10),
+          pairedCallId: cmdOpts.pairedCallId,
           startDatetime: cmdOpts.startDatetime,
           endDatetime: cmdOpts.endDatetime,
           tz: cmdOpts.tz,
@@ -183,6 +186,7 @@ export function registerPhoneCommands(program: Command): void {
             "id",
             "direction",
             "remotePhoneNumber",
+            "pairedCallId",
             "status",
             "createdAt",
           ],

--- a/cli/tests/phone-command.test.mjs
+++ b/cli/tests/phone-command.test.mjs
@@ -75,6 +75,7 @@ test("phone help exposes authority controls", () => {
   assert.match(help("phone", "call"), /dedicated_imessage_number/);
   assert.match(help("phone", "tool-activity"), /--limit <n>/);
   assert.match(help("phone", "tool-activity"), /--offset <n>/);
+  assert.match(help("phone", "calls"), /--paired-call-id <uuid>/);
   const authorityHelp = help("phone", "hosted-agent", "authority-mode");
   assert.match(authorityHelp, /admin API key/);
 });

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -771,6 +771,7 @@ class AgentIdentity:
         limit: int = 50,
         offset: int = 0,
         is_blocked: bool | None = None,
+        paired_call_id: UUID | str | None = None,
         start_datetime: str | None = None,
         end_datetime: str | None = None,
         tz: str | None = None,
@@ -785,6 +786,8 @@ class AgentIdentity:
             offset: Pagination offset (default 0).
             is_blocked: Tri-state filter — ``True`` for only blocked,
                 ``False`` for only non-blocked, ``None`` for all.
+            paired_call_id: Opaque correlation UUID shared by related managed
+                call legs.
             start_datetime: Inclusive ``created_at`` lower bound (str); ``None``
                 leaves the side open. UTC unless ``tz`` is set.
             end_datetime: ``created_at`` upper bound (str), whole-day inclusive for
@@ -796,6 +799,7 @@ class AgentIdentity:
             limit=limit,
             offset=offset,
             is_blocked=is_blocked,
+            paired_call_id=paired_call_id,
             start_datetime=start_datetime,
             end_datetime=end_datetime,
             tz=tz,

--- a/sdk/python/inkbox/phone/resources/calls.py
+++ b/sdk/python/inkbox/phone/resources/calls.py
@@ -36,6 +36,7 @@ class CallsResource:
         limit: int = 50,
         offset: int = 0,
         is_blocked: bool | None = None,
+        paired_call_id: UUID | str | None = None,
         start_datetime: str | None = None,
         end_datetime: str | None = None,
         tz: str | None = None,
@@ -61,6 +62,9 @@ class CallsResource:
             offset: Pagination offset.
             is_blocked: Tri-state filter — ``True`` for only blocked,
                 ``False`` for only non-blocked, ``None`` for all.
+            paired_call_id: Opaque correlation UUID shared by related managed
+                call legs. Pass it to select the matching leg visible to this
+                identity.
             start_datetime: Inclusive lower bound on ``created_at`` (str). Bare
                 dates resolve to the start of that day; naive datetimes are
                 interpreted in ``tz``; zoned datetimes are exact instants.
@@ -75,6 +79,8 @@ class CallsResource:
             params["agent_identity_id"] = str(agent_identity_id)
         if is_blocked is not None:
             params["is_blocked"] = is_blocked
+        if paired_call_id is not None:
+            params["paired_call_id"] = str(paired_call_id)
         if start_datetime is not None:
             params["start_datetime"] = start_datetime
         if end_datetime is not None:

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -252,6 +252,9 @@ class PhoneCall:
     # Whether voicemail detection ran. Missing/null legacy values preserve the
     # server default.
     voicemail_detection: VoicemailDetection = VoicemailDetection.ENABLED
+    # Opaque correlation shared by related managed call legs. Missing on calls
+    # created before pairing support and on calls to external numbers.
+    paired_call_id: UUID | None = None
     # Voice AI's recorded action items, surfaced inline (open items only,
     # seq-ascending); empty for client_websocket calls and Voice AI calls with
     # no open items.
@@ -284,6 +287,9 @@ class PhoneCall:
             ),
             voicemail_detection=VoicemailDetection(
                 d.get("voicemail_detection") or "enabled"
+            ),
+            paired_call_id=(
+                UUID(d["paired_call_id"]) if d.get("paired_call_id") else None
             ),
             # Open items only, seq-ascending; empty for client_websocket calls.
             post_call_action_items=[

--- a/sdk/python/inkbox/webhooks.py
+++ b/sdk/python/inkbox/webhooks.py
@@ -614,6 +614,7 @@ class PhoneIncomingCallWebhookPayload(TypedDict):
     id: str
     local_phone_number: str
     remote_phone_number: str
+    paired_call_id: NotRequired[str | None]
     direction: Literal["inbound"]
     status: CallStatusWire
     client_websocket_url: str | None
@@ -654,6 +655,7 @@ class WebhookPhoneCall(TypedDict):
     origin: CallOriginWire
     local_phone_number: str | None
     remote_phone_number: str
+    paired_call_id: NotRequired[str | None]
     direction: CallDirectionWire
     status: CallStatusWire
     hangup_reason: HangupReasonWire | None

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.5.12"
+version = "0.5.13"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/sample_data.py
+++ b/sdk/python/tests/sample_data.py
@@ -22,6 +22,7 @@ PHONE_CALL_DICT = {
     "id": "bbbb2222-0000-0000-0000-000000000001",
     "local_phone_number": "+18335794607",
     "remote_phone_number": "+15551234567",
+    "paired_call_id": "cccc3333-0000-0000-0000-000000000001",
     "direction": "outbound",
     "status": "completed",
     "client_websocket_url": "wss://agent.example.com/ws",

--- a/sdk/python/tests/test_agent_identity.py
+++ b/sdk/python/tests/test_agent_identity.py
@@ -373,6 +373,7 @@ class TestAgentIdentityListCalls:
             limit=50,
             offset=0,
             is_blocked=None,
+            paired_call_id=None,
             start_datetime=None,
             end_datetime=None,
             tz=None,
@@ -383,13 +384,19 @@ class TestAgentIdentityListCalls:
         identity, inkbox = _identity_with_mailbox()
         inkbox._calls.list.return_value = []
 
-        identity.list_calls(limit=10, offset=20, is_blocked=True)
+        identity.list_calls(
+            limit=10,
+            offset=20,
+            is_blocked=True,
+            paired_call_id="cccc3333-0000-0000-0000-000000000001",
+        )
 
         inkbox._calls.list.assert_called_once_with(
             agent_identity_id=IDENTITY_UUID,
             limit=10,
             offset=20,
             is_blocked=True,
+            paired_call_id="cccc3333-0000-0000-0000-000000000001",
             start_datetime=None,
             end_datetime=None,
             tz=None,

--- a/sdk/python/tests/test_calls.py
+++ b/sdk/python/tests/test_calls.py
@@ -32,6 +32,7 @@ from sample_data import (
 
 IDENTITY_ID = "eeee5555-0000-0000-0000-000000000001"
 CALL_ID = "bbbb2222-0000-0000-0000-000000000001"
+PAIRED_CALL_ID = "cccc3333-0000-0000-0000-000000000001"
 
 
 class TestCallsList:
@@ -107,6 +108,28 @@ class TestCallsList:
             params={"limit": 50, "offset": 0, "is_blocked": False},
         )
         assert calls[0].is_blocked is False
+
+    def test_paired_call_id_passes_through_and_parses(self, client, transport):
+        transport.get.return_value = [PHONE_CALL_DICT]
+
+        calls = client._calls.list(paired_call_id=PAIRED_CALL_ID)
+
+        transport.get.assert_called_once_with(
+            "/calls",
+            params={
+                "limit": 50,
+                "offset": 0,
+                "paired_call_id": PAIRED_CALL_ID,
+            },
+        )
+        assert calls[0].paired_call_id == UUID(PAIRED_CALL_ID)
+
+    def test_missing_paired_call_id_parses_as_none(self, client, transport):
+        legacy = dict(PHONE_CALL_DICT)
+        legacy.pop("paired_call_id")
+        transport.get.return_value = [legacy]
+
+        assert client._calls.list()[0].paired_call_id is None
 
     def test_agent_identity_id_accepts_uuid(self, client, transport):
         """UUID objects are stringified before hitting the wire."""
@@ -650,7 +673,7 @@ class TestRemovedNumberScopedSurface:
         # Keyword-only surface: no positional number slot.
         assert list(params) == [
             "self", "agent_identity_id", "limit", "offset", "is_blocked",
-            "start_datetime", "end_datetime", "tz",
+            "paired_call_id", "start_datetime", "end_datetime", "tz",
         ]
 
     def test_get_takes_only_call_id(self):

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.12"
+version = "0.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.5.12"
+version = "0.5.13"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -658,6 +658,20 @@ impl AgentIdentity {
             .list_filtered(Some(&id), limit, offset, is_blocked, filter)
     }
 
+    /// List the call leg for this identity matching an opaque pair ID.
+    pub fn list_calls_by_pair_id(
+        &self,
+        paired_call_id: &str,
+        limit: i64,
+        offset: i64,
+        is_blocked: Option<bool>,
+    ) -> Result<Vec<PhoneCall>> {
+        let id = self.id().to_string();
+        self.inkbox
+            .calls()
+            .list_by_pair_id(Some(&id), paired_call_id, limit, offset, is_blocked)
+    }
+
     /// Place an outbound call driven by Inkbox Voice AI.
     ///
     /// Sibling of [`AgentIdentity::place_call`] (which stays client-driven);

--- a/sdk/rust/src/phone/resources/calls.rs
+++ b/sdk/rust/src/phone/resources/calls.rs
@@ -44,11 +44,12 @@ impl CallsResource {
     ) -> Result<Vec<PhoneCall>> {
         // Delegate to the filtered variant with an empty (default) date range,
         // which sends no extra params — wire-identical to the original list.
-        self.list_filtered(
+        self.list_with_filters(
             agent_identity_id,
             limit,
             offset,
             is_blocked,
+            None,
             &DateRangeFilter::default(),
         )
     }
@@ -72,7 +73,41 @@ impl CallsResource {
         is_blocked: Option<bool>,
         filter: &DateRangeFilter,
     ) -> Result<Vec<PhoneCall>> {
-        // Always send limit + offset; scope by identity + filter only when set.
+        self.list_with_filters(agent_identity_id, limit, offset, is_blocked, None, filter)
+    }
+
+    /// List the call leg visible to an identity for an opaque pair ID.
+    ///
+    /// Related managed legs share the same pair ID. Identity scoping still
+    /// applies, so this returns only the matching leg the caller may access.
+    pub fn list_by_pair_id(
+        &self,
+        agent_identity_id: Option<&str>,
+        paired_call_id: &str,
+        limit: i64,
+        offset: i64,
+        is_blocked: Option<bool>,
+    ) -> Result<Vec<PhoneCall>> {
+        self.list_with_filters(
+            agent_identity_id,
+            limit,
+            offset,
+            is_blocked,
+            Some(paired_call_id),
+            &DateRangeFilter::default(),
+        )
+    }
+
+    fn list_with_filters(
+        &self,
+        agent_identity_id: Option<&str>,
+        limit: i64,
+        offset: i64,
+        is_blocked: Option<bool>,
+        paired_call_id: Option<&str>,
+        filter: &DateRangeFilter,
+    ) -> Result<Vec<PhoneCall>> {
+        // Always send limit + offset; scope by identity + filters only when set.
         let mut params: Vec<(&str, String)> =
             vec![("limit", limit.to_string()), ("offset", offset.to_string())];
         if let Some(id) = agent_identity_id {
@@ -80,6 +115,9 @@ impl CallsResource {
         }
         if let Some(b) = is_blocked {
             params.push(("is_blocked", b.to_string()));
+        }
+        if let Some(id) = paired_call_id {
+            params.push(("paired_call_id", id.to_string()));
         }
         filter.apply(&mut params);
         let data = self.http.get("/calls", &params)?;
@@ -339,6 +377,7 @@ mod tests {
             "id": "22222222-2222-2222-2222-222222222222",
             "local_phone_number": "+15550001111",
             "remote_phone_number": "+15550002222",
+            "paired_call_id": "44444444-4444-4444-4444-444444444444",
             "direction": "outbound",
             "status": "completed",
             "created_at": "2026-06-01T00:00:00+00:00",
@@ -418,6 +457,32 @@ mod tests {
             .list_filtered(None, 50, 0, None, &filter)
             .unwrap();
         mock.assert();
+    }
+
+    #[test]
+    fn list_by_pair_id_sends_pair_filter() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/v1/phone/calls")
+                .query_param("agent_identity_id", "33333333-3333-3333-3333-333333333333")
+                .query_param("paired_call_id", "44444444-4444-4444-4444-444444444444");
+            then.status(200).json_body(json!([call_json()]));
+        });
+
+        let calls = client(&server)
+            .calls()
+            .list_by_pair_id(
+                Some("33333333-3333-3333-3333-333333333333"),
+                "44444444-4444-4444-4444-444444444444",
+                50,
+                0,
+                None,
+            )
+            .unwrap();
+
+        mock.assert();
+        assert_eq!(calls.len(), 1);
     }
 
     #[test]

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -392,6 +392,9 @@ pub struct PhoneCall {
     #[serde(default)]
     pub local_phone_number: Option<String>,
     pub remote_phone_number: String,
+    /// Opaque correlation UUID shared by related managed call legs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paired_call_id: Option<Uuid>,
     pub direction: String,
     pub status: String,
     #[serde(default)]
@@ -745,6 +748,7 @@ mod tests {
             "id": "22222222-2222-2222-2222-222222222222",
             "local_phone_number": "+15550001111",
             "remote_phone_number": "+15550002222",
+            "paired_call_id": "33333333-3333-3333-3333-333333333333",
             "direction": "outbound",
             "status": "completed",
             "created_at": "2026-06-01T00:00:00+00:00",
@@ -758,7 +762,21 @@ mod tests {
     fn phone_call_dedicated_has_local_number_string() {
         let call: PhoneCall = serde_json::from_value(call_json()).unwrap();
         assert_eq!(call.local_phone_number.as_deref(), Some("+15550001111"));
+        assert_eq!(
+            call.paired_call_id,
+            Some(Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap())
+        );
         assert_eq!(call.origin, CallOrigin::DedicatedNumber);
+    }
+
+    #[test]
+    fn phone_call_missing_pair_id_defaults_to_none() {
+        let mut v = call_json();
+        v.as_object_mut().unwrap().remove("paired_call_id");
+
+        let call: PhoneCall = serde_json::from_value(v).unwrap();
+
+        assert_eq!(call.paired_call_id, None);
     }
 
     #[test]

--- a/sdk/rust/src/webhooks/types.rs
+++ b/sdk/rust/src/webhooks/types.rs
@@ -793,6 +793,9 @@ pub struct PhoneIncomingCallWebhookPayload {
     pub id: String,
     pub local_phone_number: String,
     pub remote_phone_number: String,
+    /// Opaque correlation UUID; absent on older payloads and external calls.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paired_call_id: Option<String>,
     pub direction: CallDirectionWire,
     pub status: CallStatusWire,
     pub client_websocket_url: Option<String>,
@@ -837,6 +840,9 @@ pub struct WebhookPhoneCall {
     pub origin: CallOriginWire,
     pub local_phone_number: Option<String>,
     pub remote_phone_number: String,
+    /// Opaque correlation UUID; absent on older replays and external calls.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paired_call_id: Option<String>,
     pub direction: CallDirectionWire,
     pub status: CallStatusWire,
     pub hangup_reason: Option<HangupReasonWire>,
@@ -1223,6 +1229,7 @@ mod tests {
                     "id": "c1", "origin": "dedicated_number",
                     "local_phone_number": "+14155550100",
                     "remote_phone_number": "+14155550999",
+                    "paired_call_id": "33333333-3333-3333-3333-333333333333",
                     "direction": "inbound", "status": "completed",
                     "hangup_reason": "remote", "started_at": "t0", "ended_at": "t1",
                     "created_at": "t0", "updated_at": "t1",
@@ -1246,6 +1253,10 @@ mod tests {
         assert_eq!(payload.event_type, CallLifecycleWebhookEventType::CallEnded);
         assert_eq!(payload.data.call.origin, CallOriginWire::DedicatedNumber);
         assert_eq!(payload.data.call.duration_seconds, Some(123));
+        assert_eq!(
+            payload.data.call.paired_call_id.as_deref(),
+            Some("33333333-3333-3333-3333-333333333333")
+        );
         assert_eq!(
             payload.data.contacts[0].memories,
             ["Prefers Thursday appointments."]

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -628,9 +628,11 @@ export class AgentIdentity {
    * @param options.offset - Pagination offset. Defaults to 0.
    * @param options.isBlocked - Tri-state filter. `true` for only blocked,
    *   `false` for only non-blocked, omit for all.
+   * @param options.pairedCallId - Opaque correlation UUID shared by related
+   *   managed call legs.
    */
   async listCalls(
-    options: { limit?: number; offset?: number; isBlocked?: boolean; startDatetime?: string; endDatetime?: string; tz?: string } = {},
+    options: { limit?: number; offset?: number; isBlocked?: boolean; pairedCallId?: string; startDatetime?: string; endDatetime?: string; tz?: string } = {},
   ): Promise<PhoneCall[]> {
     // Scope by identity id — no phone number required (a shared-only
     // identity can still have calls).

--- a/sdk/typescript/src/phone/resources/calls.ts
+++ b/sdk/typescript/src/phone/resources/calls.ts
@@ -43,12 +43,15 @@ export class CallsResource {
    * @param options.offset - Pagination offset. Defaults to 0.
    * @param options.isBlocked - Tri-state filter. `true` for only blocked,
    *   `false` for only non-blocked, omit for all.
+   * @param options.pairedCallId - Opaque correlation UUID shared by related
+   *   managed call legs. Selects the matching leg visible to this identity.
    */
   async list(options?: {
     agentIdentityId?: string;
     limit?: number;
     offset?: number;
     isBlocked?: boolean;
+    pairedCallId?: string;
     startDatetime?: string;
     endDatetime?: string;
     tz?: string;
@@ -63,6 +66,9 @@ export class CallsResource {
     }
     if (options?.isBlocked !== undefined) {
       params["is_blocked"] = options.isBlocked;
+    }
+    if (options?.pairedCallId !== undefined) {
+      params["paired_call_id"] = options.pairedCallId;
     }
     if (options?.startDatetime !== undefined) params["start_datetime"] = options.startDatetime;
     if (options?.endDatetime !== undefined) params["end_datetime"] = options.endDatetime;

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -241,6 +241,8 @@ export interface PhoneCall {
    */
   localPhoneNumber: string | null;
   remotePhoneNumber: string;
+  /** Opaque correlation UUID shared by related managed call legs. */
+  pairedCallId: string | null;
   /** "outbound" | "inbound" */
   direction: string;
   /** "initiated" | "ringing" | "answered" | "completed" | "failed" | "canceled" */
@@ -509,6 +511,8 @@ export interface RawPhoneCall {
   // Nullable: absent/null when the call rode the shared iMessage pool.
   local_phone_number: string | null;
   remote_phone_number: string;
+  // Optional for calls created before pairing support and external calls.
+  paired_call_id?: string | null;
   direction: string;
   status: string;
   client_websocket_url: string | null;
@@ -735,6 +739,7 @@ export function parsePhoneCall(r: RawPhoneCall): PhoneCall {
     id: r.id,
     localPhoneNumber: r.local_phone_number ?? null,
     remotePhoneNumber: r.remote_phone_number,
+    pairedCallId: r.paired_call_id ?? null,
     direction: r.direction,
     status: r.status,
     clientWebsocketUrl: r.client_websocket_url,

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.5.12";
+export const VERSION = "0.5.13";

--- a/sdk/typescript/src/webhooks/types.ts
+++ b/sdk/typescript/src/webhooks/types.ts
@@ -599,6 +599,8 @@ export interface PhoneIncomingCallWebhookPayload {
   id: string;
   local_phone_number: string;
   remote_phone_number: string;
+  /** Opaque correlation UUID; absent on older payloads and external calls. */
+  paired_call_id?: string | null;
   direction: "inbound";
   status: CallStatusWire;
   client_websocket_url: string | null;
@@ -642,6 +644,8 @@ export interface WebhookPhoneCall {
   origin: CallOriginWire;
   local_phone_number: string | null;
   remote_phone_number: string;
+  /** Opaque correlation UUID; absent on older replays and external calls. */
+  paired_call_id?: string | null;
   direction: CallDirectionWire;
   status: CallStatusWire;
   hangup_reason: HangupReasonWire | null;

--- a/sdk/typescript/tests/phone/calls.test.ts
+++ b/sdk/typescript/tests/phone/calls.test.ts
@@ -28,6 +28,7 @@ function mockHttp() {
 
 const IDENTITY_ID = "eeee5555-0000-0000-0000-000000000001";
 const CALL_ID = "bbbb2222-0000-0000-0000-000000000001";
+const PAIRED_CALL_ID = "cccc3333-0000-0000-0000-000000000001";
 
 describe("CallsResource.list", () => {
   it("uses default limit and offset with no identity scope", async () => {
@@ -94,6 +95,31 @@ describe("CallsResource.list", () => {
       is_blocked: false,
     });
     expect(calls[0].isBlocked).toBe(false);
+  });
+
+  it("forwards pairedCallId and parses the shared correlation ID", async () => {
+    const http = mockHttp();
+    vi.mocked(http.get).mockResolvedValue([RAW_PHONE_CALL]);
+    const res = new CallsResource(http);
+
+    const [call] = await res.list({ pairedCallId: PAIRED_CALL_ID });
+
+    expect(http.get).toHaveBeenCalledWith("/calls", {
+      limit: 50,
+      offset: 0,
+      paired_call_id: PAIRED_CALL_ID,
+    });
+    expect(call.pairedCallId).toBe(PAIRED_CALL_ID);
+  });
+
+  it("defaults pairedCallId to null when missing from older responses", async () => {
+    const http = mockHttp();
+    const { paired_call_id: _ignored, ...legacyPayload } = RAW_PHONE_CALL;
+    void _ignored;
+    vi.mocked(http.get).mockResolvedValue([legacyPayload]);
+    const res = new CallsResource(http);
+
+    expect((await res.list())[0].pairedCallId).toBeNull();
   });
 
   it("defaults isBlocked to false when missing from server response (back-compat)", async () => {

--- a/sdk/typescript/tests/sampleData.ts
+++ b/sdk/typescript/tests/sampleData.ts
@@ -101,6 +101,7 @@ export const RAW_PHONE_CALL = {
   id: "bbbb2222-0000-0000-0000-000000000001",
   local_phone_number: "+18335794607",
   remote_phone_number: "+15551234567",
+  paired_call_id: "cccc3333-0000-0000-0000-000000000001",
   direction: "outbound",
   status: "completed",
   client_websocket_url: "wss://agent.example.com/ws",


### PR DESCRIPTION
## Executive Summary

Exposes the optional `paired_call_id` voice-call correlation value across the Python, TypeScript, and Rust SDKs and the CLI, including identity-scoped lookup helpers and webhook types.

## Description

- Parses `paired_call_id` on call and phone-webhook payloads while preserving missing/null compatibility.
- Adds identity-scoped call list filters in Python and TypeScript.
- Adds a backwards-compatible Rust `list_by_pair_id` method without changing existing list signatures.
- Adds agent identity convenience methods and a `--paired-call-id` CLI filter/output column.
- Bumps SDK/CLI packages together to `0.5.13` and records the change.

## Reason

Managed voice calls have separate records for each participant. Consumers need a typed correlation value to select the record owned by the identity they are validating.

## Decisions

- Model the field as optional/nullable for external calls, historical records, and compatibility with older API responses.
- Keep all lookups identity-scoped; the pair ID is a selector, not an authorization token.
- Preserve Rust source compatibility by adding a dedicated method instead of changing existing method arguments.

## Testing

- Python: Ruff clean; `982 passed, 3 skipped`; coverage `88.58%`.
- TypeScript: build and typecheck pass; `1003 passed, 3 skipped`; line coverage `86.63%`.
- Rust: formatting and Clippy with warnings denied pass; `219` default tests and `281` tunnel-feature tests pass; docs and build pass.
- CLI: `87 passed`.
