### PR TITLE
feat(python): add AsyncInkbox awaitable client

### DIFF
--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -3,6 +3,7 @@ inkbox — Python SDK for the Inkbox APIs.
 """
 
 from inkbox.client import Inkbox
+from inkbox.async_client import AsyncAgentIdentity, AsyncInkbox
 from inkbox.agent_identity import AgentIdentity
 from inkbox.credentials import Credentials
 from inkbox.a2a import (
@@ -432,6 +433,8 @@ __all__ = [
     "A2AWireTaskState",
     # Entry points
     "Inkbox",
+    "AsyncInkbox",
+    "AsyncAgentIdentity",
     "AgentIdentity",
     "Credentials",
     # Exceptions

--- a/sdk/python/inkbox/async_client.py
+++ b/sdk/python/inkbox/async_client.py
@@ -1,0 +1,210 @@
+"""
+inkbox/async_client.py
+
+AsyncInkbox — async entry point for agent runtimes (FastAPI, tunnels, asyncio).
+
+ponytail: REST I/O still runs on the sync ``Inkbox`` / ``httpx.Client`` via
+``asyncio.to_thread``. That unblocks ``await`` call sites without cloning every
+resource into async form. Upgrade path: ``AsyncHttpTransport`` (httpx.AsyncClient)
+plus async resource methods, then drop the thread hop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections.abc
+import functools
+from typing import Any
+
+from inkbox.agent_identity import AgentIdentity
+from inkbox.client import Inkbox
+from inkbox.credentials import Credentials
+
+# Objects whose public methods hit the network (or wrap ones that do).
+_PROXY_TYPES = (
+    AgentIdentity,
+    Credentials,
+    Inkbox,
+)
+
+
+def _should_proxy(obj: Any) -> bool:
+    if isinstance(obj, _PROXY_TYPES):
+        return True
+    cls = type(obj)
+    if not cls.__module__.startswith("inkbox."):
+        return False
+    name = cls.__name__
+    return (
+        name.endswith("Resource")
+        or name.endswith("Namespace")
+        or name == "A2AClient"
+        or name == "UnlockedVault"
+    )
+
+
+def _exhaust_if_iterator(result: Any) -> Any:
+    # Sync helpers like ``iter_emails`` return lazy iterators that page over
+    # HTTP. Drain them inside the worker thread so the event loop never blocks
+    # on a subsequent ``next()``.
+    if isinstance(result, collections.abc.Iterator) and not isinstance(
+        result, (list, tuple, str, bytes, dict, type(None))
+    ):
+        return list(result)
+    return result
+
+
+def _wrap(obj: Any) -> Any:
+    if isinstance(obj, AgentIdentity):
+        return AsyncAgentIdentity(obj)
+    if isinstance(obj, Inkbox):
+        return AsyncInkbox.from_sync(obj)
+    if _should_proxy(obj):
+        return AsyncProxy(obj)
+    return obj
+
+
+def _as_async(fn: Any) -> Any:
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def run() -> Any:
+            return _exhaust_if_iterator(fn(*args, **kwargs))
+
+        return _wrap(await asyncio.to_thread(run))
+
+    return wrapper
+
+
+class AsyncProxy:
+    """Awaitable view of a sync SDK object (resources, credentials, …)."""
+
+    __slots__ = ("_target",)
+
+    def __init__(self, target: Any) -> None:
+        object.__setattr__(self, "_target", target)
+
+    def __repr__(self) -> str:
+        return f"AsyncProxy({self._target!r})"
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._target, name)
+        if callable(attr):
+            return _as_async(attr)
+        return _wrap(attr)
+
+
+class AsyncAgentIdentity:
+    """Awaitable :class:`~inkbox.agent_identity.AgentIdentity`."""
+
+    __slots__ = ("_identity",)
+
+    def __init__(self, identity: AgentIdentity) -> None:
+        object.__setattr__(self, "_identity", identity)
+
+    @property
+    def sync(self) -> AgentIdentity:
+        """Underlying sync identity (escape hatch)."""
+        return self._identity
+
+    def __repr__(self) -> str:
+        return f"AsyncAgentIdentity({self._identity!r})"
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._identity, name)
+        if callable(attr):
+            return _as_async(attr)
+        return _wrap(attr)
+
+
+class AsyncInkbox:
+    """
+    Async org-level entry point for all Inkbox APIs.
+
+    Same constructor kwargs as :class:`~inkbox.client.Inkbox`. Use from async
+    agents and ASGI handlers::
+
+        async with AsyncInkbox(api_key="ApiKey_...") as inkbox:
+            identity = await inkbox.create_identity("support-bot")
+            await identity.send_email(
+                to=["customer@example.com"],
+                subject="Hello!",
+                body_text="Hi there",
+            )
+    """
+
+    __slots__ = ("_sync",)
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str | None = None,
+        timeout: float = 30.0,
+        vault_key: str | None = None,
+        user_agent_prefix: str | None = None,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "_sync",
+            Inkbox(
+                api_key,
+                base_url=base_url,
+                timeout=timeout,
+                vault_key=vault_key,
+                user_agent_prefix=user_agent_prefix,
+            ),
+        )
+
+    @classmethod
+    def from_sync(cls, inkbox: Inkbox) -> AsyncInkbox:
+        """Wrap an existing sync client (does not take ownership unless closed)."""
+        self = object.__new__(cls)
+        object.__setattr__(self, "_sync", inkbox)
+        return self
+
+    @property
+    def sync(self) -> Inkbox:
+        """Underlying sync client (escape hatch)."""
+        return self._sync
+
+    async def __aenter__(self) -> AsyncInkbox:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close all underlying HTTP connection pools."""
+        await asyncio.to_thread(self._sync.close)
+
+    def __repr__(self) -> str:
+        return f"AsyncInkbox({self._sync!r})"
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._sync, name)
+        if callable(attr):
+            return _as_async(attr)
+        return _wrap(attr)
+
+    # Classmethods on Inkbox are not visible via instance __getattr__.
+    @classmethod
+    async def preview_a2a_invitation(cls, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(Inkbox.preview_a2a_invitation, *args, **kwargs)
+
+    @classmethod
+    async def signup(cls, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(Inkbox.signup, *args, **kwargs)
+
+    @classmethod
+    async def verify_signup(cls, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(Inkbox.verify_signup, *args, **kwargs)
+
+    @classmethod
+    async def resend_signup_verification(cls, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(
+            Inkbox.resend_signup_verification, *args, **kwargs
+        )
+
+    @classmethod
+    async def get_signup_status(cls, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(Inkbox.get_signup_status, *args, **kwargs)

--- a/sdk/python/tests/test_async_client.py
+++ b/sdk/python/tests/test_async_client.py
@@ -1,0 +1,110 @@
+"""Tests for AsyncInkbox / AsyncAgentIdentity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sample_data_identities import IDENTITY_DETAIL_DICT
+
+from inkbox import AsyncAgentIdentity, AsyncInkbox, Inkbox
+from inkbox.agent_identity import AgentIdentity
+from inkbox.async_client import AsyncProxy
+from inkbox.identities.types import _AgentIdentityData
+from inkbox.mail.resources.messages import MessagesResource
+
+
+@pytest.mark.asyncio
+async def test_async_inkbox_create_identity_returns_async_agent():
+    client = AsyncInkbox(api_key="sk-test")
+    data = _AgentIdentityData._from_dict(IDENTITY_DETAIL_DICT)
+
+    with patch.object(client._sync, "create_identity") as create:
+        create.return_value = AgentIdentity(data, client._sync)
+        identity = await client.create_identity("sales-agent")
+
+    assert isinstance(identity, AsyncAgentIdentity)
+    assert identity.agent_handle == "sales-agent"
+    assert identity.sync.agent_handle == "sales-agent"
+    create.assert_called_once_with("sales-agent")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_agent_send_email_awaits_sync_impl():
+    data = _AgentIdentityData._from_dict(IDENTITY_DETAIL_DICT)
+    sync_inkbox = MagicMock()
+    sync_identity = AgentIdentity(data, sync_inkbox)
+    async_identity = AsyncAgentIdentity(sync_identity)
+
+    with patch.object(sync_identity, "send_email", return_value={"id": "m1"}) as send:
+        result = await async_identity.send_email(
+            to=["a@example.com"],
+            subject="Hi",
+            body_text="Hello",
+        )
+
+    assert result == {"id": "m1"}
+    send.assert_called_once_with(
+        to=["a@example.com"],
+        subject="Hi",
+        body_text="Hello",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_iter_emails_drains_iterator_off_loop():
+    data = _AgentIdentityData._from_dict(IDENTITY_DETAIL_DICT)
+    sync_identity = AgentIdentity(data, MagicMock())
+    async_identity = AsyncAgentIdentity(sync_identity)
+
+    def fake_iter():
+        yield "one"
+        yield "two"
+
+    with patch.object(sync_identity, "iter_emails", side_effect=lambda **_: fake_iter()):
+        result = await async_identity.iter_emails()
+
+    assert result == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_resource_accessor_is_async_proxy():
+    client = AsyncInkbox(api_key="sk-test")
+    assert isinstance(client.messages, AsyncProxy)
+    assert isinstance(client.sync.messages, MessagesResource)
+
+    with patch.object(client._sync.messages, "list", return_value=[]) as list_messages:
+        assert await client.messages.list() == []
+        list_messages.assert_called_once()
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes():
+    client = AsyncInkbox(api_key="sk-test")
+    with patch.object(client._sync, "close") as close:
+        async with client:
+            pass
+        close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_classmethod_signup_delegates():
+    with patch.object(Inkbox, "signup", return_value="ok") as signup:
+        result = await AsyncInkbox.signup(
+            "human@example.com",
+            note_to_human="please",
+        )
+    assert result == "ok"
+    signup.assert_called_once()
+
+
+def test_exports():
+    from inkbox import AsyncAgentIdentity as A
+    from inkbox import AsyncInkbox as B
+
+    assert A is AsyncAgentIdentity
+    assert B is AsyncInkbox


### PR DESCRIPTION
Fixes #146

## The gap

The Python SDK is sync-only (`httpx.Client`). TypeScript is natively `await`. Async Python agents — FastAPI webhooks, ASGI tunnels, browser-use — wrap every call by hand:

```python
await asyncio.to_thread(identity.send_email, ...)
```

Miss one site and the event loop blocks. In-repo examples already do this boilerplate (`examples/use-inkbox-browser-use`).

## What this PR adds

`AsyncInkbox` / `AsyncAgentIdentity` — same constructor kwargs and public surface as sync `Inkbox` / `AgentIdentity`, but awaitable:

```python
from inkbox import AsyncInkbox

async with AsyncInkbox(api_key="ApiKey_...") as inkbox:
    identity = await inkbox.create_identity("support-bot")
    await identity.send_email(
        to=["user@example.com"],
        subject="Hello",
        body_text="Hi",
    )
```

- Resource accessors (`inkbox.messages`, `inkbox.vault`, …) and nested objects return awaitable proxies.
- Sync iterators (`iter_emails`, …) are drained off the event loop and returned as lists.
- Escape hatches: `inkbox.sync` / `identity.sync`.
- Signup classmethods (`signup`, `verify_signup`, …) are awaitable on `AsyncInkbox`.

**Implementation note.** REST still uses the sync client via `asyncio.to_thread`, so the event loop does not block without cloning every resource onto `httpx.AsyncClient`. True async I/O is a follow-up if thread-pool load becomes a problem (called out in the module docstring). Sync `Inkbox` is unchanged.

## Verification

```
pytest tests/test_async_client.py
# 7 passed
```

Live smoke against a real org (admin key): `whoami`, `get_identity`, `send_email` (to self), `iter_unread_emails`, `get_message`, `mark_emails_read`, `list_identities`, `messages.list`, `vault.info` — all via `await`.
