### PR TITLE
Normalize SDK base_url (tolerate trailing /api or /api/v1)

### DIFF
--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -69,6 +69,19 @@ from inkbox.whoami.types import WhoamiResponse, _parse_whoami
 
 _DEFAULT_BASE_URL = "https://inkbox.ai"
 
+
+def _normalize_base_url(base_url: str) -> str:
+    """Return the bare origin, tolerating a trailing ``/api`` or ``/api/v1``.
+
+    The SDK appends ``/api`` and ``/api/v1`` itself, so a caller who passes a
+    full API base (e.g. ``https://inkbox.ai/api``) would otherwise double it up.
+    """
+    trimmed = base_url.rstrip("/")
+    for suffix in ("/api/v1", "/api"):
+        if trimmed.endswith(suffix):
+            return trimmed[: -len(suffix)]
+    return trimmed
+
 # `_UNSET` is imported from inkbox.identities.types above. Identity-based
 # `is not _UNSET` checks must compare against the SAME object across all
 # layers; a module-local `object()` here would leak the sentinel through
@@ -157,6 +170,7 @@ class Inkbox:
             )
         if base_url is None:
             base_url = _DEFAULT_BASE_URL
+        base_url = _normalize_base_url(base_url)
         if not base_url.startswith("https://"):
             _parsed = urlparse(base_url)
             if _parsed.hostname not in ("localhost", "127.0.0.1"):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -185,3 +185,31 @@ class TestPerRequestHeaders:
 
         assert seen == ["stable-logical-operation"]
         client.close()
+
+
+class TestBaseUrlNormalization:
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://localhost:8000",
+            "https://localhost:8000/",
+            "https://localhost:8000/api",
+            "https://localhost:8000/api/",
+            "https://localhost:8000/api/v1",
+            "https://localhost:8000/api/v1/",
+        ],
+    )
+    def test_trailing_api_suffix_is_stripped(self, base_url):
+        # A caller may pass either the bare origin or a full API base; the SDK
+        # appends /api and /api/v1 itself, so all of these must resolve alike.
+        client = Inkbox(api_key="sk-test", base_url=base_url)
+        assert client._base_url == "https://localhost:8000"
+        assert (
+            str(client._phone_http._client.base_url)
+            == "https://localhost:8000/api/v1/phone/"
+        )
+        assert (
+            str(client._root_api_http._client.base_url).rstrip("/")
+            == "https://localhost:8000/api"
+        )
+        client.close()

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -72,6 +72,20 @@ import {
 const DEFAULT_BASE_URL = "https://inkbox.ai";
 
 /**
+ * Return the bare origin, tolerating a trailing `/api` or `/api/v1`.
+ *
+ * The SDK appends `/api` and `/api/v1` itself, so a caller who passes a full
+ * API base (e.g. `https://inkbox.ai/api`) would otherwise double it up.
+ */
+function normalizeBaseUrl(url: string): string {
+  const trimmed = url.replace(/\/+$/, "");
+  for (const suffix of ["/api/v1", "/api"]) {
+    if (trimmed.endsWith(suffix)) return trimmed.slice(0, -suffix.length);
+  }
+  return trimmed;
+}
+
+/**
  * `User-Agent` announcing the SDK (e.g. `inkbox-typescript/0.4.17`); an
  * optional caller token goes first (`inkbox-cli/1.2.3 inkbox-typescript/...`).
  */
@@ -204,8 +218,8 @@ export class Inkbox {
     const apiKey = resolved.apiKey;
     const vaultKey = resolved.vaultKey;
     this._apiKey = apiKey;
-    const baseUrl = resolved.baseUrl ?? DEFAULT_BASE_URL;
-    this._baseUrl = baseUrl.replace(/\/$/, "");
+    const baseUrl = normalizeBaseUrl(resolved.baseUrl ?? DEFAULT_BASE_URL);
+    this._baseUrl = baseUrl;
     if (!baseUrl.startsWith("https://")) {
       const parsed = new URL(baseUrl);
       if (parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
@@ -216,7 +230,7 @@ export class Inkbox {
         );
       }
     }
-    const apiRoot = `${baseUrl.replace(/\/$/, "")}/api/v1`;
+    const apiRoot = `${baseUrl}/api/v1`;
     const ms = options.timeoutMs ?? 30_000;
     this._timeoutMs = ms;
     const userAgent = sdkUserAgent(options.userAgentPrefix);
@@ -228,7 +242,7 @@ export class Inkbox {
     const idsHttp      = new HttpTransport(apiKey, `${apiRoot}/identities`, ms, cookieJar, userAgent);
     const vaultHttp    = new HttpTransport(apiKey, `${apiRoot}/vault`, ms, cookieJar, userAgent);
     const domainsHttp  = new HttpTransport(apiKey, `${apiRoot}/domains`, ms, cookieJar, userAgent);
-    const rootApiHttp  = new HttpTransport(apiKey, `${baseUrl.replace(/\/$/, "")}/api`, ms, cookieJar, userAgent);
+    const rootApiHttp  = new HttpTransport(apiKey, `${baseUrl}/api`, ms, cookieJar, userAgent);
     const apiHttp      = new HttpTransport(apiKey, apiRoot, ms, cookieJar, userAgent);
     const publicHttp   = new HttpTransport(apiKey, this._baseUrl, ms, cookieJar, userAgent);
 

--- a/sdk/typescript/tests/inkbox.test.ts
+++ b/sdk/typescript/tests/inkbox.test.ts
@@ -95,6 +95,18 @@ describe("Inkbox constructor", () => {
     expect(ink.mailboxes).toBeInstanceOf(MailboxesResource);
   });
 
+  it("normalizes a baseUrl that already includes /api or /api/v1", () => {
+    for (const baseUrl of [
+      "https://test.inkbox.ai/api",
+      "https://test.inkbox.ai/api/",
+      "https://test.inkbox.ai/api/v1",
+      "https://test.inkbox.ai/api/v1/",
+    ]) {
+      const ink = new Inkbox({ apiKey: "key", baseUrl });
+      expect((ink as unknown as { _baseUrl: string })._baseUrl).toBe("https://test.inkbox.ai");
+    }
+  });
+
   it("uses default baseUrl when not provided", () => {
     const ink = new Inkbox({ apiKey: "key" });
     expect(ink.mailboxes).toBeInstanceOf(MailboxesResource);


### PR DESCRIPTION
## Problem

Both SDKs append `/api` and `/api/v1` to `base_url` themselves, so a caller who passes a **full** API base (e.g. `https://inkbox.ai/api`) gets doubled paths — `.../api/api/whoami` → **404**. This bit the agent onboarding flow end-to-end: the agent-signup response's own recommended `inkbox-claude bootstrap --base-url https://inkbox.ai/api` fails on its first call (`whoami`), and docs/humans routinely paste `/api` too.

`whoami` lives at the unversioned `/api/whoami` on purpose, so the SDK's `_api_base` is correct — the only bug is the un-normalized input.

## Change

- **Python** (`sdk/python/inkbox/client.py`): add `_normalize_base_url()` and apply it in the constructor. Strips a trailing `/api/v1` or `/api` (and trailing slashes) so callers may pass either the bare origin or a full API base.
- **TypeScript** (`sdk/typescript/src/inkbox.ts`): mirror with `normalizeBaseUrl()`.
- Tests added in both suites covering `/api`, `/api/v1`, and trailing-slash variants.

## Testing

- `uv run pytest tests/test_client.py` → 20 passed
- `vitest run tests/inkbox.test.ts` → 25 passed

## Related (separate PRs)

- servers: stop emitting `--base-url .../api` in the signup message (authoritative fix; this PR is the defensive half).
- claude-code-plugin: graceful voice skip, failing-step in bootstrap errors, real Claude-auth check in `doctor`.

Note: the in-repo `inkbox-agent-self-signup` skill already documents `invitation_token`; the stale coverage is only in the published v0.1.0 package (republish concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)