### PR TITLE
fix(ts): return false on truncated webhook signatures

### DIFF
--- a/sdk/typescript/src/signing_keys.ts
+++ b/sdk/typescript/src/signing_keys.ts
@@ -90,6 +90,8 @@ export function verifyWebhook({
   const message = Buffer.concat([Buffer.from(`${requestId}.${timestamp}.`), body]);
   const expected = createHmac("sha256", key).update(message).digest("hex");
   const received = signature.slice("sha256=".length);
+  // timingSafeEqual throws on length mismatch; Python/Rust return false.
+  if (expected.length !== received.length) return false;
   return timingSafeEqual(Buffer.from(expected), Buffer.from(received));
 }
 

--- a/sdk/typescript/tests/signing-keys.test.ts
+++ b/sdk/typescript/tests/signing-keys.test.ts
@@ -81,6 +81,10 @@ describe("verifyWebhook", () => {
     expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders(sig), secret: TEST_KEY })).toBe(false);
   });
 
+  it("returns false for truncated signature without throwing", () => {
+    expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders("sha256=abcd"), secret: TEST_KEY })).toBe(false);
+  });
+
   it("returns false when headers are missing", () => {
     expect(verifyWebhook({ payload: TEST_BODY, headers: {}, secret: TEST_KEY })).toBe(false);
   });


### PR DESCRIPTION
Fixes #144

## The bug

`verifyWebhook` calls Node's `timingSafeEqual` with no length check. When `X-Inkbox-Signature` is `sha256=` plus a digest that is not exactly 64 hex characters, verification throws:

```
RangeError: Input buffers must have the same byte length
```

instead of returning `false`.

Python (`hmac.compare_digest`) and Rust (explicit length guard) already return `false`. A TypeScript webhook receiver that treats `verifyWebhook` as a boolean check and does not wrap it in `try/catch` will **500** on malformed or attack traffic instead of rejecting with 403.

Existing tests only covered equal-length failures, so CI stayed green.

## The fix

One length guard before `timingSafeEqual`, matching Python/Rust. One regression test for `sha256=abcd`.

```ts
if (expected.length !== received.length) return false;
return timingSafeEqual(Buffer.from(expected), Buffer.from(received));
```

CLI and any other caller already go through this shared helper — no second patch.

## Verification

```
npm test -- tests/signing-keys.test.ts
# 13 passed
```

Manual cases that previously threw now return `false`: truncated, empty digest, odd length, too-long. Valid signatures and wrong-but-same-length digests unchanged.
