### PR TITLE
Add a plugin setup guide and version the plugin with the SDK

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
+  "version": "0.5.13",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.1.0",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ Load the Inkbox skills into your coding agent so it automatically knows how to u
 
 The plugin loads the Inkbox skills and connects the remote MCP server. Sign in when prompted to authorize an identity.
 
+The plugin's version tracks the SDK and CLI release it documents, so `/plugin update` pulls the skills that match the version you're running.
+
 ### Codex (plugin)
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,8 +21,14 @@ Each package has its own `publish.sh`: **dry run by default**, `--prod` to publi
 | `cli/package.json` (+ `package-lock.json`) | `version` **and** the `@inkbox/sdk` dependency → `^<new version>` |
 | `cli/src/client.ts` | `CLI_VERSION` (User-Agent constant) |
 | `sdk/rust/Cargo.toml` (+ `Cargo.lock` `inkbox` entry) | `version` |
+| `.claude-plugin/plugin.json` | `version` |
 
 The CLI declares `@inkbox/sdk: ^<version>` and `cli/publish.sh` refuses to publish unless that matches `sdk/typescript`'s version — so bump it too.
+
+The plugin isn't published to a registry, but its version is the cache key Claude
+Code uses to decide whether an installed copy is out of date. Leaving it behind
+means people who already installed the plugin keep the old skills no matter how
+many commits land, so it moves with the same number as everything else.
 
 ## 2. Update the changelog
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,82 @@
+---
+name: inkbox-setup
+description: Connect the Inkbox MCP server bundled with this plugin, and confirm the connection is working. Use when Inkbox tools are missing, unauthorized, or acting as the wrong identity.
+---
+
+# Connect Inkbox
+
+This plugin bundles the Inkbox MCP server alongside its skills. The skills work
+on their own, but the tools (`inkbox_email_send`, `inkbox_text_send`, and the
+rest) only appear once the server is connected and authorized.
+
+## Before connecting
+
+The user needs an Inkbox account and at least one **identity**. An identity is
+the agent's own presence: a handle, an email address, and optionally a phone
+number. Creating one provisions its mailbox automatically.
+
+If they have no account or no identity yet, send them to
+<https://inkbox.ai/console> first. The Free plan includes three identities.
+
+## Connect
+
+1. Run `/mcp` and choose the `inkbox` server.
+2. Claude Code opens a browser for authorization. The user signs in.
+3. The consent page asks for two choices:
+   - **Organization** — which organization to act in.
+   - **Identity** — which identity the assistant becomes.
+4. Approving returns to Claude Code with the connection established.
+
+The identity choice is required and it is the important one. Every tool call is
+scoped to that identity alone: its mail, its messages, its contacts, its notes.
+Other identities in the same organization are not reachable from the connection,
+so picking the wrong one looks like missing data rather than an error.
+
+To act as a different identity, disconnect and reconnect, choosing the other
+identity at step 3.
+
+## Confirm it worked
+
+Call `inkbox_identity_get`. It returns the identity the connection is bound to.
+If the handle is not the one the user expected, reconnect and choose again.
+
+`inkbox_channel_status_get` reports which channels are ready — email, SMS,
+iMessage, and sending domains — and is the fastest way to explain why a send
+would fail before attempting it.
+
+## When something is missing
+
+**No Inkbox tools at all.** The server is not connected. Run `/mcp` and check
+whether `inkbox` is listed as connected; reconnect if not.
+
+**Tools return an authorization error.** The connection was revoked or expired.
+Reconnect through `/mcp`.
+
+**The consent page offers no identities.** The organization has none yet. Create
+one at <https://inkbox.ai/console>, then reconnect.
+
+**Email works but SMS tools fail.** The identity has no phone number. Numbers
+start on the Developer plan; the Free plan includes none. iMessage is available
+without a dedicated number.
+
+**A send is refused for a specific recipient.** Inkbox enforces per-identity
+contact rules and, for SMS, recipient consent. `inkbox_contact_rules_list` shows
+the rules in force, and `inkbox_sms_consent_get` reports whether a recipient can
+currently be messaged.
+
+## What this connection does not do
+
+Inkbox acts only when invoked. It does not watch the inbox in the background,
+wake the model when a message arrives, or send anything on its own. Handling
+incoming communications automatically needs a separate process that receives
+webhooks and then invokes the model.
+
+Voice is not part of this connector: it cannot place, answer, or end calls, and
+it generates no audio. The call tools are read-only, covering history and text
+transcripts of calls that already took place.
+
+## Reference
+
+- Plugin and skills: <https://inkbox.ai/docs/plugins/claude-code>
+- MCP server: <https://inkbox.ai/docs/mcp>
+- Identities: <https://inkbox.ai/docs/capabilities/identities>


### PR DESCRIPTION
## Summary

Two changes to how the plugin is delivered and explained.

- Adds `SETUP.md`, a skill that walks a user through connecting the bundled MCP server and confirming it is bound to the identity they meant.
- Moves the plugin's `version` into the SDK release lockstep, so installed copies actually receive updates.

## Setup guide

The plugin ships skills and an MCP server together. The skills work standalone, but the tools only appear once the server is authorized, and authorization requires choosing an identity. Every tool call is scoped to that identity alone, so choosing the wrong one presents as missing data rather than an error, which is hard to self-diagnose.

`SETUP.md` sits at the plugin root with skill frontmatter, so it is available as guidance when Inkbox tools are missing, unauthorized, or acting as the wrong identity. It covers connecting, confirming the bound identity, and the failure modes that are configuration rather than faults: no identity in the organization, no phone number for SMS, and sends refused by contact rules or recipient consent.

It also states two boundaries the tool list does not make obvious: the server acts only when invoked and does not watch a mailbox in the background, and it exposes no voice, so the call tools are read-only over history and text transcripts.

## Versioning

Claude Code resolves a plugin's version from `plugin.json` and uses it as the update cache key. Held at `0.1.0` since the initial manifest, no commit ever reached anyone who had already installed: the version string never changed, so the cached copy was kept and `/plugin update` reported the plugin was already current. Meanwhile the skills gained roughly a thousand lines.

`version` is now `0.5.13`, matching the SDK and CLI release the skills document, and `RELEASING.md` bumps it alongside the other five files. Folding it into a ritual that already runs on every release is more reliable than a step nobody had been told to perform.

An earlier commit on this branch removed the field entirely so the commit SHA would serve as the version. That works, but it fails this repo's own `plugin validate --strict` gate, which exists for good reason. Lockstep keeps both the strict check and semver.

## Verification

- `claude plugin validate --strict` passes on both manifests.
- Plugin version matches all four packages at `0.5.13`.
- Every link in `SETUP.md` returns `200`: the console, the plugin page, the MCP page, and the identities page.
- No skill, SDK, or CLI behavior changes.

## Related

The lockstep list in the shared stack prompt was updated to include this manifest, and its stale `0.4.9` corrected to `0.5.13`.