### PR TITLE
0.5.15: Harden tunnel runtime recovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # .gitignore
 
+*PLAN.md
+
 *.npmrc
 
 # Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.5.15 — Resilient tunnel runtimes
+
+### Added
+
+- Python and TypeScript tunnel listeners expose sampleable local `status`,
+  connection state, and latest successful connection time. Rust adds a
+  cloneable, thread-safe `TunnelStatusHandle` behind `tunnels-runtime`.
+
+### Changed
+
+- Python, TypeScript, and Rust bound tunnel connection establishment and HELLO,
+  clean partial connections and owned runtime tasks, and report cold reconnect
+  attempts and recovery. Missed PING acknowledgements force recovery at their
+  acknowledgement deadline.
+- Tunnel status callbacks are edge-triggered in all three SDKs: repeated failed
+  attempts within one outage retain `reconnecting` without emitting duplicate
+  callbacks. Attempt-level detail remains available in lifecycle logs.
+- Python and TypeScript preserve make-before-break planned handoff and typed
+  bridge drain while making cold connection loss release blocked work promptly.
+  Rust retains its blocking, caller-owned thread model and cold reconnect path.
+- TypeScript `serveForever()` now rejects on terminal runtime failures, matching
+  `wait()`. Fire-and-forget callers must attach a rejection handler.
+- Python `close()` raises `TimeoutError` rather than reporting success if its
+  runtime thread cannot stop within the shutdown bound. Signal and
+  `KeyboardInterrupt` cleanup remain non-raising.
+- Package and plugin versions moved in lockstep to 0.5.15; the CLI now depends
+  on `@inkbox/sdk` `^0.5.15`.
+
 ## 0.5.14 — A2A invitations
 
 - A2A invitation creates now preserve the server's optional share URL. Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 - Python and TypeScript preserve make-before-break planned handoff and typed
   bridge drain while making cold connection loss release blocked work promptly.
   Rust retains its blocking, caller-owned thread model and cold reconnect path.
+- TypeScript in-process WebSocket handlers now receive typed
+  `WsConnectionLost` (`1011`) on cold tunnel loss; URL-forwarded WebSockets send
+  the same CLOSE code to their local upstream. Planned drain remains
+  `WsServerDraining` (`4500`).
 - TypeScript `serveForever()` now rejects on terminal runtime failures, matching
   `wait()`. Fire-and-forget callers must attach a rejection handler.
 - Python `close()` raises `TimeoutError` rather than reporting success if its
@@ -31,6 +35,15 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   `KeyboardInterrupt` cleanup remain non-raising.
 - Package and plugin versions moved in lockstep to 0.5.15; the CLI now depends
   on `@inkbox/sdk` `^0.5.15`.
+
+### Compatibility
+
+- **Behavior change:** TypeScript callers that start `serveForever()` without
+  awaiting it must attach a rejection handler. Terminal failures no longer wait
+  for a later `wait()` call to surface.
+- **Behavior change:** Python `close()` can raise `TimeoutError` after 30 seconds.
+  A `finally` block should preserve any earlier exception if shutdown also times
+  out. Signal and `KeyboardInterrupt` cleanup remain non-raising.
 
 ## 0.5.14 — A2A invitations
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ use inkbox::tunnels::client::TunnelStatusHandle;
 let status = TunnelStatusHandle::new();
 let runtime_status = status.clone();
 let client = inkbox.clone();
-std::thread::spawn(move || {
+let tunnel_thread = std::thread::spawn(move || {
     client.tunnels().connect_with_status(
         "my-app",
         "http://127.0.0.1:8080",
@@ -280,6 +280,11 @@ std::thread::spawn(move || {
     )
 });
 println!("{:?} {}", status.status(), status.is_connected());
+
+// Join when shutdown is expected so startup/runtime errors are surfaced.
+if let Err(error) = tunnel_thread.join().expect("tunnel thread panicked") {
+    eprintln!("tunnel stopped: {error}");
+}
 ```
 
 Python and TypeScript also accept an in-process callable (Fetch handler in TS,

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Task detail includes current state and message history.
 # Outbound HTTP/2 only — no inbound port to open. POSIX only.
 listener = inkbox.tunnels.connect(name="my-app", forward_to="http://127.0.0.1:8080")
 print(listener.public_url)
+print(listener.status, listener.is_connected, listener.last_connected_at)
 listener.wait()
 ```
 
@@ -256,10 +257,35 @@ const listener = await connect(inkbox, {
   forwardTo: "http://127.0.0.1:8080",
 });
 console.log(listener.publicUrl);
+console.log(listener.status, listener.isConnected, listener.lastConnectedAt);
 await listener.wait();
 ```
 
-Both SDKs also accept an in-process callable (Fetch handler in TS, ASGI app in Python) instead of a `forward_to` URL, and a `tls_mode: "passthrough"` option for end-to-end TLS termination in your process. See [`skills/inkbox-tunnels/`](./skills/inkbox-tunnels/) for the full reference.
+### Tunnels (Rust)
+
+The blocking Rust runtime is behind the `tunnels-runtime` feature. Run it on a
+caller-owned thread and retain a cloneable local status handle:
+
+```rust
+use inkbox::tunnels::client::TunnelStatusHandle;
+
+let status = TunnelStatusHandle::new();
+let runtime_status = status.clone();
+let client = inkbox.clone();
+std::thread::spawn(move || {
+    client.tunnels().connect_with_status(
+        "my-app",
+        "http://127.0.0.1:8080",
+        runtime_status.callback(),
+    )
+});
+println!("{:?} {}", status.status(), status.is_connected());
+```
+
+Python and TypeScript also accept an in-process callable (Fetch handler in TS,
+ASGI app in Python) instead of a `forward_to` URL. All three runtimes reconnect
+after transient connection failures. See [`skills/inkbox-tunnels/`](./skills/inkbox-tunnels/)
+for the full reference.
 
 **Redeploys are graceful.** When the tunnel service redeploys, a long-running listener reconnects make-before-break: it stands up a fresh connection before closing the draining one, so short HTTP requests see no gap. In-progress WebSocket and passthrough-TCP sessions cannot migrate across a redeploy — they end with a typed `server_draining` close and the third-party peer reconnects onto the new task. Write handlers to reconnect idempotently.
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.5.14",
+        "@inkbox/sdk": "^0.5.15",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.5.14",
+    "@inkbox/sdk": "^0.5.15",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.5.14";
+export const CLI_VERSION = "0.5.15";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1176,6 +1176,9 @@ runtime reconnects. These properties describe this local listener. The
 `listener.tunnel` object is the bootstrap resource snapshot; fetch the tunnel
 again when you need current control-plane fields. Authentication rejection and
 takeover remain terminal and surface from `wait()` / `serve_forever()`.
+Synchronous `close()` raises `TimeoutError` if the runtime thread does not stop
+within 30 seconds; avoid calling it from a `finally` block if that exception
+would mask another error.
 
 Tunnels are provisioned atomically by `inkbox.create_identity(...)`;
 there is no standalone `create` / `delete` / `restore` /

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1150,6 +1150,9 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
         forward_to="http://127.0.0.1:8080",
     )
     print(listener.public_url)        # https://my-app.inkboxwire.com
+    print(listener.status)            # idle, connecting, connected, ...
+    print(listener.is_connected)      # local runtime liveness
+    print(listener.last_connected_at) # aware UTC datetime, or None
     listener.wait()                   # blocks until close()/Ctrl-C
 
     # Or forward to an in-process ASGI app (FastAPI / Starlette / yours)
@@ -1164,6 +1167,15 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
 ```
 
 Async variant (`serve_forever()` / `aclose()`) is available for callers already inside an event loop. Pick one pair; don't mix `wait`/`close` with the async APIs.
+
+The listener retries transient connect, HELLO, transport, and PING failures with
+bounded establishment and exponential backoff. `status` is one of `idle`,
+`connecting`, `connected`, `reconnecting`, `closed`, or `superseded`;
+`last_connected_at` retains the latest successful connection time while the
+runtime reconnects. These properties describe this local listener. The
+`listener.tunnel` object is the bootstrap resource snapshot; fetch the tunnel
+again when you need current control-plane fields. Authentication rejection and
+takeover remain terminal and surface from `wait()` / `serve_forever()`.
 
 Tunnels are provisioned atomically by `inkbox.create_identity(...)`;
 there is no standalone `create` / `delete` / `restore` /

--- a/sdk/python/inkbox/tunnels/client/_listener.py
+++ b/sdk/python/inkbox/tunnels/client/_listener.py
@@ -150,7 +150,11 @@ class TunnelListener:
             raise err
 
     def close(self) -> None:
-        """Sync graceful shutdown."""
+        """Sync graceful shutdown.
+
+        Raises:
+            TimeoutError: If the runtime thread does not stop within 30 seconds.
+        """
         self._close(raise_on_timeout=True)
 
     def _close(self, *, raise_on_timeout: bool) -> None:

--- a/sdk/python/inkbox/tunnels/client/_listener.py
+++ b/sdk/python/inkbox/tunnels/client/_listener.py
@@ -17,6 +17,7 @@ import logging
 import signal
 import sys
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +31,7 @@ from inkbox.tunnels.client._runtime import (
     DEFAULT_OUTBOUND_BODY_BYTES,
     StatusCallback,
     TunnelRuntime,
+    TunnelRuntimeStatus,
 )
 from inkbox.tunnels.client._url_forward import validate_forward_target
 from inkbox.tunnels.types import Tunnel
@@ -62,6 +64,9 @@ class TunnelListener:
         tunnel: A snapshot of the :class:`Tunnel` resource record taken
             at bootstrap. Not refreshed; call ``inkbox.tunnels.get(id)``
             for live state.
+        status: Current local runtime state.
+        is_connected: Whether the local runtime is currently connected.
+        last_connected_at: UTC time of the latest successful connection.
     """
 
     def __init__(
@@ -91,6 +96,18 @@ class TunnelListener:
     def tunnel(self) -> Tunnel:
         return self._bundle.tunnel
 
+    @property
+    def status(self) -> TunnelRuntimeStatus:
+        return self._runtime.status
+
+    @property
+    def is_connected(self) -> bool:
+        return self._runtime.is_connected
+
+    @property
+    def last_connected_at(self) -> datetime | None:
+        return self._runtime.last_connected_at
+
     # --- sync API -----------------------------------------------------------
 
     def wait(self) -> None:
@@ -115,7 +132,7 @@ class TunnelListener:
                 while not self._stopped.wait(timeout=1.0):
                     pass
             except KeyboardInterrupt:
-                self.close()
+                self._close(raise_on_timeout=False)
                 raise
         finally:
             if sigterm_handler_installed:
@@ -134,11 +151,22 @@ class TunnelListener:
 
     def close(self) -> None:
         """Sync graceful shutdown."""
+        self._close(raise_on_timeout=True)
+
+    def _close(self, *, raise_on_timeout: bool) -> None:
         loop = self._loop
         if loop is not None and not loop.is_closed():
             loop.call_soon_threadsafe(self._schedule_async_close)
         if self._thread is not None:
             self._thread.join(timeout=30.0)
+            if self._thread.is_alive():
+                message = "tunnel runtime thread did not stop within 30 seconds"
+                if raise_on_timeout:
+                    raise TimeoutError(message)
+                logger.error(message)
+        elif self._runtime.status != "closed":
+            self._runtime._stop.set()
+            self._runtime._notify_status("closed")
 
     # --- async API ----------------------------------------------------------
 
@@ -173,7 +201,7 @@ class TunnelListener:
 
     def _signal_handler(self, signum: int, frame: object) -> None:
         logger.info("received signal %s; shutting down listener", signum)
-        self.close()
+        self._close(raise_on_timeout=False)
 
     def _start_thread_if_needed(self) -> None:
         if self._thread is not None:
@@ -256,7 +284,7 @@ def connect(
             (1-32). Omit to let the server decide.
         on_status: Callback invoked with status strings
             (``"connecting"``, ``"connected"``, ``"reconnecting"``,
-            ``"closed"``).
+            ``"closed"``, ``"superseded"``).
         max_inbound_body_bytes: Cap on materialized inbound bodies;
             oversize requests get a 413 to the third party.
         max_outbound_body_bytes: Cap on materialized outbound bodies;

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -28,9 +28,12 @@ import random
 import socket
 import ssl
 import struct
+import threading
 import time
 from contextlib import suppress
-from typing import Any, Callable, NoReturn
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Callable, Literal, NoReturn
 from uuid import UUID
 
 import h2.config
@@ -90,6 +93,11 @@ PING_INTERVAL = 20.0
 # is the failure mode this guards against — without it, ``_read_loop``
 # can park forever on a half-broken socket.
 PING_ACK_TIMEOUT = 10.0
+CONNECT_TIMEOUT_SEC = 10.0
+HELLO_TIMEOUT_SEC = 15.0
+TASK_TEARDOWN_TIMEOUT_SEC = 5.0
+WRITER_CLOSE_TIMEOUT_SEC = 1.0
+INITIAL_BACKOFF_SEC = 1.0
 # OS TCP keepalive cadence applied to the underlying socket. Kicks in
 # below the application-level PING ack timeout when the OS supports it
 # (Linux/macOS); on platforms without per-socket keepalive knobs we
@@ -169,8 +177,22 @@ class _StreamEvent:
         self.reset_code = reset_code
 
 
-# Type for status callbacks.
-StatusCallback = Callable[[str], None]
+TunnelRuntimeStatus = Literal[
+    "idle", "connecting", "connected", "reconnecting", "closed", "superseded",
+]
+StatusCallback = Callable[[TunnelRuntimeStatus], None]
+
+_DISPATCH_GENERATION: ContextVar[int] = ContextVar(
+    "inkbox_tunnel_dispatch_generation", default=-1,
+)
+
+
+class _ConnectTimeoutError(TimeoutError):
+    pass
+
+
+class _HelloTimeoutError(TimeoutError):
+    pass
 
 
 class _Connection:
@@ -202,6 +224,11 @@ class _Connection:
         "read_task",
         "outstanding_ping_payload",
         "outstanding_ping_sent_at",
+        "closed",
+        "bridge_close_code",
+        "aborted",
+        "waiters_woken",
+        "ping_acknowledged",
         "goaway_received",
         "superseded",
     )
@@ -227,6 +254,11 @@ class _Connection:
         self.read_task: asyncio.Task[None] | None = None
         self.outstanding_ping_payload: bytes | None = None
         self.outstanding_ping_sent_at: float | None = None
+        self.closed = asyncio.Event()
+        self.bridge_close_code: int | None = None
+        self.aborted = False
+        self.waiters_woken = False
+        self.ping_acknowledged = asyncio.Event()
         # Set once a GOAWAY (ConnectionTerminated) lands; the read loop
         # winds down because hyper-h2 is now CLOSED.
         self.goaway_received = False
@@ -299,6 +331,7 @@ class TunnelRuntime:
         # replacement; the supervisor + HTTP-reply gate key off it.
         self._handoff_in_flight = False
         self._handoff_task: asyncio.Task[None] | None = None
+        self._handoff_terminal_error: _TunnelAuthError | None = None
         self._last_handoff_at = 0.0
         # Set when another client took over this tunnel: serve_forever stops
         # and does not reconnect. Distinct from a transient drop or a drain.
@@ -309,6 +342,11 @@ class TunnelRuntime:
         # handoff must let an in-flight handler finish and post its reply
         # on the NEW conn. Only a cold reconnect cancels them.
         self._tasks: set[asyncio.Task[Any]] = set()
+        self._generation = 0
+
+        self._status_lock = threading.Lock()
+        self._status: TunnelRuntimeStatus = "idle"
+        self._last_connected_at: datetime | None = None
 
         # httpx.AsyncClient for URL forwarding + body-uri GETs. Lazily
         # created on first dispatch, closed deterministically in aclose().
@@ -443,19 +481,37 @@ class TunnelRuntime:
 
     # --- public lifecycle ----------------------------------------------------
 
+    @property
+    def status(self) -> TunnelRuntimeStatus:
+        with self._status_lock:
+            return self._status
+
+    @property
+    def is_connected(self) -> bool:
+        return self.status == "connected"
+
+    @property
+    def last_connected_at(self) -> datetime | None:
+        with self._status_lock:
+            return self._last_connected_at
+
     async def aclose(self) -> None:
         self._stop.set()
-        # Cancel the ping loop on every connection (active + draining) so
-        # no ping loop leaks across a handoff set, and close each writer.
         conns = [c for c in [self._active, *self._draining] if c is not None]
+        tasks: set[asyncio.Task[Any]] = set(self._tasks)
         for conn in conns:
-            self._stop_ping_loop(conn)
-            if conn.writer is not None:
-                try:
-                    conn.writer.close()
-                    await conn.writer.wait_closed()
-                except (OSError, ConnectionError):
-                    pass
+            ping_task = self._stop_ping_loop(conn)
+            if ping_task is not None:
+                tasks.add(ping_task)
+            self._publish_connection_closed(conn, bridge_close_code=1000)
+        tasks.update(
+            conn.read_task for conn in conns if conn.read_task is not None
+        )
+        if self._handoff_task is not None:
+            tasks.add(self._handoff_task)
+        await self._cancel_tasks_bounded(tasks, context="listener shutdown")
+        for conn in conns:
+            await self._close_connection_writer(conn)
         if self._passthrough_dispatch is not None:
             try:
                 await self._passthrough_dispatch.aclose()  # type: ignore[union-attr]
@@ -468,23 +524,34 @@ class TunnelRuntime:
             except Exception:
                 pass
             self._http_client = None
+        if self.status != "superseded":
+            self._notify_status("closed")
 
     def _force_reconnect(self) -> None:
-        writer = self._writer
-        if writer is None:
-            return
-        with suppress(Exception):
-            writer.close()
+        if self._active is not None:
+            self._force_reconnect_conn(self._active)
 
     async def serve_forever(self) -> None:
-        backoff = 1.0
+        if self._stop.is_set():
+            self._notify_status("closed")
+            return
+        backoff = INITIAL_BACKOFF_SEC
         consecutive_failures = 0
+        attempt = 0
         self._notify_status("connecting")
         while not self._stop.is_set():
+            attempt += 1
+            logger.info("tunnel runtime: connection attempt %d", attempt)
             try:
                 await self._run_once()
-                backoff = 1.0
+                backoff = INITIAL_BACKOFF_SEC
                 consecutive_failures = 0
+                if not self._stop.is_set():
+                    if self.status != "reconnecting":
+                        logger.warning(
+                            "tunnel runtime: connected session lost; reconnecting",
+                        )
+                    self._notify_status("reconnecting")
             except asyncio.CancelledError:
                 raise
             except _TunnelAuthError:
@@ -497,6 +564,13 @@ class TunnelRuntime:
                 raise
             except _TunnelSupersededError as e:
                 self._stop_superseded(e)
+            except (_ConnectTimeoutError, _HelloTimeoutError) as exc:
+                consecutive_failures += 1
+                logger.warning(
+                    "tunnel runtime: %s (attempt %d); reconnecting",
+                    exc, attempt,
+                )
+                self._notify_status("reconnecting")
             except Exception:
                 # A takeover GOAWAY that lands mid-hello sets _superseded but
                 # surfaces as a plain connection error; go terminal here so we
@@ -527,16 +601,33 @@ class TunnelRuntime:
         conn = _Connection(self._next_conn_id)
         self._next_conn_id += 1
         self._active = conn
-        await self._open_connection(conn)
-        conn.read_task = asyncio.create_task(self._read_loop(conn))
         try:
             try:
-                await self._send_hello(conn)
-            except Exception:
-                conn.read_task.cancel()
-                raise
-            self._notify_status("connected")
+                await asyncio.wait_for(
+                    self._open_connection(conn), timeout=CONNECT_TIMEOUT_SEC,
+                )
+            except asyncio.TimeoutError as exc:
+                raise _ConnectTimeoutError(
+                    f"connection setup timed out after {CONNECT_TIMEOUT_SEC:.1f}s",
+                ) from exc
+            conn.read_task = asyncio.create_task(
+                self._read_loop(conn), name=f"inkbox-tunnel-read-{conn.conn_id}",
+            )
+            try:
+                await asyncio.wait_for(
+                    self._send_hello(conn), timeout=HELLO_TIMEOUT_SEC,
+                )
+            except asyncio.TimeoutError as exc:
+                raise _HelloTimeoutError(
+                    f"hello timed out after {HELLO_TIMEOUT_SEC:.1f}s",
+                ) from exc
+            recovered = self.last_connected_at is not None
             self._start_serving(conn)
+            self._record_connected(emit=True)
+            logger.info(
+                "tunnel runtime: %s connection established",
+                "recovered" if recovered else "initial",
+            )
             # Supervise the active connection. A NO_ERROR GOAWAY swaps in
             # a fresh active out-of-band (make-before-break); follow it
             # without going through the backoff loop. Only a cold death
@@ -549,12 +640,16 @@ class TunnelRuntime:
                 if self._handoff_in_flight and self._handoff_task is not None:
                     with suppress(asyncio.CancelledError, Exception):
                         await self._handoff_task
+                if self._handoff_terminal_error is not None:
+                    raise self._handoff_terminal_error
                 nxt = self._active
                 if nxt is not None and nxt is not conn and not nxt.draining:
                     conn = nxt
                     continue
                 if conn.read_task is None or conn.read_task.done():
                     break
+            if conn.read_task is not None and conn.read_task.done():
+                conn.read_task.result()
             # Another client took over this tunnel: stop, do not reconnect.
             if self._superseded:
                 raise _TunnelSupersededError(
@@ -591,41 +686,102 @@ class TunnelRuntime:
         """Cold teardown of the supervised conn + any draining conns +
         all runtime dispatch tasks. The cold path (no live successor) is
         the only one that cancels in-flight dispatch tasks."""
-        for c in [conn, *list(self._draining)]:
-            self._stop_ping_loop(c)
-            rt = c.read_task
-            if rt is not None and not rt.done():
-                rt.cancel()
-                with suppress(asyncio.CancelledError, Exception):
-                    await rt
-        for task in list(self._tasks):
-            task.cancel()
-        for task in list(self._tasks):
-            with suppress(asyncio.CancelledError, Exception):
-                await task
-        self._tasks.clear()
-        for c in [conn, *list(self._draining)]:
+        self._generation += 1
+        conns = [conn, *list(self._draining)]
+        tasks: set[asyncio.Task[Any]] = set(self._tasks)
+        for c in conns:
+            ping_task = self._stop_ping_loop(c)
+            if ping_task is not None:
+                tasks.add(ping_task)
+            self._publish_connection_closed(c)
+            if c.read_task is not None:
+                tasks.add(c.read_task)
+        await self._cancel_tasks_bounded(tasks, context="cold reconnect")
+        for c in conns:
+            self._force_reconnect_conn(c)
             await self._close_connection_writer(c)
         self._draining.clear()
         if self._active is conn:
             self._active = None
 
-    async def _close_connection_writer(self, conn: _Connection) -> None:
+    async def _close_connection_writer(
+        self,
+        conn: _Connection,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        if timeout is None:
+            timeout = WRITER_CLOSE_TIMEOUT_SEC
+        writer = conn.writer
+        if writer is not None:
+            with suppress(Exception):
+                writer.close()
+            try:
+                await asyncio.wait_for(
+                    writer.wait_closed(), timeout=max(0.0, timeout),
+                )
+            except (asyncio.TimeoutError, OSError, ConnectionError):
+                self._abort_writer(writer)
         conn.streams.clear()
         conn.window_events.clear()
-        if conn.writer is not None:
-            with suppress(OSError, ConnectionError):
-                conn.writer.close()
-                await conn.writer.wait_closed()
         conn.writer = None
         conn.reader = None
         conn.h2 = None
 
     def _spawn(self, coro: Any) -> asyncio.Task[Any]:
-        task = asyncio.create_task(coro)
+        inherited_generation = _DISPATCH_GENERATION.get()
+        generation = (
+            inherited_generation
+            if inherited_generation != -1
+            else self._generation
+        )
+
+        async def _run() -> Any:
+            token = _DISPATCH_GENERATION.set(generation)
+            try:
+                return await coro
+            finally:
+                _DISPATCH_GENERATION.reset(token)
+
+        task = asyncio.create_task(_run())
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
         return task
+
+    async def _cancel_tasks_bounded(
+        self,
+        tasks: set[asyncio.Task[Any]],
+        *,
+        context: str,
+        timeout: float | None = None,
+    ) -> None:
+        if timeout is None:
+            timeout = TASK_TEARDOWN_TIMEOUT_SEC
+        current = asyncio.current_task()
+        pending = {task for task in tasks if task is not current and not task.done()}
+        for task in pending:
+            task.cancel()
+        if pending:
+            _done, pending = await asyncio.wait(
+                pending, timeout=max(0.0, timeout),
+            )
+        for task in tasks - pending:
+            if task.done():
+                with suppress(asyncio.CancelledError, Exception):
+                    task.result()
+        for task in pending:
+            if task not in self._tasks:
+                self._tasks.add(task)
+                task.add_done_callback(self._tasks.discard)
+            stack = task.get_stack(limit=1)
+            location = "unknown"
+            if stack:
+                frame = stack[-1]
+                location = f"{frame.f_code.co_filename}:{frame.f_lineno}"
+            logger.warning(
+                "tunnel runtime: task %r still pending after %s teardown at %s",
+                task.get_name(), context, location,
+            )
 
     # --- make-before-break handoff ------------------------------------------
 
@@ -642,8 +798,10 @@ class TunnelRuntime:
             return
         logger.info("tunnel runtime: starting handoff (reason=%r)", reason)
         self._handoff_in_flight = True
+        self._handoff_terminal_error = None
         self._last_handoff_at = time.monotonic()
         old_conn.draining = True
+        old_conn.bridge_close_code = WS_CLOSE_SERVER_DRAINING
         self._draining.add(old_conn)
         # The old h2 is CLOSED at GOAWAY; pinging it is meaningless.
         self._stop_ping_loop(old_conn)
@@ -653,6 +811,7 @@ class TunnelRuntime:
         try:
             new_conn = await self._make_replacement_connection()
             self._active = new_conn
+            self._record_connected(emit=False)
             # Supervisor was watching old_conn; wake it to follow new.
             self._supervisor_wake.set()
         except asyncio.CancelledError:
@@ -661,6 +820,10 @@ class TunnelRuntime:
             # External takeover during the handoff hello: _superseded is set,
             # so end the old conn and wake the supervisor to stop terminally
             # (no cold redial, which would boot the client that replaced us).
+            self._force_reconnect_conn(old_conn)
+            self._supervisor_wake.set()
+        except _TunnelAuthError as exc:
+            self._handoff_terminal_error = exc
             self._force_reconnect_conn(old_conn)
             self._supervisor_wake.set()
         except Exception:
@@ -674,34 +837,61 @@ class TunnelRuntime:
             self._supervisor_wake.set()
         finally:
             self._handoff_in_flight = False
-            self._handoff_task = None
-            await self._drain_old_connection(old_conn)
+            try:
+                await self._drain_old_connection(old_conn)
+            finally:
+                self._handoff_task = None
 
     async def _make_replacement_connection(self) -> _Connection:
         """Dial + hello + park a replacement, retrying transient hello
         failures (a drain 503 back on the still-draining task) within a
         bounded jittered budget."""
         backoff = 0.1
-        start = time.monotonic()
+        deadline = time.monotonic() + HANDOFF_REDIAL_BUDGET_SEC
         while not self._stop.is_set():
+            if deadline - time.monotonic() <= 0:
+                raise RuntimeError("handoff redial budget exhausted")
             conn = _Connection(self._next_conn_id)
             self._next_conn_id += 1
             try:
-                await self._open_connection(conn)
-                conn.read_task = asyncio.create_task(self._read_loop(conn))
-                await self._send_hello(conn)
+                remaining = deadline - time.monotonic()
+                await asyncio.wait_for(
+                    self._open_connection(conn),
+                    timeout=min(CONNECT_TIMEOUT_SEC, remaining),
+                )
+                conn.read_task = asyncio.create_task(
+                    self._read_loop(conn),
+                    name=f"inkbox-tunnel-read-{conn.conn_id}",
+                )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError
+                await asyncio.wait_for(
+                    self._send_hello(conn),
+                    timeout=min(HELLO_TIMEOUT_SEC, remaining),
+                )
                 self._start_serving(conn)
                 return conn
             except asyncio.CancelledError:
+                self._force_reconnect_conn(conn)
+                await self._cancel_tasks_bounded(
+                    {conn.read_task} if conn.read_task is not None else set(),
+                    context="handoff cancellation",
+                )
+                await self._close_connection_writer(conn)
                 raise
             except Exception as exc:
                 self._force_reconnect_conn(conn)
-                rt = conn.read_task
-                if rt is not None and not rt.done():
-                    rt.cancel()
-                    with suppress(asyncio.CancelledError, Exception):
-                        await rt
-                await self._close_connection_writer(conn)
+                remaining = max(0.0, deadline - time.monotonic())
+                await self._cancel_tasks_bounded(
+                    {conn.read_task} if conn.read_task is not None else set(),
+                    context="handoff retry",
+                    timeout=min(TASK_TEARDOWN_TIMEOUT_SEC, remaining),
+                )
+                remaining = max(0.0, deadline - time.monotonic())
+                await self._close_connection_writer(
+                    conn, timeout=min(WRITER_CLOSE_TIMEOUT_SEC, remaining),
+                )
                 # A rejected key or a takeover is terminal; never retry either
                 # (retrying a takeover would boot the client that replaced us).
                 if isinstance(exc, (_TunnelAuthError, _TunnelSupersededError)):
@@ -713,10 +903,11 @@ class TunnelRuntime:
                     raise _TunnelSupersededError(
                         "another client connected to this tunnel during handoff",
                     )
-                if (time.monotonic() - start) > HANDOFF_REDIAL_BUDGET_SEC:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     raise RuntimeError("handoff redial budget exhausted")
                 jitter = backoff * BACKOFF_JITTER * (2 * random.random() - 1)
-                await asyncio.sleep(max(0.05, backoff + jitter))
+                await asyncio.sleep(min(max(0.05, backoff + jitter), remaining))
                 backoff = min(backoff * 2, 5.0)
         raise RuntimeError("runtime stopped during handoff")
 
@@ -726,12 +917,15 @@ class TunnelRuntime:
         bridge, then close the old writer. No bridge-drain window to wait
         on (unlike Node)."""
         self._surface_draining_to_bridges(old_conn)
-        self._stop_ping_loop(old_conn)
+        self._publish_connection_closed(
+            old_conn, bridge_close_code=WS_CLOSE_SERVER_DRAINING,
+        )
+        ping_task = self._stop_ping_loop(old_conn)
         rt = old_conn.read_task
-        if rt is not None and not rt.done():
-            rt.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await rt
+        tasks = {task for task in (ping_task, rt) if task is not None}
+        await self._cancel_tasks_bounded(
+            tasks, context="handoff drain",
+        )
         await self._close_connection_writer(old_conn)
         self._draining.discard(old_conn)
 
@@ -739,6 +933,8 @@ class TunnelRuntime:
         """Push a typed server_draining disconnect to every live bridge
         on the draining conn so the customer's handler/ASGI app sees a
         clean close instead of a hang. No send_* on the old (CLOSED) h2."""
+        if conn.bridge_close_code is None:
+            conn.bridge_close_code = WS_CLOSE_SERVER_DRAINING
         for stream_id in list(conn.bridge_stream_ids):
             queue = conn.streams.get(stream_id)
             if queue is not None:
@@ -751,15 +947,75 @@ class TunnelRuntime:
         """Wake non-bridge stream awaiters on a closed conn with a plain
         reset so in-flight intake/response waits don't hang. Bridges get
         the typed server_draining close via _surface_draining_to_bridges."""
+        if conn.waiters_woken:
+            return
+        conn.waiters_woken = True
         for stream_id, queue in list(conn.streams.items()):
             if stream_id in conn.bridge_stream_ids:
                 continue
             with suppress(asyncio.QueueFull):
                 queue.put_nowait(_StreamEvent("reset"))
+        for event in list(conn.window_events.values()):
+            event.set()
+        conn.conn_window_event.set()
+
+    def _publish_connection_closed(
+        self, conn: _Connection, *, bridge_close_code: int | None = None,
+    ) -> None:
+        if conn.bridge_close_code is None and bridge_close_code is not None:
+            conn.bridge_close_code = bridge_close_code
+        self._wake_streams_on_close(conn)
+        conn.closed.set()
+
+    async def _next_stream_event(
+        self,
+        conn: _Connection,
+        stream_id: int,
+        queue: asyncio.Queue[_StreamEvent],
+    ) -> _StreamEvent:
+        with suppress(asyncio.QueueEmpty):
+            return queue.get_nowait()
+        if conn.closed.is_set():
+            code = conn.bridge_close_code if stream_id in conn.bridge_stream_ids else None
+            if stream_id in conn.bridge_stream_ids and code is None:
+                code = 1011
+            return _StreamEvent("reset", reset_code=code)
+        get_task = asyncio.create_task(queue.get())
+        close_task = asyncio.create_task(conn.closed.wait())
+        try:
+            await asyncio.wait(
+                {get_task, close_task}, return_when=asyncio.FIRST_COMPLETED,
+            )
+            if get_task.done():
+                return get_task.result()
+            with suppress(asyncio.QueueEmpty):
+                return queue.get_nowait()
+            code = conn.bridge_close_code if stream_id in conn.bridge_stream_ids else None
+            if stream_id in conn.bridge_stream_ids and code is None:
+                code = 1011
+            return _StreamEvent("reset", reset_code=code)
+        finally:
+            for task in (get_task, close_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(get_task, close_task, return_exceptions=True)
 
     def _force_reconnect_conn(self, conn: _Connection) -> None:
-        writer = conn.writer
-        if writer is None:
+        if conn.aborted:
+            return
+        conn.aborted = True
+        self._enter_reconnecting(conn)
+        self._publish_connection_closed(conn)
+        if conn.writer is not None:
+            self._abort_writer(conn.writer)
+
+    @staticmethod
+    def _abort_writer(writer: asyncio.StreamWriter) -> None:
+        transport = getattr(writer, "transport", None)
+        abort = getattr(transport, "abort", None)
+        if callable(abort):
+            with suppress(Exception):
+                abort()
             return
         with suppress(Exception):
             writer.close()
@@ -908,8 +1164,10 @@ class TunnelRuntime:
             stream_id = self._open_stream_locked(hello_headers, end_stream=True, conn=conn)
             await self._flush_conn(conn)
 
-        status, body = await self._await_response(stream_id, conn=conn)
-        conn.streams.pop(stream_id, None)
+        try:
+            status, body = await self._await_response(stream_id, conn=conn)
+        finally:
+            conn.streams.pop(stream_id, None)
         if status in (401, 403):
             raise _TunnelAuthError(
                 f"/_system/hello returned {status}; the API key was rejected "
@@ -985,7 +1243,7 @@ class TunnelRuntime:
         body = bytearray()
         got_headers = False
         while True:
-            event = await queue.get()
+            event = await self._next_stream_event(conn, stream_id, queue)
             if event.kind == "headers" and not got_headers:
                 got_headers = True
                 status_str = next(
@@ -1015,6 +1273,7 @@ class TunnelRuntime:
             not self._stop.is_set()
             and not conn.draining
             and conn.h2 is not None
+            and not (conn.read_task is not None and conn.read_task.done())
         ):
             try:
                 envelope = await self._park_one_intake(conn, slot)
@@ -1079,7 +1338,7 @@ class TunnelRuntime:
         body = bytearray()
         try:
             while True:
-                event = await queue.get()
+                event = await self._next_stream_event(conn, stream_id, queue)
                 if event.kind == "headers" and headers is None:
                     headers = event.headers
                 elif event.kind == "data":
@@ -1122,20 +1381,17 @@ class TunnelRuntime:
 
     # --- read pump ----------------------------------------------------------
 
-    def _stop_ping_loop(self, conn: _Connection) -> None:
+    def _stop_ping_loop(self, conn: _Connection) -> asyncio.Task[None] | None:
         task = conn.ping_task
         conn.ping_task = None
         if task is not None and not task.done():
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
             task.cancel()
+        return task
 
     async def _ping_loop(self, conn: _Connection | None = None) -> None:
-        """Send a PING every ``PING_INTERVAL`` and force-reconnect if a
-        prior PING has not been acked within ``PING_ACK_TIMEOUT``.
-
-        Detects silently-dead TCP that the OS hasn't reported yet
-        (carrier loss, firewall idle reap, NAT rebind, etc.). The TS
-        runtime has the same shape; this brings Python to parity.
-        """
+        """Send PINGs and abort when an acknowledgement misses its deadline."""
         conn = conn if conn is not None else self._active
         assert conn is not None
 
@@ -1151,22 +1407,10 @@ class TunnelRuntime:
             await asyncio.sleep(PING_INTERVAL)
             if conn.h2 is None or conn.writer is None:
                 return
-            # Before sending the next PING, fail fast if the previous
-            # one is still unacked past the deadline.
-            if (
-                conn.outstanding_ping_payload is not None
-                and conn.outstanding_ping_sent_at is not None
-                and (time.monotonic() - conn.outstanding_ping_sent_at)
-                > PING_ACK_TIMEOUT
-            ):
-                logger.warning(
-                    "tunnel runtime: PING ack not received within %.1fs; "
-                    "forcing reconnect",
-                    PING_ACK_TIMEOUT,
-                )
-                _force()
-                return
             payload = struct.pack("!Q", int(time.monotonic_ns()) & ((1 << 64) - 1))
+            conn.ping_acknowledged.clear()
+            conn.outstanding_ping_payload = payload
+            conn.outstanding_ping_sent_at = time.monotonic()
             try:
                 async with conn.send_lock:
                     conn.h2.ping(payload)
@@ -1178,31 +1422,56 @@ class TunnelRuntime:
                 )
                 _force()
                 return
-            conn.outstanding_ping_payload = payload
-            conn.outstanding_ping_sent_at = time.monotonic()
+            ack_task = asyncio.create_task(conn.ping_acknowledged.wait())
+            stop_task = asyncio.create_task(self._stop.wait())
+            close_task = asyncio.create_task(conn.closed.wait())
+            try:
+                done, _pending = await asyncio.wait(
+                    {ack_task, stop_task, close_task},
+                    timeout=PING_ACK_TIMEOUT,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if ack_task in done:
+                    continue
+                if stop_task in done or close_task in done:
+                    return
+                logger.warning(
+                    "tunnel runtime: PING ack not received within %.1fs; "
+                    "forcing reconnect",
+                    PING_ACK_TIMEOUT,
+                )
+                _force()
+                return
+            finally:
+                for task in (ack_task, stop_task, close_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(
+                    ack_task, stop_task, close_task, return_exceptions=True,
+                )
 
     async def _read_loop(self, conn: _Connection | None = None) -> None:
         conn = conn if conn is not None else self._active
         assert conn is not None and conn.h2 is not None and conn.reader is not None
-        while not self._stop.is_set():
-            chunk = await conn.reader.read(65536)
-            if not chunk:
-                return
-            try:
-                events = conn.h2.receive_data(chunk)
-            except h2.exceptions.ProtocolError:
-                logger.exception("h2 protocol error")
-                return
-            for event in events:
-                await self._handle_event(event, conn)
-            if conn.goaway_received:
-                # hyper-h2 is CLOSED; nothing more will arrive on this
-                # conn. Surface a synthetic reset to any pending stream
-                # awaiters so they wake instead of hanging.
-                self._wake_streams_on_close(conn)
-                return
-            async with conn.send_lock:
-                await self._flush_conn(conn)
+        try:
+            while not self._stop.is_set():
+                chunk = await conn.reader.read(65536)
+                if not chunk:
+                    return
+                try:
+                    events = conn.h2.receive_data(chunk)
+                except h2.exceptions.ProtocolError:
+                    logger.exception("h2 protocol error")
+                    return
+                for event in events:
+                    await self._handle_event(event, conn)
+                if conn.goaway_received:
+                    return
+                async with conn.send_lock:
+                    await self._flush_conn(conn)
+        finally:
+            self._enter_reconnecting(conn)
+            self._publish_connection_closed(conn)
 
     async def _handle_event(
         self, event: h2.events.Event, conn: _Connection | None = None,
@@ -1251,19 +1520,14 @@ class TunnelRuntime:
                 if ev is not None:
                     ev.set()
         elif isinstance(event, h2.events.PingAckReceived):
-            # Clear the outstanding-ping marker so ``_ping_loop``'s next
-            # tick doesn't trip the watchdog. ``ping_data`` round-trips
-            # the bytes we sent; we don't strictly require equality
-            # (a single outstanding ping at a time means the only
-            # legitimate ack is for that ping) but we still validate
-            # for sanity.
             ack_data = getattr(event, "ping_data", None)
             if (
                 conn.outstanding_ping_payload is not None
-                and (ack_data is None or ack_data == conn.outstanding_ping_payload)
+                and ack_data == conn.outstanding_ping_payload
             ):
                 conn.outstanding_ping_payload = None
                 conn.outstanding_ping_sent_at = None
+                conn.ping_acknowledged.set()
         elif isinstance(event, h2.events.ConnectionTerminated):
             debug = ""
             try:
@@ -1660,7 +1924,7 @@ class TunnelRuntime:
 
         async def _await_connect_200() -> bool:
             while True:
-                event = await queue.get()
+                event = await self._next_stream_event(origin, stream_id, queue)
                 if event.kind == "headers":
                     status_str = next(
                         (v for k, v in event.headers if k == ":status"), "0",
@@ -1821,7 +2085,7 @@ class TunnelRuntime:
 
         async def _await_connect_200() -> bool:
             while True:
-                event = await queue.get()
+                event = await self._next_stream_event(origin, stream_id, queue)
                 if event.kind == "headers":
                     status_str = next(
                         (v for k, v in event.headers if k == ":status"), "0",
@@ -1989,7 +2253,11 @@ class TunnelRuntime:
             when upstream closed (abrupt EOF/RST) so the loop can exit
             without waiting for a third-party frame that may never
             arrive."""
-            get_task = asyncio.create_task(origin.streams[stream_id].get())
+            get_task = asyncio.create_task(
+                self._next_stream_event(
+                    origin, stream_id, origin.streams[stream_id],
+                ),
+            )
             close_task = asyncio.create_task(upstream_closed.wait())
             try:
                 done, _pending = await asyncio.wait(
@@ -2219,7 +2487,9 @@ class TunnelRuntime:
         sender = self._spawn(app_to_wire())
         try:
             while not recv_done:
-                event = await origin.streams[stream_id].get()
+                event = await self._next_stream_event(
+                    origin, stream_id, origin.streams[stream_id],
+                )
                 if event.kind == "data":
                     unacked_wire_bytes += event.flow_controlled_length
                     wire_buf.extend(event.data)
@@ -2338,7 +2608,7 @@ class TunnelRuntime:
         async def _await_bridge_status_200() -> None:
             queue = origin.streams[stream_id]
             while True:
-                event = await queue.get()
+                event = await self._next_stream_event(origin, stream_id, queue)
                 if event.kind == "headers":
                     status_str = next(
                         (v for k, v in event.headers if k == ":status"), "0",
@@ -2473,7 +2743,9 @@ class TunnelRuntime:
             unacked_wire_bytes = 0
             try:
                 while True:
-                    event = await origin.streams[stream_id].get()
+                    event = await self._next_stream_event(
+                        origin, stream_id, origin.streams[stream_id],
+                    )
                     if event.kind == "end":
                         return
                     if event.kind == "reset":
@@ -2710,6 +2982,7 @@ class TunnelRuntime:
                 and not c.draining
                 and c.h2 is not None
                 and not c.goaway_received
+                and not c.closed.is_set()
             )
         if usable(self._active):
             return self._active
@@ -2726,6 +2999,9 @@ class TunnelRuntime:
         body: bytes,
         target: _Connection | None = None,
     ) -> None:
+        generation = _DISPATCH_GENERATION.get()
+        if self._drop_stale_reply(generation, request_id):
+            return
         # HTTP webhook replies migrate to the current active conn; pass
         # an explicit ``target`` (the origin) for replies that must NOT
         # migrate (WS-upgrade reply). A webhook can finish in the window
@@ -2738,6 +3014,8 @@ class TunnelRuntime:
                         asyncio.shield(self._handoff_task),
                         timeout=POST_ACTIVE_WAIT_SEC,
                     )
+            if self._drop_stale_reply(generation, request_id):
+                return
             conn = self._pick_reply_connection(self._active)
             if conn is None:
                 logger.warning(
@@ -2747,6 +3025,12 @@ class TunnelRuntime:
                 return
         else:
             conn = target
+            if conn.closed.is_set() or conn.h2 is None:
+                logger.warning(
+                    "closed connection cannot post reply request_id=%s; dropping",
+                    request_id,
+                )
+                return
 
         req_headers: list[tuple[str, str]] = [
             (":method", "POST"),
@@ -2766,6 +3050,12 @@ class TunnelRuntime:
             req_headers.append((f"inkbox-h-{kl}", v))
 
         async with conn.send_lock:
+            if (
+                self._drop_stale_reply(generation, request_id)
+                or conn.closed.is_set()
+                or conn.h2 is None
+            ):
+                return
             stream_id = self._open_stream_locked(
                 req_headers, end_stream=(len(body) == 0), conn=conn,
             )
@@ -2784,6 +3074,14 @@ class TunnelRuntime:
             logger.warning("/_system/response/%s timed out", request_id)
         finally:
             conn.streams.pop(stream_id, None)
+
+    def _drop_stale_reply(self, generation: int, request_id: str) -> bool:
+        if generation == -1 or generation == self._generation:
+            return False
+        logger.warning(
+            "dropping stale reply request_id=%s after reconnect", request_id,
+        )
+        return True
 
     async def _reset_bridge_stream(
         self, stream_id: int, conn: _Connection | None = None,
@@ -2837,13 +3135,16 @@ class TunnelRuntime:
         conn: _Connection | None = None,
     ) -> None:
         conn = conn if conn is not None else self._active
-        assert conn is not None and conn.h2 is not None
+        if conn is None or conn.h2 is None or conn.closed.is_set():
+            raise ConnectionError("h2 connection torn down")
         offset = 0
         total = len(data)
         while offset < total:
+            if conn.closed.is_set():
+                raise ConnectionError("h2 connection closed")
             await self._await_window(stream_id, conn=conn)
             async with conn.send_lock:
-                if conn.h2 is None:
+                if conn.h2 is None or conn.closed.is_set():
                     raise ConnectionError("h2 connection torn down")
                 window = min(
                     conn.h2.local_flow_control_window(stream_id),
@@ -2859,9 +3160,10 @@ class TunnelRuntime:
                 await self._flush_conn(conn)
         if end_stream and offset == 0:
             async with conn.send_lock:
-                if conn.h2 is not None:
-                    conn.h2.send_data(stream_id, b"", end_stream=True)
-                    await self._flush_conn(conn)
+                if conn.h2 is None or conn.closed.is_set():
+                    raise ConnectionError("h2 connection torn down")
+                conn.h2.send_data(stream_id, b"", end_stream=True)
+                await self._flush_conn(conn)
 
     def _mark_window_blocked(
         self, stream_id: int, conn: _Connection | None = None,
@@ -2913,8 +3215,10 @@ class TunnelRuntime:
     ) -> None:
         conn = conn if conn is not None else self._active
         assert conn is not None
+        if conn.closed.is_set():
+            raise ConnectionError("h2 connection closed")
         async with conn.send_lock:
-            if conn.h2 is None:
+            if conn.h2 is None or conn.closed.is_set():
                 raise ConnectionError("h2 connection torn down")
             stream_window = conn.h2.local_flow_control_window(stream_id)
             conn_window = conn.h2.outbound_flow_control_window
@@ -2929,7 +3233,7 @@ class TunnelRuntime:
         if not wait_tasks:
             return
         try:
-            done, pending = await asyncio.wait(
+            await asyncio.wait(
                 wait_tasks, return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
@@ -2937,13 +3241,39 @@ class TunnelRuntime:
                 if not t.done():
                     t.cancel()
             for t in wait_tasks:
-                if not t.done():
-                    with suppress(asyncio.CancelledError, Exception):
-                        await t
+                with suppress(asyncio.CancelledError, Exception):
+                    await t
+        if conn.closed.is_set():
+            raise ConnectionError("h2 connection closed")
 
     # --- utilities ----------------------------------------------------------
 
-    def _notify_status(self, status: str) -> None:
+    def _record_connected(self, *, emit: bool) -> None:
+        with self._status_lock:
+            self._status = "connected"
+            self._last_connected_at = datetime.now(timezone.utc)
+        if emit:
+            self._invoke_status_callback("connected")
+
+    def _notify_status(self, status: TunnelRuntimeStatus) -> None:
+        with self._status_lock:
+            if self._status == status:
+                return
+            self._status = status
+        self._invoke_status_callback(status)
+
+    def _enter_reconnecting(self, conn: _Connection) -> None:
+        if (
+            conn is self._active
+            and not conn.draining
+            and not self._stop.is_set()
+            and not self._superseded
+            and self.status == "connected"
+        ):
+            logger.warning("tunnel runtime: connected session lost; reconnecting")
+            self._notify_status("reconnecting")
+
+    def _invoke_status_callback(self, status: TunnelRuntimeStatus) -> None:
         if self._on_status is not None:
             try:
                 self._on_status(status)
@@ -2988,4 +3318,6 @@ def _first_header(
 async def _safe_close_stream_writer(writer: asyncio.StreamWriter) -> None:
     with suppress(Exception):
         writer.close()
-        await writer.wait_closed()
+        await asyncio.wait_for(
+            writer.wait_closed(), timeout=WRITER_CLOSE_TIMEOUT_SEC,
+        )

--- a/sdk/python/inkbox/tunnels/client/_runtime.py
+++ b/sdk/python/inkbox/tunnels/client/_runtime.py
@@ -180,7 +180,10 @@ class _StreamEvent:
 TunnelRuntimeStatus = Literal[
     "idle", "connecting", "connected", "reconnecting", "closed", "superseded",
 ]
-StatusCallback = Callable[[TunnelRuntimeStatus], None]
+TunnelCallbackStatus = Literal[
+    "connecting", "connected", "reconnecting", "closed", "superseded",
+]
+StatusCallback = Callable[[TunnelCallbackStatus], None]
 
 _DISPATCH_GENERATION: ContextVar[int] = ContextVar(
     "inkbox_tunnel_dispatch_generation", default=-1,
@@ -649,7 +652,11 @@ class TunnelRuntime:
                 if conn.read_task is None or conn.read_task.done():
                     break
             if conn.read_task is not None and conn.read_task.done():
-                conn.read_task.result()
+                try:
+                    conn.read_task.result()
+                except asyncio.CancelledError:
+                    if not self._stop.is_set() and not conn.aborted:
+                        raise
             # Another client took over this tunnel: stop, do not reconnect.
             if self._superseded:
                 raise _TunnelSupersededError(
@@ -808,6 +815,7 @@ class TunnelRuntime:
         self._handoff_task = asyncio.create_task(self._run_handoff(old_conn))
 
     async def _run_handoff(self, old_conn: _Connection) -> None:
+        owner = asyncio.current_task()
         try:
             new_conn = await self._make_replacement_connection()
             self._active = new_conn
@@ -836,11 +844,13 @@ class TunnelRuntime:
             self._force_reconnect_conn(old_conn)
             self._supervisor_wake.set()
         finally:
-            self._handoff_in_flight = False
+            if self._handoff_task is owner:
+                self._handoff_in_flight = False
             try:
                 await self._drain_old_connection(old_conn)
             finally:
-                self._handoff_task = None
+                if self._handoff_task is owner:
+                    self._handoff_task = None
 
     async def _make_replacement_connection(self) -> _Connection:
         """Dial + hello + park a replacement, retrying transient hello
@@ -3255,7 +3265,7 @@ class TunnelRuntime:
         if emit:
             self._invoke_status_callback("connected")
 
-    def _notify_status(self, status: TunnelRuntimeStatus) -> None:
+    def _notify_status(self, status: TunnelCallbackStatus) -> None:
         with self._status_lock:
             if self._status == status:
                 return
@@ -3273,7 +3283,7 @@ class TunnelRuntime:
             logger.warning("tunnel runtime: connected session lost; reconnecting")
             self._notify_status("reconnecting")
 
-    def _invoke_status_callback(self, status: TunnelRuntimeStatus) -> None:
+    def _invoke_status_callback(self, status: TunnelCallbackStatus) -> None:
         if self._on_status is not None:
             try:
                 self._on_status(status)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.5.14"
+version = "0.5.15"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_tunnels_reconnect.py
+++ b/sdk/python/tests/test_tunnels_reconnect.py
@@ -17,8 +17,8 @@ from inkbox.tunnels.client._listener import TunnelListener
 from inkbox.tunnels.client._runtime import (
     _DISPATCH_GENERATION,
     StatusCallback,
+    TunnelCallbackStatus,
     TunnelRuntime,
-    TunnelRuntimeStatus,
     _ConnectTimeoutError,
     _Connection,
     _HelloTimeoutError,
@@ -354,6 +354,175 @@ async def test_auth_failure_during_handoff_is_terminal(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_failed_handoff_canceled_reader_reaches_cold_retry(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    attempts = 0
+    recovered = asyncio.Event()
+
+    async def open_connection(_conn: _Connection) -> None:
+        nonlocal attempts
+        attempts += 1
+
+    async def read_loop(_conn: _Connection) -> None:
+        await asyncio.Event().wait()
+
+    async def hello(_conn: _Connection) -> None:
+        return None
+
+    async def failed_replacement() -> _Connection:
+        raise RuntimeError("replacement failed")
+
+    def start_serving(conn: _Connection) -> None:
+        if attempts == 1:
+            runtime._begin_handoff(conn, reason="drain")
+        else:
+            recovered.set()
+            runtime._stop.set()
+            runtime._publish_connection_closed(conn)
+
+    monkeypatch.setattr(runtime, "_open_connection", open_connection)
+    monkeypatch.setattr(runtime, "_read_loop", read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", hello)
+    monkeypatch.setattr(runtime, "_start_serving", start_serving)
+    monkeypatch.setattr(
+        runtime, "_make_replacement_connection", failed_replacement,
+    )
+    monkeypatch.setattr(runtime_module, "INITIAL_BACKOFF_SEC", 0.01)
+    monkeypatch.setattr(runtime_module, "BACKOFF_JITTER", 0.0)
+
+    await asyncio.wait_for(runtime.serve_forever(), timeout=0.5)
+
+    assert recovered.is_set()
+    assert attempts == 2
+    assert runtime.status == "closed"
+
+
+@pytest.mark.asyncio
+async def test_normal_shutdown_canceled_reader_is_not_fatal(monkeypatch) -> None:
+    runtime = _runtime()
+    serving = asyncio.Event()
+
+    async def open_connection(_conn: _Connection) -> None:
+        return None
+
+    async def read_loop(_conn: _Connection) -> None:
+        await asyncio.Event().wait()
+
+    async def hello(_conn: _Connection) -> None:
+        return None
+
+    monkeypatch.setattr(runtime, "_open_connection", open_connection)
+    monkeypatch.setattr(runtime, "_read_loop", read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", hello)
+    monkeypatch.setattr(runtime, "_start_serving", lambda _conn: serving.set())
+
+    run_task = asyncio.create_task(runtime._run_once())
+    await asyncio.wait_for(serving.wait(), timeout=0.1)
+    await runtime.aclose()
+    await asyncio.wait_for(run_task, timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_read_exception_still_propagates(monkeypatch) -> None:
+    runtime = _runtime()
+
+    async def open_connection(_conn: _Connection) -> None:
+        return None
+
+    async def read_loop(_conn: _Connection) -> None:
+        raise RuntimeError("unexpected read failure")
+
+    async def hello(_conn: _Connection) -> None:
+        return None
+
+    monkeypatch.setattr(runtime, "_open_connection", open_connection)
+    monkeypatch.setattr(runtime, "_read_loop", read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", hello)
+    monkeypatch.setattr(runtime, "_start_serving", lambda _conn: None)
+
+    with pytest.raises(RuntimeError, match="unexpected read failure"):
+        await asyncio.wait_for(runtime._run_once(), timeout=0.1)
+
+
+async def _start_second_handoff_during_first_drain(runtime, monkeypatch):
+    first = _connection(1)
+    second = _connection(2)
+    third = _connection(3)
+    runtime._active = first
+    release_second = asyncio.Event()
+    second_started = asyncio.Event()
+    replacement_count = 0
+    second_tasks: list[asyncio.Task[None]] = []
+
+    async def replacement() -> _Connection:
+        nonlocal replacement_count
+        replacement_count += 1
+        if replacement_count == 1:
+            return second
+        second_started.set()
+        await release_second.wait()
+        return third
+
+    async def drain(conn: _Connection) -> None:
+        if conn is not first:
+            return
+        runtime._last_handoff_at = 0.0
+        runtime._begin_handoff(second, reason="second-drain")
+        task = runtime._handoff_task
+        assert task is not None
+        second_tasks.append(task)
+        await second_started.wait()
+
+    monkeypatch.setattr(runtime, "_make_replacement_connection", replacement)
+    monkeypatch.setattr(runtime, "_drain_old_connection", drain)
+    runtime._begin_handoff(first, reason="first-drain")
+    first_task = runtime._handoff_task
+    assert first_task is not None
+    await asyncio.wait_for(second_started.wait(), timeout=0.1)
+    await asyncio.wait_for(first_task, timeout=0.1)
+    return second_tasks[0], release_second, third
+
+
+@pytest.mark.asyncio
+async def test_first_handoff_cannot_clear_second_handoff(monkeypatch) -> None:
+    runtime = _runtime()
+
+    second_task, release_second, third = await _start_second_handoff_during_first_drain(
+        runtime, monkeypatch,
+    )
+
+    assert runtime._handoff_task is second_task
+    assert runtime._handoff_in_flight
+    release_second.set()
+    await asyncio.wait_for(second_task, timeout=0.1)
+    assert runtime._active is third
+    assert runtime._handoff_task is None
+    assert not runtime._handoff_in_flight
+
+
+@pytest.mark.asyncio
+async def test_aclose_retains_second_handoff_ownership(monkeypatch) -> None:
+    runtime = _runtime()
+
+    second_task, release_second, _third = await _start_second_handoff_during_first_drain(
+        runtime, monkeypatch,
+    )
+
+    try:
+        await asyncio.wait_for(runtime.aclose(), timeout=0.1)
+        assert second_task.done()
+        assert runtime._handoff_task is None
+        assert not runtime._handoff_in_flight
+    finally:
+        release_second.set()
+        if not second_task.done():
+            second_task.cancel()
+            await asyncio.gather(second_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_ping_timeout_is_independent_of_next_interval(monkeypatch) -> None:
     import inkbox.tunnels.client._runtime as runtime_module
 
@@ -611,7 +780,61 @@ def test_listener_exposes_thread_safe_local_liveness() -> None:
 
 
 def test_status_callback_uses_runtime_status_type() -> None:
-    assert StatusCallback == Callable[[TunnelRuntimeStatus], None]
+    assert StatusCallback == Callable[[TunnelCallbackStatus], None]
+    assert "idle" not in TunnelCallbackStatus.__args__
+
+
+def test_status_callback_exception_is_isolated_and_state_is_deduplicated(
+    caplog,
+) -> None:
+    callbacks: list[str] = []
+
+    def callback(status: TunnelCallbackStatus) -> None:
+        callbacks.append(status)
+        raise RuntimeError("callback failed")
+
+    runtime = _runtime(on_status=callback)
+    with caplog.at_level(logging.ERROR, logger="inkbox.tunnels"):
+        runtime._notify_status("connecting")
+        runtime._notify_status("connecting")
+        runtime._notify_status("reconnecting")
+        runtime._notify_status("reconnecting")
+
+    assert callbacks == ["connecting", "reconnecting"]
+    assert runtime.status == "reconnecting"
+    assert caplog.text.count("on_status callback raised") == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_attempts_back_off_and_dedupe_reconnecting(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    statuses: list[TunnelCallbackStatus] = []
+    runtime = _runtime(on_status=statuses.append)
+    attempts = 0
+    delays: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fail() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 3:
+            runtime._stop.set()
+        raise RuntimeError("dial failed")
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(runtime, "_run_once", fail)
+    monkeypatch.setattr(runtime_module.random, "random", lambda: 0.5)
+    monkeypatch.setattr(runtime_module.asyncio, "sleep", record_sleep)
+
+    await runtime.serve_forever()
+
+    assert attempts == 3
+    assert delays == [1.0, 2.0]
+    assert statuses == ["connecting", "reconnecting", "closed"]
 
 
 def test_sync_close_reports_runtime_thread_timeout() -> None:

--- a/sdk/python/tests/test_tunnels_reconnect.py
+++ b/sdk/python/tests/test_tunnels_reconnect.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import time
+from datetime import datetime, timezone
+from typing import Callable
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import h2.events
+import pytest
+
+from inkbox.tunnels.client._bootstrap import TunnelBundle
+from inkbox.tunnels.client._listener import TunnelListener
+from inkbox.tunnels.client._runtime import (
+    _DISPATCH_GENERATION,
+    StatusCallback,
+    TunnelRuntime,
+    TunnelRuntimeStatus,
+    _ConnectTimeoutError,
+    _Connection,
+    _HelloTimeoutError,
+    _StreamEvent,
+    _TunnelAuthError,
+)
+from inkbox.tunnels.types import TLSMode, Tunnel, TunnelStatus
+
+
+def _runtime(**kwargs: object) -> TunnelRuntime:
+    options: dict[str, object] = {
+        "tunnel_id": uuid4(),
+        "api_key": "ApiKey_test",
+        "zone": "tunnel.example",
+        "public_host": "agent.tunnel.example",
+        "pool_size": 1,
+        "forward_to": "http://127.0.0.1:1",
+        "tls_terminator": None,
+    }
+    options.update(kwargs)
+    return TunnelRuntime(**options)  # type: ignore[arg-type]
+
+
+class ScriptedReader:
+    def __init__(self, *results: bytes | BaseException) -> None:
+        self._results = list(results)
+        self._blocked = asyncio.Event()
+
+    async def read(self, _size: int = -1) -> bytes:
+        if not self._results:
+            await self._blocked.wait()
+            return b""
+        result = self._results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class AbortableWriter:
+    def __init__(self, on_abort=None, *, hang_close: bool = False) -> None:
+        self.writes: list[bytes] = []
+        self.close_calls = 0
+        self.abort_calls = 0
+        self._on_abort = on_abort
+        self._hang_close = hang_close
+        self.transport = self
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+    async def wait_closed(self) -> None:
+        if self._hang_close:
+            await asyncio.Event().wait()
+
+    def abort(self) -> None:
+        self.abort_calls += 1
+        if self._on_abort is not None:
+            self._on_abort()
+
+    def get_extra_info(self, _name: str):
+        return None
+
+
+class MinimalH2:
+    max_outbound_frame_size = 16384
+    outbound_flow_control_window = 65535
+
+    def __init__(self, *, stream_window: int = 65535) -> None:
+        self.stream_window = stream_window
+        self.pings: list[bytes] = []
+        self.sent_headers: list[int] = []
+        self._next_stream = 1
+
+    def data_to_send(self) -> bytes:
+        return b""
+
+    def receive_data(self, _chunk: bytes) -> list[object]:
+        return []
+
+    def get_next_available_stream_id(self) -> int:
+        stream_id = self._next_stream
+        self._next_stream += 2
+        return stream_id
+
+    def send_headers(self, stream_id: int, _headers, *, end_stream: bool) -> None:
+        self.sent_headers.append(stream_id)
+
+    def local_flow_control_window(self, _stream_id: int) -> int:
+        return self.stream_window
+
+    def send_data(self, _stream_id: int, _data: bytes, *, end_stream: bool) -> None:
+        return None
+
+    def ping(self, payload: bytes) -> None:
+        self.pings.append(payload)
+
+
+def _connection(conn_id: int = 1) -> _Connection:
+    conn = _Connection(conn_id)
+    conn.h2 = MinimalH2()  # type: ignore[assignment]
+    conn.reader = ScriptedReader()
+    conn.writer = AbortableWriter()  # type: ignore[assignment]
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_aborts_after_publishing_closed() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    observed: list[bool] = []
+    writer = AbortableWriter(lambda: observed.append(conn.closed.is_set()))
+    conn.writer = writer  # type: ignore[assignment]
+
+    runtime._force_reconnect_conn(conn)
+    runtime._force_reconnect_conn(conn)
+
+    assert observed == [True]
+    assert writer.abort_calls == 1
+    assert conn.closed.is_set()
+
+
+def test_force_reconnect_falls_back_to_writer_close() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    writer = MagicMock(spec=["close"])
+    conn.writer = writer
+
+    runtime._force_reconnect_conn(conn)
+
+    writer.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_read_eof_is_durable_for_late_waiter() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    conn.reader = ScriptedReader(b"")
+
+    await runtime._read_loop(conn)
+    conn.streams[1] = asyncio.Queue()
+
+    status, body = await asyncio.wait_for(
+        runtime._await_response(1, conn), timeout=0.1,
+    )
+    assert (status, body) == (0, b"")
+
+
+@pytest.mark.asyncio
+async def test_queued_response_wins_over_connection_close() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    queue: asyncio.Queue[_StreamEvent] = asyncio.Queue()
+    conn.streams[1] = queue
+    queue.put_nowait(_StreamEvent("headers", headers=[(":status", "204")]))
+    queue.put_nowait(_StreamEvent("end"))
+    runtime._publish_connection_closed(conn)
+
+    assert await runtime._await_response(1, conn) == (204, b"")
+
+
+@pytest.mark.asyncio
+async def test_closed_connection_releases_flow_control_waiter() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    conn.h2 = MinimalH2(stream_window=0)  # type: ignore[assignment]
+    send = asyncio.create_task(runtime._send_data(1, b"x", end_stream=True, conn=conn))
+    await asyncio.sleep(0)
+
+    runtime._publish_connection_closed(conn)
+
+    with pytest.raises(ConnectionError):
+        await asyncio.wait_for(send, timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_cold_and_planned_bridge_close_codes() -> None:
+    runtime = _runtime()
+
+    cold = _connection(1)
+    cold.bridge_stream_ids.add(3)
+    cold.streams[3] = asyncio.Queue()
+    runtime._publish_connection_closed(cold)
+    cold_event = await runtime._next_stream_event(cold, 3, cold.streams[3])
+
+    planned = _connection(2)
+    planned.bridge_stream_ids.add(5)
+    planned.streams[5] = asyncio.Queue()
+    planned.streams[5].put_nowait(_StreamEvent("reset", reset_code=4500))
+    runtime._publish_connection_closed(planned, bridge_close_code=4500)
+    planned_event = await runtime._next_stream_event(planned, 5, planned.streams[5])
+
+    assert cold_event.reset_code == 1011
+    assert planned_event.reset_code == 4500
+
+
+@pytest.mark.asyncio
+async def test_cold_callable_bridge_returns_1011() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    stream_id = 3
+    conn.bridge_stream_ids.add(stream_id)
+    conn.streams[stream_id] = asyncio.Queue()
+
+    class Session:
+        async def outbound(self):
+            if False:
+                yield None
+
+        async def deliver(self, _message) -> None:
+            return None
+
+        def signal_outbound_eof(self) -> None:
+            return None
+
+    runtime._publish_connection_closed(conn)
+
+    close_code = await asyncio.wait_for(
+        runtime._pump_ws(stream_id, Session(), conn),  # type: ignore[arg-type]
+        timeout=0.1,
+    )
+
+    assert close_code == 1011
+
+
+@pytest.mark.asyncio
+async def test_hello_timeout_removes_stream_and_aborts(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+    candidates: list[_Connection] = []
+
+    async def open_connection(candidate: _Connection) -> None:
+        candidates.append(candidate)
+        candidate.h2 = conn.h2
+        candidate.reader = conn.reader
+        candidate.writer = conn.writer
+
+    monkeypatch.setattr(runtime, "_open_connection", open_connection)
+    monkeypatch.setattr(runtime_module, "HELLO_TIMEOUT_SEC", 0.02)
+
+    with pytest.raises(_HelloTimeoutError):
+        await asyncio.wait_for(runtime._run_once(), timeout=0.2)
+
+    assert conn.writer.abort_calls == 1  # type: ignore[union-attr]
+    assert candidates[0].streams == {}
+    assert candidates[0].closed.is_set()
+    assert runtime._active is None
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_is_bounded_and_cleans_active(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+
+    async def stalled_open(_candidate: _Connection) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(runtime, "_open_connection", stalled_open)
+    monkeypatch.setattr(runtime_module, "CONNECT_TIMEOUT_SEC", 0.02)
+
+    with pytest.raises(_ConnectTimeoutError):
+        await asyncio.wait_for(runtime._run_once(), timeout=0.1)
+
+    assert runtime._active is None
+
+
+@pytest.mark.asyncio
+async def test_handoff_stalled_dial_respects_total_budget(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+
+    async def stalled_open(_conn: _Connection) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(runtime, "_open_connection", stalled_open)
+    monkeypatch.setattr(runtime_module, "HANDOFF_REDIAL_BUDGET_SEC", 0.03)
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError, match="budget exhausted"):
+        await asyncio.wait_for(runtime._make_replacement_connection(), timeout=0.2)
+
+    assert time.monotonic() - started < 0.15
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_during_handoff_is_terminal(monkeypatch) -> None:
+    runtime = _runtime()
+    initial_attempts = 0
+
+    async def open_connection(_conn: _Connection) -> None:
+        nonlocal initial_attempts
+        initial_attempts += 1
+        return None
+
+    async def read_loop(conn: _Connection) -> None:
+        await conn.closed.wait()
+
+    async def hello(_conn: _Connection) -> None:
+        return None
+
+    async def replacement() -> _Connection:
+        raise _TunnelAuthError("replacement API key rejected")
+
+    async def wait_for_handoff(conn: _Connection) -> None:
+        runtime._begin_handoff(conn, reason="drain")
+        task = runtime._handoff_task
+        assert task is not None
+        await task
+
+    monkeypatch.setattr(runtime, "_open_connection", open_connection)
+    monkeypatch.setattr(runtime, "_read_loop", read_loop)
+    monkeypatch.setattr(runtime, "_send_hello", hello)
+    monkeypatch.setattr(runtime, "_start_serving", lambda _conn: None)
+    monkeypatch.setattr(runtime, "_make_replacement_connection", replacement)
+    monkeypatch.setattr(runtime, "_wait_close_or_handoff", wait_for_handoff)
+
+    with pytest.raises(_TunnelAuthError, match="replacement API key rejected"):
+        await asyncio.wait_for(runtime.serve_forever(), timeout=0.2)
+
+    assert initial_attempts == 1
+    assert runtime._handoff_terminal_error is not None
+    assert runtime.status == "closed"
+
+
+@pytest.mark.asyncio
+async def test_ping_timeout_is_independent_of_next_interval(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+    monkeypatch.setattr(runtime_module, "PING_INTERVAL", 0.01)
+    monkeypatch.setattr(runtime_module, "PING_ACK_TIMEOUT", 0.03)
+    started = time.monotonic()
+
+    await asyncio.wait_for(runtime._ping_loop(conn), timeout=0.1)
+
+    assert conn.aborted
+    assert 0.025 <= time.monotonic() - started < 0.09
+
+
+@pytest.mark.asyncio
+async def test_only_matching_ping_ack_releases_wait(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+    monkeypatch.setattr(runtime_module, "PING_INTERVAL", 0.01)
+    monkeypatch.setattr(runtime_module, "PING_ACK_TIMEOUT", 0.08)
+    task = asyncio.create_task(runtime._ping_loop(conn))
+    while conn.outstanding_ping_payload is None:
+        await asyncio.sleep(0)
+    payload = conn.outstanding_ping_payload
+
+    await runtime._handle_event(h2.events.PingAckReceived(ping_data=b"stale!!!"), conn)
+    assert not conn.ping_acknowledged.is_set()
+    await runtime._handle_event(h2.events.PingAckReceived(ping_data=payload), conn)
+    assert conn.ping_acknowledged.is_set()
+
+    runtime._stop.set()
+    await asyncio.wait_for(task, timeout=0.1)
+    assert not conn.aborted
+
+
+@pytest.mark.asyncio
+async def test_hanging_writer_close_is_bounded_and_aborted(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    conn = _connection()
+    writer = AbortableWriter(hang_close=True)
+    conn.writer = writer  # type: ignore[assignment]
+    monkeypatch.setattr(runtime_module, "WRITER_CLOSE_TIMEOUT_SEC", 0.02)
+
+    await asyncio.wait_for(runtime._close_connection_writer(conn), timeout=0.1)
+
+    assert writer.close_calls == 1
+    assert writer.abort_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_resistant_task_cannot_block_reconnect(monkeypatch) -> None:
+    import inkbox.tunnels.client._runtime as runtime_module
+
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+    started = asyncio.Event()
+    second_cancel = asyncio.Event()
+    release = asyncio.Event()
+
+    async def resistant_dispatch() -> None:
+        cancellations = 0
+        started.set()
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancellations += 1
+                if cancellations == 2:
+                    second_cancel.set()
+
+    task = runtime._spawn(resistant_dispatch())
+    await started.wait()
+    monkeypatch.setattr(runtime_module, "TASK_TEARDOWN_TIMEOUT_SEC", 0.01)
+
+    await asyncio.wait_for(runtime._teardown_cold(conn), timeout=0.1)
+
+    assert task in runtime._tasks
+    assert not task.done()
+    close_task = asyncio.create_task(runtime.aclose())
+    await asyncio.wait_for(second_cancel.wait(), timeout=0.1)
+    release.set()
+    await asyncio.wait_for(close_task, timeout=0.1)
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_cannot_post_to_replacement() -> None:
+    runtime = _runtime()
+    runtime._generation = 2
+    opened: list[int] = []
+    runtime._open_stream_locked = lambda *args, **kwargs: opened.append(1) or 1  # type: ignore[method-assign]
+    token = _DISPATCH_GENERATION.set(1)
+    try:
+        await runtime._post_response("old", status=200, headers=[], body=b"")
+    finally:
+        _DISPATCH_GENERATION.reset(token)
+
+    assert opened == []
+
+
+@pytest.mark.asyncio
+async def test_running_post_is_blocked_after_cold_teardown() -> None:
+    runtime = _runtime()
+    old = _connection(1)
+    replacement = _connection(2)
+    runtime._active = old
+    runtime._handoff_in_flight = True
+    release_handoff = asyncio.Event()
+
+    async def handoff_wait() -> None:
+        await release_handoff.wait()
+
+    handoff_task = asyncio.create_task(handoff_wait())
+    runtime._handoff_task = handoff_task
+    opened: list[int] = []
+
+    def open_stream(_headers, *, end_stream, conn=None):
+        opened.append(conn.conn_id)
+        conn.streams[1] = asyncio.Queue()
+        conn.streams[1].put_nowait(_StreamEvent("end"))
+        return 1
+
+    runtime._open_stream_locked = open_stream  # type: ignore[method-assign]
+    token = _DISPATCH_GENERATION.set(runtime._generation)
+    try:
+        post_task = asyncio.create_task(
+            runtime._post_response("stale", status=200, headers=[], body=b""),
+        )
+    finally:
+        _DISPATCH_GENERATION.reset(token)
+    await asyncio.sleep(0)
+
+    await runtime._teardown_cold(old)
+    runtime._active = replacement
+    release_handoff.set()
+    await asyncio.wait_for(post_task, timeout=0.1)
+    await handoff_task
+
+    assert opened == []
+
+
+@pytest.mark.asyncio
+async def test_post_rechecks_generation_after_waiting_for_send_lock() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+    opened: list[int] = []
+    selected = asyncio.Event()
+    original_pick = runtime._pick_reply_connection
+
+    def pick(origin):
+        result = original_pick(origin)
+        selected.set()
+        return result
+
+    runtime._pick_reply_connection = pick  # type: ignore[method-assign]
+    runtime._open_stream_locked = lambda *args, **kwargs: opened.append(1) or 1  # type: ignore[method-assign]
+    await conn.send_lock.acquire()
+    token = _DISPATCH_GENERATION.set(runtime._generation)
+    try:
+        post_task = asyncio.create_task(
+            runtime._post_response("stale-lock", status=200, headers=[], body=b""),
+        )
+    finally:
+        _DISPATCH_GENERATION.reset(token)
+    await asyncio.wait_for(selected.wait(), timeout=0.1)
+
+    runtime._generation += 1
+    conn.send_lock.release()
+    await asyncio.wait_for(post_task, timeout=0.1)
+
+    assert opened == []
+
+
+@pytest.mark.asyncio
+async def test_reply_selection_rejects_closed_connections() -> None:
+    runtime = _runtime()
+    closed = _connection(1)
+    fallback = _connection(2)
+    runtime._active = closed
+    runtime._publish_connection_closed(closed)
+
+    assert runtime._pick_reply_connection(fallback) is fallback
+
+    opened: list[int] = []
+    runtime._open_stream_locked = lambda *args, **kwargs: opened.append(1) or 1  # type: ignore[method-assign]
+    await runtime._post_response(
+        "closed-target", status=200, headers=[], body=b"", target=closed,
+    )
+    assert opened == []
+
+
+@pytest.mark.asyncio
+async def test_child_tasks_inherit_cold_generation() -> None:
+    runtime = _runtime()
+    runtime._generation = 2
+
+    async def sample_generation() -> int:
+        return _DISPATCH_GENERATION.get()
+
+    token = _DISPATCH_GENERATION.set(1)
+    try:
+        task = runtime._spawn(sample_generation())
+        assert await task == 1
+    finally:
+        _DISPATCH_GENERATION.reset(token)
+
+
+def _bundle() -> TunnelBundle:
+    now = datetime.now(timezone.utc)
+    return TunnelBundle(
+        tunnel=Tunnel(
+            id=uuid4(), organization_id="org", tunnel_name="agent",
+            agent_identity_id=None, tls_mode=TLSMode.EDGE, cert_pem=None,
+            cert_fingerprint_sha256=None, cert_expires_at=None,
+            status=TunnelStatus.ACTIVE, last_connected_at=None,
+            last_connected_ip_addr=None, last_disconnected_at=None,
+            currently_connected=False, public_host="agent.tunnel.example",
+            zone="tunnel.example", metadata={}, created_at=now, updated_at=now,
+        ),
+        public_host="agent.tunnel.example", zone="tunnel.example",
+        tls_terminator=None,
+    )
+
+
+def test_listener_exposes_thread_safe_local_liveness() -> None:
+    runtime = _runtime()
+    listener = TunnelListener(bundle=_bundle(), runtime=runtime)
+
+    assert listener.status == "idle"
+    assert not listener.is_connected
+    assert listener.last_connected_at is None
+
+    runtime._record_connected(emit=True)
+    first = listener.last_connected_at
+    runtime._notify_status("reconnecting")
+
+    assert first is not None and first.tzinfo == timezone.utc
+    assert listener.status == "reconnecting"
+    assert not listener.is_connected
+    assert listener.last_connected_at == first
+
+    runtime._record_connected(emit=False)
+    assert listener.is_connected
+    assert listener.last_connected_at is not None
+    assert listener.last_connected_at >= first
+
+
+def test_status_callback_uses_runtime_status_type() -> None:
+    assert StatusCallback == Callable[[TunnelRuntimeStatus], None]
+
+
+def test_sync_close_reports_runtime_thread_timeout() -> None:
+    runtime = _runtime()
+    listener = TunnelListener(bundle=_bundle(), runtime=runtime)
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    listener._thread = thread
+
+    with pytest.raises(TimeoutError, match="runtime thread"):
+        listener.close()
+
+    thread.join.assert_called_once_with(timeout=30.0)
+
+
+def test_signal_handler_logs_thread_timeout_without_raising(caplog) -> None:
+    runtime = _runtime()
+    listener = TunnelListener(bundle=_bundle(), runtime=runtime)
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    listener._thread = thread
+
+    with caplog.at_level(logging.ERROR, logger="inkbox.tunnels"):
+        listener._signal_handler(signal.SIGTERM, None)
+
+    assert "runtime thread did not stop" in caplog.text
+    assert listener.status == "idle"
+
+
+def test_close_before_wait_stays_closed() -> None:
+    runtime = _runtime()
+    listener = TunnelListener(bundle=_bundle(), runtime=runtime)
+
+    listener.close()
+
+    assert listener.status == "closed"
+    assert runtime._stop.is_set()
+
+
+@pytest.mark.asyncio
+async def test_superseded_status_survives_cleanup() -> None:
+    runtime = _runtime()
+    runtime._notify_status("superseded")
+
+    await runtime.aclose()
+
+    assert runtime.status == "superseded"
+
+
+@pytest.mark.asyncio
+async def test_explicit_aclose_is_idempotent() -> None:
+    runtime = _runtime()
+    conn = _connection()
+    runtime._active = conn
+
+    await runtime.aclose()
+    await runtime.aclose()
+
+    assert runtime.status == "closed"
+    assert conn.closed.is_set()

--- a/sdk/python/tests/test_tunnels_runtime.py
+++ b/sdk/python/tests/test_tunnels_runtime.py
@@ -1515,6 +1515,8 @@ async def test_aclose_cancels_ping_loops_on_every_conn():
     draining_ping = asyncio.create_task(_idle())
     active.ping_task = active_ping
     draining.ping_task = draining_ping
+    active_writer = active.writer
+    draining_writer = draining.writer
 
     await runtime.aclose()
 
@@ -1527,8 +1529,8 @@ async def test_aclose_cancels_ping_loops_on_every_conn():
             await t
         assert t.cancelled() or t.done()
     # Both writers were closed.
-    active.writer.close.assert_called()
-    draining.writer.close.assert_called()
+    active_writer.close.assert_called()
+    draining_writer.close.assert_called()
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_tunnels_superseded.py
+++ b/sdk/python/tests/test_tunnels_superseded.py
@@ -347,7 +347,7 @@ async def test_make_replacement_reraises_superseded_no_retry(monkeypatch):
         attempts["n"] += 1
         raise _TunnelSupersededError("taken over during handoff")
 
-    async def _close(conn):
+    async def _close(conn, **_kwargs):
         return None
 
     monkeypatch.setattr(runtime, "_open_connection", _open)
@@ -381,7 +381,7 @@ async def test_make_replacement_terminal_on_flag_set_plain_error(monkeypatch):
         runtime._superseded = True  # set by the read loop's GOAWAY handler
         raise RuntimeError("connection reset during hello")  # plain, not typed
 
-    async def _close(conn):
+    async def _close(conn, **_kwargs):
         return None
 
     monkeypatch.setattr(runtime, "_open_connection", _open)

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.14"
+version = "0.5.15"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1201,6 +1201,7 @@ dependencies = [
  "hmac",
  "http 1.4.2",
  "httpmock",
+ "log",
  "p256",
  "rand 0.8.6",
  "reqwest",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.5.14"
+version = "0.5.15"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"
@@ -32,6 +32,7 @@ default = []
 tunnels-runtime = [
     "dep:tokio", "dep:rustls", "dep:rustls-pemfile", "dep:h2", "dep:http", "dep:bytes",
     "dep:tokio-rustls", "dep:webpki-roots", "dep:p256", "dep:x509-cert", "dep:der", "dep:spki",
+    "dep:log",
     # `sha2/oid` exposes the SHA-256 AssociatedOid impl that x509-cert's ECDSA
     # DynSignatureAlgorithmIdentifier needs to emit `ecdsa-with-SHA256` in CSRs.
     "sha2/oid",
@@ -41,6 +42,7 @@ tunnels-runtime = [
 # Local HTTP mock server for the phone resource tests (query/body/error-shape
 # assertions against the blocking transport).
 httpmock = "0.7"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 
 [dependencies]
 # HTTP — blocking client mirrors the synchronous Python SDK surface.
@@ -86,3 +88,4 @@ p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"], optional = true
 x509-cert = { version = "0.2", features = ["pem", "builder"], optional = true }
 der = { version = "0.7", optional = true }
 spki = { version = "0.7", optional = true }
+log = { version = "0.4", optional = true }

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -388,9 +388,37 @@ pure Rust.
   for inbound tunnels (pulls in `tokio`, `rustls` (ring), `h2`). Bring a tunnel
   online with `inkbox.tunnels().connect(name, forward_to)`, or
   `connect_with_status(name, forward_to, on_status)` to observe `"connecting"` /
-  `"connected"` / `"reconnecting"` / `"closed"`. The control-plane tunnels surface
+  `"connected"` / `"reconnecting"` / `"closed"` / `"superseded"`. The control-plane tunnels surface
   (`inkbox.tunnels()`: list / get / update / sign_csr) is always available
   without this feature.
+
+The connect methods remain blocking. Run them on a caller-owned thread and use
+`TunnelStatusHandle` to sample local liveness elsewhere:
+
+```rust
+use inkbox::tunnels::client::TunnelStatusHandle;
+
+let status = TunnelStatusHandle::new();
+let runtime_status = status.clone();
+let client = inkbox.clone();
+std::thread::spawn(move || {
+    client.tunnels().connect_with_status(
+        "my-app",
+        "http://127.0.0.1:8080",
+        runtime_status.callback(),
+    )
+});
+
+let snapshot = status.snapshot();
+println!("{:?} {:?}", snapshot.status, snapshot.last_connected_at);
+```
+
+The handle records `Idle`, `Connecting`, `Connected`, `Reconnecting`, `Closed`,
+or `Superseded` and retains the latest successful connection time while
+reconnecting. It is local runtime state, distinct from fields returned by
+`inkbox.tunnels().get(...)`. Establishment is bounded and transient failures use
+cold reconnect with exponential backoff; Rust does not use make-before-break
+handoff. The SDK does not create an OS thread or take ownership of joining it.
 
 ## Status
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -401,7 +401,7 @@ use inkbox::tunnels::client::TunnelStatusHandle;
 let status = TunnelStatusHandle::new();
 let runtime_status = status.clone();
 let client = inkbox.clone();
-std::thread::spawn(move || {
+let tunnel_thread = std::thread::spawn(move || {
     client.tunnels().connect_with_status(
         "my-app",
         "http://127.0.0.1:8080",
@@ -411,6 +411,11 @@ std::thread::spawn(move || {
 
 let snapshot = status.snapshot();
 println!("{:?} {:?}", snapshot.status, snapshot.last_connected_at);
+
+// Join when shutdown is expected so bootstrap/runtime errors are not lost.
+if let Err(error) = tunnel_thread.join().expect("tunnel thread panicked") {
+    eprintln!("tunnel stopped: {error}");
+}
 ```
 
 The handle records `Idle`, `Connecting`, `Connected`, `Reconnecting`, `Closed`,
@@ -419,6 +424,10 @@ reconnecting. It is local runtime state, distinct from fields returned by
 `inkbox.tunnels().get(...)`. Establishment is bounded and transient failures use
 cold reconnect with exponential backoff; Rust does not use make-before-break
 handoff. The SDK does not create an OS thread or take ownership of joining it.
+The status remains `Idle` until runtime startup reaches its first lifecycle
+transition, so inspect the thread result for validation or bootstrap failures.
+Status callbacks run inline and must return promptly; send blocking monitoring
+work to a caller-owned thread or queue.
 
 ## Status
 

--- a/sdk/rust/src/tunnels/client/mod.rs
+++ b/sdk/rust/src/tunnels/client/mod.rs
@@ -27,6 +27,7 @@ pub mod envelope;
 pub mod protocol;
 pub mod runtime;
 pub mod state;
+pub mod status;
 pub mod url_forward;
 pub mod wsframe;
 
@@ -35,6 +36,7 @@ pub use bootstrap::{resolve_zone_and_host, validate_pool_size, TunnelBundle};
 pub use envelope::{filter_response_headers, parse_envelope, Envelope};
 pub use runtime::{ForwardTo, StatusCallback, TunnelRuntime, TunnelRuntimeConfig};
 pub use state::{load_state, save_state, StateEntry};
+pub use status::{LocalTunnelStatus, TunnelStatusHandle, TunnelStatusSnapshot};
 pub use url_forward::{
     build_forward_headers, forward_envelope_to_url, join_forward_path, validate_envelope_path,
     validate_forward_target, ForwardResult,

--- a/sdk/rust/src/tunnels/client/runtime.rs
+++ b/sdk/rust/src/tunnels/client/runtime.rs
@@ -86,6 +86,9 @@ const HELLO_REASON_SUPERSEDED: &str = "hello-superseded";
 /// Status strings passed to the `on_status` callback. Mirrors the Python
 /// status vocabulary (`"connecting"`, `"connected"`, `"reconnecting"`,
 /// `"closed"`, `"superseded"`).
+///
+/// Callbacks run inline on the runtime task and must return promptly. Panics
+/// are isolated, but blocking work delays lifecycle progress on that worker.
 pub type StatusCallback = Box<dyn Fn(&str) + Send + Sync>;
 
 /// Where inbound third-party traffic is forwarded.
@@ -265,6 +268,7 @@ struct RuntimeTestHooks {
     connector: Option<TestConnector>,
     sleeper: Option<TestSleeper>,
     random: Option<Arc<dyn Fn() -> f64 + Send + Sync>>,
+    intake_started: Option<Arc<AtomicU64>>,
 }
 
 /// The data-plane runtime.
@@ -331,6 +335,10 @@ impl TunnelRuntime {
     pub async fn serve_forever(self: &Arc<Self>) -> Result<()> {
         let mut backoff = self.timings.initial_backoff.as_secs_f64();
         let mut attempt = 0u64;
+        if self.is_stopped() {
+            self.notify_status("closed");
+            return Ok(());
+        }
         self.notify_status("connecting");
         loop {
             if self.is_stopped() {
@@ -386,6 +394,7 @@ impl TunnelRuntime {
         self.stopped.store(true, Ordering::SeqCst);
         self.generation.fetch_add(1, Ordering::SeqCst);
         self.stop.send_replace(true);
+        self.notify_status("closed");
         *self.active.lock().await = None;
         let mut lingering = std::mem::take(&mut *self.lingering());
         shutdown_owned_tasks(&mut lingering, self.timings.teardown).await;
@@ -705,6 +714,10 @@ impl TunnelRuntime {
         dispatch_handles: Arc<StdMutex<Vec<OwnedTask>>>,
         started: oneshot::Sender<()>,
     ) {
+        #[cfg(test)]
+        if let Some(started_count) = &self.test_hooks.intake_started {
+            started_count.fetch_add(1, Ordering::SeqCst);
+        }
         let _ = started.send(());
         while !self.is_stopped() {
             match self.park_one_intake(&conn, slot).await {
@@ -714,10 +727,11 @@ impl TunnelRuntime {
                     let handle = tokio::spawn(async move {
                         let _ = me.dispatch(env, c).await;
                     });
-                    dispatch_handles
-                        .lock()
-                        .unwrap_or_else(|err| err.into_inner())
-                        .push(OwnedTask::new("request dispatch", handle));
+                    push_dispatch_task(
+                        &dispatch_handles,
+                        OwnedTask::new("request dispatch", handle),
+                    )
+                    .await;
                 }
                 Ok(None) => continue,
                 // Another client took over: record it (force_down is
@@ -1078,6 +1092,9 @@ impl TunnelRuntime {
             if last.as_deref() == Some(status) {
                 return;
             }
+            if last.as_deref() == Some("superseded") && status == "closed" {
+                return;
+            }
             *last = Some(status.to_string());
         }
         if let Some(cb) = &self.cfg.on_status {
@@ -1085,6 +1102,31 @@ impl TunnelRuntime {
                 log::error!(
                     "tunnel status callback panicked for status {status}; continuing runtime"
                 );
+            }
+        }
+    }
+}
+
+async fn push_dispatch_task(tasks: &StdMutex<Vec<OwnedTask>>, task: OwnedTask) {
+    let finished = {
+        let mut tasks = tasks.lock().unwrap_or_else(|err| err.into_inner());
+        let mut finished = Vec::new();
+        let mut index = 0;
+        while index < tasks.len() {
+            if tasks[index].handle.is_finished() {
+                finished.push(tasks.swap_remove(index));
+            } else {
+                index += 1;
+            }
+        }
+        tasks.push(task);
+        finished
+    };
+
+    for mut task in finished {
+        if let Err(err) = (&mut task.handle).await {
+            if err.is_panic() {
+                log::error!("tunnel {} task panicked", task.name);
             }
         }
     }

--- a/sdk/rust/src/tunnels/client/runtime.rs
+++ b/sdk/rust/src/tunnels/client/runtime.rs
@@ -12,14 +12,20 @@
 //! implemented. WebSocket and TCP-passthrough bridges are dispatched through
 //! [`bridge`](super::bridge) (see [`TunnelRuntime::dispatch`]).
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::future::Future;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+#[cfg(test)]
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use bytes::Bytes;
 use h2::client::SendRequest;
 use http::{Method, Request};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{oneshot, watch, Mutex, Notify};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
 
 use crate::error::{InkboxError, Result};
 
@@ -38,6 +44,14 @@ pub const PING_INTERVAL: Duration = Duration::from_secs(20);
 /// Hard ceiling on an unacked PING before we force a reconnect. Guards
 /// against a silently-dead TCP the kernel hasn't reported yet.
 pub const PING_ACK_TIMEOUT: Duration = Duration::from_secs(10);
+/// Aggregate budget for TCP, TLS, and HTTP/2 establishment.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Budget for sending HELLO and reading its complete response.
+pub const HELLO_TIMEOUT: Duration = Duration::from_secs(15);
+/// Group budget for stopping connection-owned background tasks.
+pub const TASK_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+/// Initial cold reconnect delay before jitter.
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// OS TCP keepalive cadence applied to the underlying socket.
 pub const TCP_KEEPALIVE_IDLE_SECONDS: u64 = 30;
 pub const TCP_KEEPALIVE_INTERVAL_SECONDS: u64 = 10;
@@ -138,11 +152,119 @@ fn transient(msg: impl Into<String>) -> InkboxError {
 /// server-advertised parameters from the hello response.
 struct ActiveConn {
     send: SendRequest<Bytes>,
+    generation: u64,
     owner_token: String,
     server_pool_size: Option<i64>,
     #[allow(dead_code)]
     intake_idle_seconds: Option<f64>,
     response_deadline_seconds: Option<f64>,
+}
+
+struct ConnectionTasks {
+    driver: Option<JoinHandle<()>>,
+    ping: Option<JoinHandle<()>>,
+}
+
+impl ConnectionTasks {
+    fn take_owned(&mut self) -> Vec<OwnedTask> {
+        let mut tasks = Vec::with_capacity(2);
+        if let Some(driver) = self.driver.take() {
+            tasks.push(OwnedTask::new("connection driver", driver));
+        }
+        if let Some(ping) = self.ping.take() {
+            tasks.push(OwnedTask::new("PING monitor", ping));
+        }
+        tasks
+    }
+
+    async fn shutdown(&mut self, timeout: Duration) -> Vec<OwnedTask> {
+        let mut tasks = self.take_owned();
+        shutdown_owned_tasks(&mut tasks, timeout).await;
+        tasks
+    }
+}
+
+impl Drop for ConnectionTasks {
+    fn drop(&mut self) {
+        if let Some(driver) = &self.driver {
+            driver.abort();
+        }
+        if let Some(ping) = &self.ping {
+            ping.abort();
+        }
+    }
+}
+
+struct OpenConnection {
+    send: SendRequest<Bytes>,
+    closed: oneshot::Receiver<()>,
+    tasks: ConnectionTasks,
+}
+
+struct OwnedTask {
+    name: &'static str,
+    handle: JoinHandle<()>,
+}
+
+impl OwnedTask {
+    fn new(name: &'static str, handle: JoinHandle<()>) -> Self {
+        Self { name, handle }
+    }
+}
+
+impl Drop for OwnedTask {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RuntimeTimings {
+    connect: Duration,
+    hello: Duration,
+    teardown: Duration,
+    ping_interval: Duration,
+    ping_ack: Duration,
+    initial_backoff: Duration,
+    backoff_cap: f64,
+    backoff_jitter: f64,
+}
+
+impl Default for RuntimeTimings {
+    fn default() -> Self {
+        Self {
+            connect: CONNECT_TIMEOUT,
+            hello: HELLO_TIMEOUT,
+            teardown: TASK_TEARDOWN_TIMEOUT,
+            ping_interval: PING_INTERVAL,
+            ping_ack: PING_ACK_TIMEOUT,
+            initial_backoff: INITIAL_BACKOFF,
+            backoff_cap: BACKOFF_CAP,
+            backoff_jitter: BACKOFF_JITTER,
+        }
+    }
+}
+
+#[cfg(test)]
+type TestOpenFuture = Pin<Box<dyn Future<Output = Result<OpenConnection>> + Send>>;
+#[cfg(test)]
+type TestConnector = Arc<
+    dyn Fn(Instant, RuntimeTimings, Arc<AtomicBool>, Arc<Notify>, Arc<AtomicBool>) -> TestOpenFuture
+        + Send
+        + Sync
+        + 'static,
+>;
+#[cfg(test)]
+type TestSleepFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+#[cfg(test)]
+type TestSleeper = Arc<dyn Fn(Duration) -> TestSleepFuture + Send + Sync + 'static>;
+
+#[cfg(test)]
+#[derive(Default)]
+struct RuntimeTestHooks {
+    connector: Option<TestConnector>,
+    sleeper: Option<TestSleeper>,
+    random: Option<Arc<dyn Fn() -> f64 + Send + Sync>>,
 }
 
 /// The data-plane runtime.
@@ -155,8 +277,15 @@ pub struct TunnelRuntime {
     http: reqwest::Client,
     /// The connection that parks new intakes (published once hello succeeds).
     active: Arc<Mutex<Option<Arc<ActiveConn>>>>,
-    stop: Arc<Notify>,
+    stop: watch::Sender<bool>,
     stopped: Arc<AtomicBool>,
+    successful_connections: AtomicU64,
+    generation: AtomicU64,
+    last_notified_status: StdMutex<Option<String>>,
+    lingering_tasks: StdMutex<Vec<OwnedTask>>,
+    timings: RuntimeTimings,
+    #[cfg(test)]
+    test_hooks: RuntimeTestHooks,
 }
 
 impl TunnelRuntime {
@@ -177,8 +306,15 @@ impl TunnelRuntime {
             cfg,
             http,
             active: Arc::new(Mutex::new(None)),
-            stop: Arc::new(Notify::new()),
+            stop: watch::channel(false).0,
             stopped: Arc::new(AtomicBool::new(false)),
+            successful_connections: AtomicU64::new(0),
+            generation: AtomicU64::new(0),
+            last_notified_status: StdMutex::new(None),
+            lingering_tasks: StdMutex::new(Vec::new()),
+            timings: RuntimeTimings::default(),
+            #[cfg(test)]
+            test_hooks: RuntimeTestHooks::default(),
         }
     }
 
@@ -193,15 +329,19 @@ impl TunnelRuntime {
     /// transient failures. Returns `Err` on a permanent auth failure (the
     /// Python `_TunnelAuthError` path), or `Ok(())` on a clean shutdown.
     pub async fn serve_forever(self: &Arc<Self>) -> Result<()> {
-        let mut backoff = 1.0f64;
+        let mut backoff = self.timings.initial_backoff.as_secs_f64();
+        let mut attempt = 0u64;
         self.notify_status("connecting");
         loop {
             if self.is_stopped() {
                 self.notify_status("closed");
                 return Ok(());
             }
+            attempt += 1;
+            log::info!("tunnel connection attempt {attempt} starting");
+            let connected_before = self.successful_connections.load(Ordering::SeqCst);
             match self.run_once().await {
-                Ok(()) => backoff = 1.0,
+                Ok(()) => backoff = self.timings.initial_backoff.as_secs_f64(),
                 Err(err) if is_auth_error(&err) => {
                     self.notify_status("closed");
                     return Err(err);
@@ -213,22 +353,29 @@ impl TunnelRuntime {
                     self.notify_status("superseded");
                     return Err(err);
                 }
-                Err(_) => self.notify_status("reconnecting"),
+                Err(err) => {
+                    if let Some(phase) = timeout_phase(&err) {
+                        log::warn!("tunnel connection attempt {attempt} timed out during {phase}");
+                    } else {
+                        log::warn!("tunnel connection attempt {attempt} failed: {err}");
+                    }
+                }
+            }
+            if self.successful_connections.load(Ordering::SeqCst) > connected_before {
+                backoff = self.timings.initial_backoff.as_secs_f64();
             }
             if self.is_stopped() {
                 self.notify_status("closed");
                 return Ok(());
             }
-            let jitter = backoff * BACKOFF_JITTER * (2.0 * pseudo_rand() - 1.0);
+            let jitter =
+                backoff * self.timings.backoff_jitter * (2.0 * self.random_fraction() - 1.0);
             let sleep_for = (backoff + jitter).max(0.1);
-            tokio::select! {
-                _ = tokio::time::sleep(Duration::from_secs_f64(sleep_for)) => {}
-                _ = self.stop.notified() => {
-                    self.notify_status("closed");
-                    return Ok(());
-                }
+            if !self.sleep_or_stop(Duration::from_secs_f64(sleep_for)).await {
+                self.notify_status("closed");
+                return Ok(());
             }
-            backoff = (backoff * 2.0).min(BACKOFF_CAP);
+            backoff = (backoff * 2.0).min(self.timings.backoff_cap);
         }
     }
 
@@ -237,8 +384,12 @@ impl TunnelRuntime {
     /// `SendRequest` handles closes the h2 connection.
     pub async fn aclose(&self) {
         self.stopped.store(true, Ordering::SeqCst);
-        self.stop.notify_waiters();
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        self.stop.send_replace(true);
         *self.active.lock().await = None;
+        let mut lingering = std::mem::take(&mut *self.lingering());
+        shutdown_owned_tasks(&mut lingering, self.timings.teardown).await;
+        self.retain_tasks(&mut lingering);
     }
 
     // --- connection lifecycle --------------------------------------------
@@ -259,15 +410,68 @@ impl TunnelRuntime {
 
         // Dial + h2 handshake. The driver runs as a background task; when it
         // ends (GOAWAY / reset / TCP close) `conn_closed` fires.
-        let (send, conn_closed) = self
-            .open_connection(force_down.clone(), superseded.clone())
-            .await?;
+        let connect_deadline = Instant::now() + self.timings.connect;
+        let open = self
+            .wait_for_stop(self.establish_connection(
+                connect_deadline,
+                force_down.clone(),
+                superseded.clone(),
+            ))
+            .await;
+        let OpenConnection {
+            send,
+            mut closed,
+            mut tasks,
+        } = match open {
+            None => return Ok(()),
+            Some(Ok(open)) => open,
+            Some(Err(err)) => {
+                self.notify_reconnecting();
+                return Err(err);
+            }
+        };
 
         // Hello handshake — establishes the owner_token used to park intakes.
         // A displaced-during-hello loser returns the superseded tag here.
-        let active = match self.send_hello(send).await {
-            Ok(active) => active,
-            Err(e) => {
+        let hello_deadline = Instant::now() + self.timings.hello;
+        let mut stop_rx = self.stop.subscribe();
+        let hello = if *stop_rx.borrow() {
+            None
+        } else {
+            tokio::select! {
+                biased;
+                _ = stop_rx.changed() => None,
+                _ = &mut closed => {
+                    Some(Err(if superseded.load(Ordering::SeqCst) {
+                        superseded_error("another client connected to this tunnel")
+                    } else {
+                        transient("tunnel connection closed during hello")
+                    }))
+                }
+                result = with_phase_timeout(
+                    hello_deadline,
+                    "hello",
+                    self.send_hello(send),
+                ) => Some(result),
+            }
+        };
+        let active = match hello {
+            None => {
+                self.shutdown_connection_tasks(&mut tasks).await;
+                return Ok(());
+            }
+            Some(Ok(active)) => active,
+            Some(Err(e)) => {
+                if !superseded.load(Ordering::SeqCst)
+                    && !is_auth_error(&e)
+                    && !is_superseded_error(&e)
+                {
+                    self.notify_reconnecting();
+                }
+                self.shutdown_connection_tasks(&mut tasks).await;
+                if self.is_stopped() {
+                    return Ok(());
+                }
                 // A takeover GOAWAY can land mid-hello: the driver sets the
                 // flag while the hello itself fails as a plain transient error.
                 // Honor the flag so we stop instead of redialing and booting
@@ -278,47 +482,83 @@ impl TunnelRuntime {
                 return Err(e);
             }
         };
-        let active = Arc::new(active);
-        *self.active.lock().await = Some(active.clone());
-        self.notify_status("connected");
 
-        // Park the intake pool. effective_pool = server default or our
-        // requested size or 1.
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let dispatch_handles = Arc::new(StdMutex::new(Vec::new()));
+
+        // Park the intake pool before publishing connected state. A status
+        // callback may block without delaying intake task creation.
+        let mut active = active;
+        active.generation = generation;
+        let active = Arc::new(active);
         let effective_pool = active
             .server_pool_size
             .or(self.cfg.pool_size)
             .unwrap_or(1)
             .max(1) as usize;
-        let mut handles = Vec::with_capacity(effective_pool);
+        let mut intake_tasks = Vec::with_capacity(effective_pool);
+        let mut intake_started = Vec::with_capacity(effective_pool);
         for slot in 0..effective_pool {
             let me = self.clone();
             let conn = active.clone();
             let fd = force_down.clone();
             let sup = superseded.clone();
-            handles.push(tokio::spawn(async move {
-                me.intake_loop(conn, slot, fd, sup).await
-            }));
+            let dispatches = dispatch_handles.clone();
+            let (started_tx, started_rx) = oneshot::channel();
+            intake_started.push(started_rx);
+            intake_tasks.push(OwnedTask::new(
+                "intake worker",
+                tokio::spawn(async move {
+                    me.intake_loop(conn, slot, fd, sup, dispatches, started_tx)
+                        .await
+                }),
+            ));
+        }
+        for started in intake_started {
+            let _ = started.await;
         }
 
-        // Supervise: return when the connection dies, a keepalive/owner-token
-        // failure forces it down, or stop is requested.
-        tokio::select! {
-            _ = conn_closed => {}
-            _ = force_down.notified() => {}
-            _ = self.stop.notified() => {}
-            _ = wait_until_stopped(self.stopped.clone()) => {}
+        *self.active.lock().await = Some(active.clone());
+        let connection_number = self.successful_connections.fetch_add(1, Ordering::SeqCst);
+        if connection_number == 0 {
+            log::info!("tunnel connection established");
+        } else {
+            log::info!("tunnel connection recovered");
+        }
+        self.notify_status("connected");
+
+        let mut stop_rx = self.stop.subscribe();
+        if !*stop_rx.borrow() {
+            tokio::select! {
+                _ = &mut closed => {}
+                _ = force_down.notified() => {}
+                _ = stop_rx.changed() => {}
+            }
         }
 
-        // Tear the pool down; dropping `active`/its `SendRequest` closes h2.
-        for h in handles {
-            h.abort();
+        let terminal_superseded = superseded.load(Ordering::SeqCst);
+        let stopping = self.is_stopped();
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        if !terminal_superseded && !stopping {
+            self.notify_reconnecting();
         }
+
         *self.active.lock().await = None;
-        // Another client took over this tunnel: stop, do not reconnect.
-        if superseded.load(Ordering::SeqCst) {
-            return Err(superseded_error("another client connected to this tunnel"));
-        }
-        if self.is_stopped() {
+        let dispatch_tasks = {
+            let mut handles = dispatch_handles
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            handles.drain(..).collect::<Vec<_>>()
+        };
+        intake_tasks.extend(dispatch_tasks);
+        intake_tasks.extend(tasks.take_owned());
+        shutdown_owned_tasks(&mut intake_tasks, self.timings.teardown).await;
+        self.retain_tasks(&mut intake_tasks);
+        drop(active);
+
+        if terminal_superseded {
+            Err(superseded_error("another client connected to this tunnel"))
+        } else if stopping {
             Ok(())
         } else {
             Err(transient("tunnel connection closed; reconnecting"))
@@ -331,9 +571,10 @@ impl TunnelRuntime {
     /// connection dies.
     async fn open_connection(
         self: &Arc<Self>,
+        deadline: Instant,
         force_down: Arc<Notify>,
         superseded: Arc<AtomicBool>,
-    ) -> Result<(SendRequest<Bytes>, tokio::sync::oneshot::Receiver<()>)> {
+    ) -> Result<OpenConnection> {
         use tokio::net::TcpStream;
         use tokio_rustls::TlsConnector;
 
@@ -349,64 +590,30 @@ impl TunnelRuntime {
 
         let server_name = rustls::pki_types::ServerName::try_from(self.cfg.zone.clone())
             .map_err(|_| transient(format!("invalid zone host {:?}", self.cfg.zone)))?;
-        let tcp = TcpStream::connect((self.cfg.zone.as_str(), 443))
-            .await
-            .map_err(|e| transient(format!("tcp connect {}: {e}", self.cfg.zone)))?;
+        let tcp = with_phase_timeout(deadline, "tcp", async {
+            TcpStream::connect((self.cfg.zone.as_str(), 443))
+                .await
+                .map_err(|e| transient(format!("tcp connect {}: {e}", self.cfg.zone)))
+        })
+        .await?;
         let _ = tcp.set_nodelay(true);
-        let tls_stream = TlsConnector::from(Arc::new(tls))
-            .connect(server_name, tcp)
-            .await
-            .map_err(|e| transient(format!("tls handshake {}: {e}", self.cfg.zone)))?;
+        let tls_stream = with_phase_timeout(deadline, "tls", async {
+            TlsConnector::from(Arc::new(tls))
+                .connect(server_name, tcp)
+                .await
+                .map_err(|e| transient(format!("tls handshake {}: {e}", self.cfg.zone)))
+        })
+        .await?;
 
-        let (send, connection) = h2::client::Builder::new()
-            .enable_push(false)
-            .handshake(tls_stream)
-            .await
-            .map_err(|e| transient(format!("h2 handshake: {e}")))?;
-
-        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
-
-        // Take the PingPong before the driver consumes the connection. Mirrors
-        // Python `_ping_loop`: ping every PING_INTERVAL, give up (→ reconnect)
-        // if a ping isn't acked within PING_ACK_TIMEOUT.
-        let mut connection = connection;
-        let ping_pong = connection.ping_pong();
-        tokio::spawn(async move {
-            // Classify the close: a GOAWAY carrying the dedicated superseded
-            // code is a takeover (stop, don't reconnect). Rust reads only the
-            // code, so this is the reliable channel; any other close reconnects.
-            if let Err(e) = connection.await {
-                if is_superseded_goaway(&e) {
-                    superseded.store(true, Ordering::SeqCst);
-                }
-            }
-            let _ = closed_tx.send(());
-        });
-        if let Some(mut pp) = ping_pong {
-            let stopped_ping = self.stopped.clone();
-            let force_down_ping = force_down.clone();
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(PING_INTERVAL).await;
-                    if stopped_ping.load(Ordering::SeqCst) {
-                        return;
-                    }
-                    match tokio::time::timeout(PING_ACK_TIMEOUT, pp.ping(h2::Ping::opaque())).await
-                    {
-                        Ok(Ok(_pong)) => {}
-                        // Ack timed out or the connection errored. The socket may
-                        // still look open to the driver (no `conn_closed`), so
-                        // force the supervisor to tear it down and reconnect.
-                        _ => {
-                            force_down_ping.notify_one();
-                            return;
-                        }
-                    }
-                }
-            });
-        }
-
-        Ok((send, closed_rx))
+        start_h2_connection(
+            tls_stream,
+            deadline,
+            self.timings,
+            self.stopped.clone(),
+            force_down,
+            superseded,
+        )
+        .await
     }
 
     /// Perform the `/_system/hello` handshake (Python `_send_hello`).
@@ -474,6 +681,7 @@ impl TunnelRuntime {
             .to_string();
         Ok(ActiveConn {
             send,
+            generation: 0,
             owner_token,
             server_pool_size: payload.get("default_pool_size").and_then(|v| v.as_i64()),
             intake_idle_seconds: payload.get("intake_idle_seconds").and_then(|v| v.as_f64()),
@@ -494,15 +702,22 @@ impl TunnelRuntime {
         slot: usize,
         force_down: Arc<Notify>,
         superseded: Arc<AtomicBool>,
+        dispatch_handles: Arc<StdMutex<Vec<OwnedTask>>>,
+        started: oneshot::Sender<()>,
     ) {
+        let _ = started.send(());
         while !self.is_stopped() {
             match self.park_one_intake(&conn, slot).await {
                 Ok(Some(env)) => {
                     let me = self.clone();
                     let c = conn.clone();
-                    tokio::spawn(async move {
+                    let handle = tokio::spawn(async move {
                         let _ = me.dispatch(env, c).await;
                     });
+                    dispatch_handles
+                        .lock()
+                        .unwrap_or_else(|err| err.into_inner())
+                        .push(OwnedTask::new("request dispatch", handle));
                 }
                 Ok(None) => continue,
                 // Another client took over: record it (force_down is
@@ -710,6 +925,9 @@ impl TunnelRuntime {
         inkbox_reason: Option<&str>,
         body: Vec<u8>,
     ) -> Result<()> {
+        if self.generation.load(Ordering::SeqCst) != conn.generation {
+            return Err(transient("response belongs to a closed tunnel connection"));
+        }
         let path = format!("{PATH_RESPONSE_PREFIX}{request_id}");
         let mut builder = Request::builder()
             .method(Method::POST)
@@ -768,11 +986,215 @@ impl TunnelRuntime {
         self.stopped.load(Ordering::SeqCst)
     }
 
-    fn notify_status(&self, status: &str) {
-        if let Some(cb) = &self.cfg.on_status {
-            cb(status);
+    async fn establish_connection(
+        self: &Arc<Self>,
+        deadline: Instant,
+        force_down: Arc<Notify>,
+        superseded: Arc<AtomicBool>,
+    ) -> Result<OpenConnection> {
+        #[cfg(test)]
+        if let Some(connector) = &self.test_hooks.connector {
+            return with_phase_timeout(
+                deadline,
+                "tcp",
+                connector(
+                    deadline,
+                    self.timings,
+                    self.stopped.clone(),
+                    force_down,
+                    superseded,
+                ),
+            )
+            .await;
+        }
+        self.open_connection(deadline, force_down, superseded).await
+    }
+
+    async fn wait_for_stop<T, F>(&self, future: F) -> Option<T>
+    where
+        F: Future<Output = T>,
+    {
+        let mut stop_rx = self.stop.subscribe();
+        if *stop_rx.borrow() {
+            return None;
+        }
+        tokio::select! {
+            biased;
+            _ = stop_rx.changed() => None,
+            result = future => Some(result),
         }
     }
+
+    async fn sleep_or_stop(&self, duration: Duration) -> bool {
+        #[cfg(test)]
+        let sleep = if let Some(sleeper) = &self.test_hooks.sleeper {
+            sleeper(duration)
+        } else {
+            Box::pin(tokio::time::sleep(duration)) as TestSleepFuture
+        };
+        #[cfg(not(test))]
+        let sleep = tokio::time::sleep(duration);
+        self.wait_for_stop(sleep).await.is_some()
+    }
+
+    fn random_fraction(&self) -> f64 {
+        #[cfg(test)]
+        if let Some(random) = &self.test_hooks.random {
+            return random();
+        }
+        pseudo_rand()
+    }
+
+    fn notify_reconnecting(&self) {
+        if !self.is_stopped() {
+            self.notify_status("reconnecting");
+        }
+    }
+
+    async fn shutdown_connection_tasks(&self, tasks: &mut ConnectionTasks) {
+        let mut pending = tasks.shutdown(self.timings.teardown).await;
+        self.retain_tasks(&mut pending);
+    }
+
+    fn retain_tasks(&self, tasks: &mut Vec<OwnedTask>) {
+        if tasks.is_empty() {
+            return;
+        }
+        self.lingering().append(tasks);
+    }
+
+    fn lingering(&self) -> std::sync::MutexGuard<'_, Vec<OwnedTask>> {
+        self.lingering_tasks
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn notify_status(&self, status: &str) {
+        {
+            let mut last = self
+                .last_notified_status
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            if last.as_deref() == Some(status) {
+                return;
+            }
+            *last = Some(status.to_string());
+        }
+        if let Some(cb) = &self.cfg.on_status {
+            if catch_unwind(AssertUnwindSafe(|| cb(status))).is_err() {
+                log::error!(
+                    "tunnel status callback panicked for status {status}; continuing runtime"
+                );
+            }
+        }
+    }
+}
+
+async fn start_h2_connection<T>(
+    io: T,
+    deadline: Instant,
+    timings: RuntimeTimings,
+    stopped: Arc<AtomicBool>,
+    force_down: Arc<Notify>,
+    superseded: Arc<AtomicBool>,
+) -> Result<OpenConnection>
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (send, connection) = with_phase_timeout(deadline, "h2", async {
+        h2::client::Builder::new()
+            .enable_push(false)
+            .handshake(io)
+            .await
+            .map_err(|e| transient(format!("h2 handshake: {e}")))
+    })
+    .await?;
+    let mut connection = connection;
+    let send = with_phase_timeout(deadline, "h2", async {
+        tokio::select! {
+            ready = send.ready() => ready
+                .map_err(|e| transient(format!("h2 connection readiness: {e}"))),
+            result = &mut connection => match result {
+                Ok(()) => Err(transient("h2 connection closed before readiness")),
+                Err(err) => Err(transient(format!("h2 connection before readiness: {err}"))),
+            },
+        }
+    })
+    .await?;
+
+    let (closed_tx, closed_rx) = oneshot::channel();
+    let ping_pong = connection.ping_pong();
+    let driver = tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            if is_superseded_goaway(&err) {
+                superseded.store(true, Ordering::SeqCst);
+            }
+        }
+        let _ = closed_tx.send(());
+    });
+    let ping = ping_pong.map(|mut ping_pong| {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(timings.ping_interval).await;
+                if stopped.load(Ordering::SeqCst) {
+                    return;
+                }
+                if !matches!(
+                    tokio::time::timeout(timings.ping_ack, ping_pong.ping(h2::Ping::opaque()))
+                        .await,
+                    Ok(Ok(_))
+                ) {
+                    force_down.notify_one();
+                    return;
+                }
+            }
+        })
+    });
+    Ok(OpenConnection {
+        send,
+        closed: closed_rx,
+        tasks: ConnectionTasks {
+            driver: Some(driver),
+            ping,
+        },
+    })
+}
+
+async fn shutdown_owned_tasks(tasks: &mut Vec<OwnedTask>, timeout: Duration) {
+    for task in tasks.iter() {
+        task.handle.abort();
+    }
+    let completed = tokio::time::timeout(timeout, async {
+        while tasks.iter().any(|task| !task.handle.is_finished()) {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .is_ok();
+
+    let mut remaining = Vec::new();
+    for mut task in tasks.drain(..) {
+        if task.handle.is_finished() {
+            let _ = (&mut task.handle).await;
+        } else {
+            remaining.push(task);
+        }
+    }
+    if !completed {
+        for task in &remaining {
+            log::warn!("tunnel {} task did not stop during teardown", task.name);
+        }
+    }
+    *tasks = remaining;
+}
+
+async fn with_phase_timeout<T, F>(deadline: Instant, phase: &'static str, future: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    tokio::time::timeout_at(deadline, future)
+        .await
+        .map_err(|_| transient(format!("tunnel connect timeout during {phase}")))?
 }
 
 /// Read an h2 response body fully, releasing flow-control capacity as data
@@ -804,15 +1226,6 @@ fn http_headers_to_pairs(headers: &http::HeaderMap) -> Vec<(String, String)> {
         .collect()
 }
 
-async fn wait_until_stopped(stopped: Arc<AtomicBool>) {
-    loop {
-        if stopped.load(Ordering::SeqCst) {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-}
-
 /// True iff `err` is the permanent auth-failure tag from `/_system/hello`.
 fn is_auth_error(err: &InkboxError) -> bool {
     matches!(err, InkboxError::Tunnel(m) if m.starts_with("tunnel-auth:"))
@@ -836,6 +1249,13 @@ fn is_superseded_error(err: &InkboxError) -> bool {
     err.is_tunnel_superseded()
 }
 
+fn timeout_phase(err: &InkboxError) -> Option<&str> {
+    let InkboxError::Tunnel(message) = err else {
+        return None;
+    };
+    message.strip_prefix("tunnel connect timeout during ")
+}
+
 /// True iff a connection-driver `h2::Error` carries the dedicated superseded
 /// GOAWAY code. Rust reads only the code (no debug bytes), so this is the
 /// reliable takeover channel on the connection itself.
@@ -854,99 +1274,5 @@ fn pseudo_rand() -> f64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn cfg() -> TunnelRuntimeConfig {
-        TunnelRuntimeConfig {
-            tunnel_id: "11111111-1111-1111-1111-111111111111".into(),
-            api_key: "sk-test".into(),
-            zone: "inkboxwire.com".into(),
-            public_host: "my-agent.inkboxwire.com".into(),
-            pool_size: None,
-            forward_to: ForwardTo::Url("http://localhost:8080".into()),
-            tls_material: None,
-            max_inbound_body_bytes: DEFAULT_INBOUND_BODY_BYTES,
-            max_outbound_body_bytes: DEFAULT_OUTBOUND_BODY_BYTES,
-            on_status: None,
-            forward_to_verify_tls: true,
-            forward_to_ca_bundle: None,
-        }
-    }
-
-    #[test]
-    fn public_url_shape() {
-        let rt = TunnelRuntime::new(cfg());
-        assert_eq!(rt.public_url(), "https://my-agent.inkboxwire.com");
-        assert_eq!(rt.url(PATH_HELLO), "https://inkboxwire.com/_system/hello");
-    }
-
-    #[test]
-    fn error_classification() {
-        assert!(is_auth_error(&tunnel_auth_error("nope")));
-        assert!(!is_auth_error(&transient("transient")));
-        assert!(is_owner_token_invalid(&owner_token_invalid("x")));
-    }
-
-    #[test]
-    fn superseded_error_classification() {
-        // A takeover is its own terminal reason, distinct from auth / transient
-        // / owner-token so the supervisor stops without reconnecting.
-        assert!(is_superseded_error(&superseded_error("x")));
-        assert!(!is_superseded_error(&transient("x")));
-        assert!(!is_superseded_error(&tunnel_auth_error("x")));
-        assert!(!is_superseded_error(&owner_token_invalid("x")));
-        assert!(!is_auth_error(&superseded_error("x")));
-        assert!(!is_owner_token_invalid(&superseded_error("x")));
-    }
-
-    #[test]
-    fn is_tunnel_superseded_is_public_and_structural() {
-        // Callers can distinguish a terminal takeover from a transient error
-        // structurally (no string matching on their side).
-        assert!(superseded_error("x").is_tunnel_superseded());
-        assert!(!transient("x").is_tunnel_superseded());
-        assert!(!tunnel_auth_error("x").is_tunnel_superseded());
-    }
-
-    #[test]
-    fn superseded_goaway_reads_the_dedicated_code() {
-        // Rust reads only the GOAWAY code, so the dedicated code is the reliable
-        // takeover channel. h2::Error::from(Reason) mirrors a received GOAWAY:
-        // reason() surfaces the code (the GOAWAY-then-close survival property).
-        let takeover = h2::Error::from(h2::Reason::from(SUPERSEDED_GOAWAY_ERROR_CODE));
-        assert!(is_superseded_goaway(&takeover));
-
-        // Drain (NO_ERROR) and a generic backpressure code are NOT takeovers.
-        assert!(!is_superseded_goaway(&h2::Error::from(
-            h2::Reason::NO_ERROR
-        )));
-        assert!(!is_superseded_goaway(&h2::Error::from(
-            h2::Reason::ENHANCE_YOUR_CALM
-        )));
-    }
-
-    #[tokio::test]
-    async fn serve_forever_returns_on_immediate_stop() {
-        let rt = Arc::new(TunnelRuntime::new(cfg()));
-        rt.aclose().await;
-        assert!(rt.serve_forever().await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn status_callback_receives_connecting_then_closed() {
-        use std::sync::Mutex as StdMutex;
-        let seen = Arc::new(StdMutex::new(Vec::<String>::new()));
-        let seen2 = seen.clone();
-        let mut c = cfg();
-        c.on_status = Some(Box::new(move |s: &str| {
-            seen2.lock().unwrap().push(s.to_string())
-        }));
-        let rt = Arc::new(TunnelRuntime::new(c));
-        rt.aclose().await;
-        let _ = rt.serve_forever().await;
-        let got = seen.lock().unwrap().clone();
-        assert!(got.contains(&"connecting".to_string()));
-        assert!(got.contains(&"closed".to_string()));
-    }
-}
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/sdk/rust/src/tunnels/client/runtime_tests.rs
+++ b/sdk/rust/src/tunnels/client/runtime_tests.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 use std::future::pending;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::{Duration, Instant as StdInstant};
+use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -74,6 +74,7 @@ struct PeerSignals {
     forward_to_client: AtomicBool,
     hello_seen: Notify,
     intakes: AtomicUsize,
+    responses: AtomicUsize,
     tasks: StdMutex<Vec<JoinHandle<()>>>,
 }
 
@@ -83,6 +84,7 @@ impl PeerSignals {
             forward_to_client: AtomicBool::new(true),
             hello_seen: Notify::new(),
             intakes: AtomicUsize::new(0),
+            responses: AtomicUsize::new(0),
             tasks: StdMutex::new(Vec::new()),
         })
     }
@@ -252,6 +254,7 @@ async fn open_loopback_peer(
                     pending_responses.push(respond);
                 }
                 _ => {
+                    signals_for_server.responses.fetch_add(1, Ordering::SeqCst);
                     let response = http::Response::builder().status(200).body(()).unwrap();
                     respond.send_response(response, true).unwrap();
                 }
@@ -327,6 +330,20 @@ impl StatusRecorder {
     }
 }
 
+fn assert_ordered_subsequence(actual: &[String], expected: &[&str]) {
+    let mut next = 0;
+    for status in actual {
+        if next < expected.len() && status == expected[next] {
+            next += 1;
+        }
+    }
+    assert_eq!(
+        next,
+        expected.len(),
+        "missing ordered subsequence {expected:?} in {actual:?}"
+    );
+}
+
 fn build_runtime(
     script: &ScriptedConnector,
     recorder: &StatusRecorder,
@@ -364,9 +381,38 @@ fn error_and_takeover_classification() {
 
 #[tokio::test]
 async fn immediate_stop_is_persistent() {
-    let runtime = Arc::new(TunnelRuntime::new(cfg()));
+    let recorder = StatusRecorder::new();
+    let mut config = cfg();
+    config.on_status = Some(recorder.callback());
+    let runtime = Arc::new(TunnelRuntime::new(config));
     runtime.aclose().await;
     assert!(runtime.serve_forever().await.is_ok());
+    assert_eq!(recorder.snapshot(), ["closed"]);
+}
+
+#[tokio::test]
+async fn aclose_without_serve_publishes_closed() {
+    let handle = TunnelStatusHandle::new();
+    let mut config = cfg();
+    config.on_status = Some(handle.callback());
+    let runtime = TunnelRuntime::new(config);
+
+    runtime.aclose().await;
+
+    assert_eq!(handle.status(), LocalTunnelStatus::Closed);
+}
+
+#[tokio::test]
+async fn aclose_does_not_overwrite_superseded() {
+    let recorder = StatusRecorder::new();
+    let mut config = cfg();
+    config.on_status = Some(recorder.callback());
+    let runtime = TunnelRuntime::new(config);
+    runtime.notify_status("superseded");
+
+    runtime.aclose().await;
+
+    assert_eq!(recorder.snapshot(), ["superseded"]);
 }
 
 #[tokio::test]
@@ -383,14 +429,12 @@ async fn connect_timeout_retries_and_shutdown_interrupts_backoff() {
     });
 
     recorder.wait_count("reconnecting", 1).await;
-    let started = StdInstant::now();
     runtime.aclose().await;
-    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+    assert!(tokio::time::timeout(Duration::from_secs(1), serving)
         .await
         .unwrap()
         .unwrap()
         .is_ok());
-    assert!(started.elapsed() < Duration::from_millis(100));
     assert_eq!(recorder.snapshot().last().unwrap(), "closed");
 }
 
@@ -412,14 +456,12 @@ async fn assert_shutdown_interrupts_connect(action: ConnectAction) {
     .await
     .unwrap();
 
-    let started = StdInstant::now();
     runtime.aclose().await;
-    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+    assert!(tokio::time::timeout(Duration::from_secs(1), serving)
         .await
         .unwrap()
         .unwrap()
         .is_ok());
-    assert!(started.elapsed() < Duration::from_millis(100));
     let statuses = recorder.snapshot();
     assert!(
         !statuses.contains(&"reconnecting".to_string()),
@@ -446,14 +488,12 @@ async fn shutdown_interrupts_h2_handshake() {
     });
 
     entered.notified().await;
-    let started = StdInstant::now();
     runtime.aclose().await;
-    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+    assert!(tokio::time::timeout(Duration::from_secs(1), serving)
         .await
         .unwrap()
         .unwrap()
         .is_ok());
-    assert!(started.elapsed() < Duration::from_millis(100));
     assert!(!recorder.snapshot().contains(&"reconnecting".to_string()));
 }
 
@@ -479,21 +519,26 @@ async fn stop_before_backoff_registration_is_not_lost() {
     assert_eq!(recorder.snapshot().last().unwrap(), "closed");
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn intake_runs_while_connected_callback_is_blocked() {
+#[tokio::test]
+async fn connected_follows_intake_worker_start() {
     let signals = PeerSignals::new();
     let script =
         ScriptedConnector::new([ConnectAction::Peer(HelloMode::Complete, signals.clone())]);
     let recorder = StatusRecorder::new();
-    let callback_finished = Arc::new(AtomicBool::new(false));
+    let intake_started = Arc::new(AtomicU64::new(0));
+    let started_when_connected = Arc::new(AtomicU64::new(0));
     let mut runtime = build_runtime(&script, &recorder, fast_timings());
+    runtime.test_hooks.intake_started = Some(intake_started.clone());
     let callback_recorder = recorder.clone();
-    let callback_finished_inner = callback_finished.clone();
+    let started_for_callback = intake_started.clone();
+    let observed = started_when_connected.clone();
     runtime.cfg.on_status = Some(Box::new(move |status| {
         callback_recorder.push(status);
         if status == "connected" {
-            std::thread::sleep(Duration::from_millis(200));
-            callback_finished_inner.store(true, Ordering::SeqCst);
+            observed.store(
+                started_for_callback.load(Ordering::SeqCst),
+                Ordering::SeqCst,
+            );
         }
     }));
     let runtime = Arc::new(runtime);
@@ -503,14 +548,7 @@ async fn intake_runs_while_connected_callback_is_blocked() {
     });
 
     recorder.wait_count("connected", 1).await;
-    tokio::time::timeout(Duration::from_millis(100), async {
-        while signals.intakes.load(Ordering::SeqCst) == 0 {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("intake did not start while callback was blocked");
-    assert!(!callback_finished.load(Ordering::SeqCst));
+    assert_eq!(started_when_connected.load(Ordering::SeqCst), 1);
 
     runtime.aclose().await;
     serving.await.unwrap().unwrap();
@@ -532,14 +570,12 @@ async fn shutdown_interrupts_stalled_hello() {
     });
 
     signals.hello_seen.notified().await;
-    let started = StdInstant::now();
     runtime.aclose().await;
-    assert!(tokio::time::timeout(Duration::from_millis(150), serving)
+    assert!(tokio::time::timeout(Duration::from_secs(1), serving)
         .await
         .unwrap()
         .unwrap()
         .is_ok());
-    assert!(started.elapsed() < Duration::from_millis(150));
     assert!(!recorder.snapshot().contains(&"reconnecting".to_string()));
     signals.abort_tasks();
 }
@@ -582,9 +618,7 @@ async fn reconnecting_precedes_bounded_teardown_and_is_not_duplicated() {
     });
 
     recorder.wait_count("connected", 1).await;
-    let started = StdInstant::now();
     recorder.wait_count("reconnecting", 1).await;
-    assert!(started.elapsed() < Duration::from_millis(100));
     assert_eq!(
         recorder
             .snapshot()
@@ -595,7 +629,7 @@ async fn reconnecting_precedes_bounded_teardown_and_is_not_duplicated() {
     );
 
     runtime.aclose().await;
-    tokio::time::timeout(Duration::from_millis(500), serving)
+    tokio::time::timeout(Duration::from_secs(1), serving)
         .await
         .unwrap()
         .unwrap()
@@ -614,7 +648,7 @@ async fn ping_timeout_forces_reconnect_before_another_interval() {
     let recorder = StatusRecorder::new();
     let mut timings = fast_timings();
     timings.ping_interval = Duration::from_millis(200);
-    timings.ping_ack = Duration::from_millis(30);
+    timings.ping_ack = Duration::from_millis(100);
     let runtime = Arc::new(build_runtime(&script, &recorder, timings));
     let serving = tokio::spawn({
         let runtime = runtime.clone();
@@ -623,22 +657,20 @@ async fn ping_timeout_forces_reconnect_before_another_interval() {
 
     recorder.wait_count("connected", 1).await;
     first.stop_forwarding();
-    let started = StdInstant::now();
     recorder.wait_count("reconnecting", 1).await;
-    assert!(started.elapsed() < Duration::from_millis(320));
     recorder.wait_count("connected", 2).await;
 
     runtime.aclose().await;
     serving.await.unwrap().unwrap();
-    assert_eq!(
-        recorder.snapshot(),
-        [
+    assert_ordered_subsequence(
+        &recorder.snapshot(),
+        &[
             "connecting",
             "connected",
             "reconnecting",
             "connected",
             "closed",
-        ]
+        ],
     );
     first.abort_tasks();
     second.abort_tasks();
@@ -787,6 +819,76 @@ async fn terminal_status_matches_status_handle() {
         assert!(!handle.is_connected());
         signals.abort_tasks();
     }
+}
+
+#[tokio::test]
+async fn completed_dispatch_tasks_are_pruned_without_losing_teardown_ownership() {
+    let tasks = Arc::new(StdMutex::new(Vec::new()));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    for _ in 0..1_000 {
+        let completed = completed.clone();
+        let handle = tokio::spawn(async move {
+            completed.fetch_add(1, Ordering::SeqCst);
+        });
+        while !handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        push_dispatch_task(tasks.as_ref(), OwnedTask::new("request dispatch", handle)).await;
+        assert!(tasks.lock().unwrap().len() <= 1);
+    }
+    assert_eq!(completed.load(Ordering::SeqCst), 1_000);
+
+    let pending_dropped = Arc::new(AtomicBool::new(false));
+    let pending = pending_task(pending_dropped.clone());
+    tokio::task::yield_now().await;
+    push_dispatch_task(tasks.as_ref(), OwnedTask::new("request dispatch", pending)).await;
+    assert_eq!(tasks.lock().unwrap().len(), 1);
+
+    let mut remaining = std::mem::take(&mut *tasks.lock().unwrap());
+    shutdown_owned_tasks(&mut remaining, Duration::from_secs(1)).await;
+    assert!(remaining.is_empty());
+    assert!(pending_dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn stale_generation_response_is_rejected_before_send() {
+    let signals = PeerSignals::new();
+    let timings = fast_timings();
+    let runtime = TunnelRuntime::new(cfg());
+    let force_down = Arc::new(Notify::new());
+    let superseded = Arc::new(AtomicBool::new(false));
+    let OpenConnection {
+        send,
+        closed: _closed,
+        mut tasks,
+    } = open_loopback_peer(
+        Instant::now() + Duration::from_secs(1),
+        timings,
+        runtime.stopped.clone(),
+        force_down,
+        superseded,
+        HelloMode::Complete,
+        signals.clone(),
+    )
+    .await
+    .unwrap();
+    let mut active = runtime.send_hello(send).await.unwrap();
+    active.generation = 1;
+    runtime.generation.store(2, Ordering::SeqCst);
+
+    let err = runtime
+        .post_response(&active, "request-1", 200, &[], None, Vec::new())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, InkboxError::Tunnel(message) if message.contains("closed tunnel connection"))
+    );
+    assert_eq!(signals.responses.load(Ordering::SeqCst), 0);
+    let pending = tasks.shutdown(Duration::from_secs(1)).await;
+    assert!(pending.is_empty());
+    signals.abort_tasks();
 }
 
 struct DropSignal(Arc<AtomicBool>);

--- a/sdk/rust/src/tunnels/client/runtime_tests.rs
+++ b/sdk/rust/src/tunnels/client/runtime_tests.rs
@@ -1,0 +1,864 @@
+use std::collections::VecDeque;
+use std::future::pending;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant as StdInstant};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::*;
+use crate::tunnels::client::{LocalTunnelStatus, TunnelStatusHandle};
+
+struct TestLogger {
+    messages: StdMutex<Vec<String>>,
+}
+
+impl log::Log for TestLogger {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        self.messages
+            .lock()
+            .unwrap()
+            .push(record.args().to_string());
+    }
+
+    fn flush(&self) {}
+}
+
+static TEST_LOGGER: TestLogger = TestLogger {
+    messages: StdMutex::new(Vec::new()),
+};
+
+fn cfg() -> TunnelRuntimeConfig {
+    TunnelRuntimeConfig {
+        tunnel_id: "11111111-1111-1111-1111-111111111111".into(),
+        api_key: "test-key".into(),
+        zone: "example.com".into(),
+        public_host: "agent.example.com".into(),
+        pool_size: Some(1),
+        forward_to: ForwardTo::Url("http://localhost:8080".into()),
+        tls_material: None,
+        max_inbound_body_bytes: DEFAULT_INBOUND_BODY_BYTES,
+        max_outbound_body_bytes: DEFAULT_OUTBOUND_BODY_BYTES,
+        on_status: None,
+        forward_to_verify_tls: true,
+        forward_to_ca_bundle: None,
+    }
+}
+
+fn fast_timings() -> RuntimeTimings {
+    RuntimeTimings {
+        connect: Duration::from_millis(80),
+        hello: Duration::from_millis(80),
+        teardown: Duration::from_millis(50),
+        ping_interval: Duration::from_millis(20),
+        ping_ack: Duration::from_millis(20),
+        initial_backoff: Duration::from_millis(100),
+        backoff_cap: 0.8,
+        backoff_jitter: 0.0,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HelloMode {
+    Complete,
+    StallBody,
+    Auth,
+    Superseded,
+}
+
+struct PeerSignals {
+    forward_to_client: AtomicBool,
+    hello_seen: Notify,
+    intakes: AtomicUsize,
+    tasks: StdMutex<Vec<JoinHandle<()>>>,
+}
+
+impl PeerSignals {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            forward_to_client: AtomicBool::new(true),
+            hello_seen: Notify::new(),
+            intakes: AtomicUsize::new(0),
+            tasks: StdMutex::new(Vec::new()),
+        })
+    }
+
+    fn stop_forwarding(&self) {
+        self.forward_to_client.store(false, Ordering::SeqCst);
+    }
+
+    fn abort_tasks(&self) {
+        for task in self.tasks.lock().unwrap().drain(..) {
+            task.abort();
+        }
+    }
+}
+
+enum ConnectAction {
+    Fail,
+    Hang,
+    H2Hang(Arc<Notify>),
+    Peer(HelloMode, Arc<PeerSignals>),
+    PeerSlowTeardown(Arc<PeerSignals>),
+}
+
+#[derive(Clone)]
+struct ScriptedConnector {
+    actions: Arc<StdMutex<VecDeque<ConnectAction>>>,
+    attempts: Arc<AtomicUsize>,
+}
+
+impl ScriptedConnector {
+    fn new(actions: impl IntoIterator<Item = ConnectAction>) -> Self {
+        Self {
+            actions: Arc::new(StdMutex::new(actions.into_iter().collect())),
+            attempts: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn hook(&self) -> TestConnector {
+        let script = self.clone();
+        Arc::new(move |deadline, timings, stopped, force_down, superseded| {
+            let action = script.actions.lock().unwrap().pop_front();
+            script.attempts.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                match action.unwrap_or(ConnectAction::Hang) {
+                    ConnectAction::Fail => Err(transient("scripted connect failure")),
+                    ConnectAction::Hang => pending().await,
+                    ConnectAction::H2Hang(entered) => {
+                        let (client, server_guard) = tokio::io::duplex(1);
+                        entered.notify_one();
+                        let result = start_h2_connection(
+                            client, deadline, timings, stopped, force_down, superseded,
+                        )
+                        .await;
+                        drop(server_guard);
+                        result
+                    }
+                    ConnectAction::Peer(mode, signals) => {
+                        open_loopback_peer(
+                            deadline, timings, stopped, force_down, superseded, mode, signals,
+                        )
+                        .await
+                    }
+                    ConnectAction::PeerSlowTeardown(signals) => {
+                        let force_after_hello = force_down.clone();
+                        let mut open = open_loopback_peer(
+                            deadline,
+                            timings,
+                            stopped,
+                            force_down,
+                            superseded,
+                            HelloMode::Complete,
+                            signals,
+                        )
+                        .await?;
+                        let (started_tx, started_rx) = std::sync::mpsc::channel();
+                        let blocking_ping = tokio::task::spawn_blocking(move || {
+                            started_tx.send(()).unwrap();
+                            std::thread::sleep(Duration::from_millis(250));
+                        });
+                        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+                        if let Some(ping) = open.tasks.ping.replace(blocking_ping) {
+                            ping.abort();
+                        }
+                        tokio::spawn(async move {
+                            tokio::time::sleep(Duration::from_millis(10)).await;
+                            force_after_hello.notify_one();
+                        });
+                        Ok(open)
+                    }
+                }
+            })
+        })
+    }
+}
+
+// The loopback fixture uses in-memory duplex streams instead of certificate
+// files. It still drives the real h2 handshake, connection driver, HELLO,
+// intake, and PING paths while keeping test-only trust material out of crates.
+async fn open_loopback_peer(
+    deadline: Instant,
+    timings: RuntimeTimings,
+    stopped: Arc<AtomicBool>,
+    force_down: Arc<Notify>,
+    superseded: Arc<AtomicBool>,
+    hello_mode: HelloMode,
+    signals: Arc<PeerSignals>,
+) -> Result<OpenConnection> {
+    let (client_io, client_proxy) = tokio::io::duplex(64 * 1024);
+    let (server_proxy, server_io) = tokio::io::duplex(64 * 1024);
+    let (mut from_client, mut to_client) = tokio::io::split(client_proxy);
+    let (mut from_server, mut to_server) = tokio::io::split(server_proxy);
+
+    let client_to_server = tokio::spawn(async move {
+        let _ = tokio::io::copy(&mut from_client, &mut to_server).await;
+    });
+
+    let signals_for_proxy = signals.clone();
+    let server_to_client = tokio::spawn(async move {
+        let mut buf = [0u8; 4096];
+        loop {
+            let Ok(read) = from_server.read(&mut buf).await else {
+                return;
+            };
+            if read == 0 {
+                return;
+            }
+            if signals_for_proxy.forward_to_client.load(Ordering::SeqCst)
+                && to_client.write_all(&buf[..read]).await.is_err()
+            {
+                return;
+            }
+        }
+    });
+
+    let signals_for_server = signals.clone();
+    let server = tokio::spawn(async move {
+        let mut connection = h2::server::handshake(server_io).await.unwrap();
+        let mut pending_responses = Vec::new();
+        let mut pending_bodies = Vec::new();
+        while let Some(result) = connection.accept().await {
+            let (request, mut respond) = result.unwrap();
+            match request.uri().path() {
+                PATH_HELLO => {
+                    signals_for_server.hello_seen.notify_one();
+                    let (status, body) = match hello_mode {
+                        HelloMode::Complete | HelloMode::StallBody => (
+                            200,
+                            br#"{"owner_token":"owner","default_pool_size":1}"#.as_slice(),
+                        ),
+                        HelloMode::Auth => (401, b"{}".as_slice()),
+                        HelloMode::Superseded => {
+                            (409, br#"{"reason":"hello-superseded"}"#.as_slice())
+                        }
+                    };
+                    let response = http::Response::builder().status(status).body(()).unwrap();
+                    let mut body_stream = respond.send_response(response, false).unwrap();
+                    if matches!(hello_mode, HelloMode::StallBody) {
+                        pending_bodies.push(body_stream);
+                    } else {
+                        body_stream
+                            .send_data(Bytes::copy_from_slice(body), true)
+                            .unwrap();
+                    }
+                }
+                PATH_INTAKE => {
+                    signals_for_server.intakes.fetch_add(1, Ordering::SeqCst);
+                    pending_responses.push(respond);
+                }
+                _ => {
+                    let response = http::Response::builder().status(200).body(()).unwrap();
+                    respond.send_response(response, true).unwrap();
+                }
+            }
+        }
+        drop((pending_responses, pending_bodies));
+    });
+
+    signals
+        .tasks
+        .lock()
+        .unwrap()
+        .extend([client_to_server, server_to_client, server]);
+
+    start_h2_connection(
+        client_io, deadline, timings, stopped, force_down, superseded,
+    )
+    .await
+}
+
+#[derive(Clone)]
+struct StatusRecorder {
+    seen: Arc<StdMutex<Vec<String>>>,
+    changed: watch::Sender<usize>,
+}
+
+impl StatusRecorder {
+    fn new() -> Self {
+        Self {
+            seen: Arc::new(StdMutex::new(Vec::new())),
+            changed: watch::channel(0).0,
+        }
+    }
+
+    fn callback(&self) -> StatusCallback {
+        let recorder = self.clone();
+        Box::new(move |status| recorder.push(status))
+    }
+
+    fn push(&self, status: &str) {
+        let count = {
+            let mut seen = self.seen.lock().unwrap();
+            seen.push(status.to_string());
+            seen.len()
+        };
+        let _ = self.changed.send(count);
+    }
+
+    async fn wait_count(&self, status: &str, count: usize) {
+        let mut changed = self.changed.subscribe();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if self
+                    .seen
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|value| value.as_str() == status)
+                    .count()
+                    >= count
+                {
+                    return;
+                }
+                changed.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("status transition timed out");
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+
+fn build_runtime(
+    script: &ScriptedConnector,
+    recorder: &StatusRecorder,
+    timings: RuntimeTimings,
+) -> TunnelRuntime {
+    let mut config = cfg();
+    config.on_status = Some(recorder.callback());
+    let mut runtime = TunnelRuntime::new(config);
+    runtime.timings = timings;
+    runtime.test_hooks.connector = Some(script.hook());
+    runtime.test_hooks.random = Some(Arc::new(|| 0.5));
+    runtime
+}
+
+#[test]
+fn public_url_shape() {
+    let runtime = TunnelRuntime::new(cfg());
+    assert_eq!(runtime.public_url(), "https://agent.example.com");
+    assert_eq!(runtime.url(PATH_HELLO), "https://example.com/_system/hello");
+}
+
+#[test]
+fn error_and_takeover_classification() {
+    assert!(is_auth_error(&tunnel_auth_error("nope")));
+    assert!(is_owner_token_invalid(&owner_token_invalid("x")));
+    assert!(is_superseded_error(&superseded_error("x")));
+    assert!(superseded_error("x").is_tunnel_superseded());
+    assert!(!is_superseded_error(&transient("x")));
+    let takeover = h2::Error::from(h2::Reason::from(SUPERSEDED_GOAWAY_ERROR_CODE));
+    assert!(is_superseded_goaway(&takeover));
+    assert!(!is_superseded_goaway(&h2::Error::from(
+        h2::Reason::NO_ERROR
+    )));
+}
+
+#[tokio::test]
+async fn immediate_stop_is_persistent() {
+    let runtime = Arc::new(TunnelRuntime::new(cfg()));
+    runtime.aclose().await;
+    assert!(runtime.serve_forever().await.is_ok());
+}
+
+#[tokio::test]
+async fn connect_timeout_retries_and_shutdown_interrupts_backoff() {
+    let script = ScriptedConnector::new([
+        ConnectAction::H2Hang(Arc::new(Notify::new())),
+        ConnectAction::Hang,
+    ]);
+    let recorder = StatusRecorder::new();
+    let runtime = Arc::new(build_runtime(&script, &recorder, fast_timings()));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("reconnecting", 1).await;
+    let started = StdInstant::now();
+    runtime.aclose().await;
+    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+        .await
+        .unwrap()
+        .unwrap()
+        .is_ok());
+    assert!(started.elapsed() < Duration::from_millis(100));
+    assert_eq!(recorder.snapshot().last().unwrap(), "closed");
+}
+
+async fn assert_shutdown_interrupts_connect(action: ConnectAction) {
+    let script = ScriptedConnector::new([action]);
+    let recorder = StatusRecorder::new();
+    let mut timings = fast_timings();
+    timings.connect = Duration::from_secs(5);
+    let runtime = Arc::new(build_runtime(&script, &recorder, timings));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while script.attempts.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let started = StdInstant::now();
+    runtime.aclose().await;
+    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+        .await
+        .unwrap()
+        .unwrap()
+        .is_ok());
+    assert!(started.elapsed() < Duration::from_millis(100));
+    let statuses = recorder.snapshot();
+    assert!(
+        !statuses.contains(&"reconnecting".to_string()),
+        "unexpected statuses: {statuses:?}"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_interrupts_stalled_connect_boundary() {
+    assert_shutdown_interrupts_connect(ConnectAction::Hang).await;
+}
+
+#[tokio::test]
+async fn shutdown_interrupts_h2_handshake() {
+    let entered = Arc::new(Notify::new());
+    let script = ScriptedConnector::new([ConnectAction::H2Hang(entered.clone())]);
+    let recorder = StatusRecorder::new();
+    let mut timings = fast_timings();
+    timings.connect = Duration::from_secs(5);
+    let runtime = Arc::new(build_runtime(&script, &recorder, timings));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    entered.notified().await;
+    let started = StdInstant::now();
+    runtime.aclose().await;
+    assert!(tokio::time::timeout(Duration::from_millis(100), serving)
+        .await
+        .unwrap()
+        .unwrap()
+        .is_ok());
+    assert!(started.elapsed() < Duration::from_millis(100));
+    assert!(!recorder.snapshot().contains(&"reconnecting".to_string()));
+}
+
+#[tokio::test]
+async fn stop_before_backoff_registration_is_not_lost() {
+    let script = ScriptedConnector::new([ConnectAction::Fail, ConnectAction::Hang]);
+    let recorder = StatusRecorder::new();
+    let mut runtime = build_runtime(&script, &recorder, fast_timings());
+    let stop = runtime.stop.clone();
+    let stopped = runtime.stopped.clone();
+    let callback_recorder = recorder.clone();
+    runtime.cfg.on_status = Some(Box::new(move |status| {
+        callback_recorder.push(status);
+        if status == "reconnecting" {
+            stopped.store(true, Ordering::SeqCst);
+            stop.send_replace(true);
+        }
+    }));
+
+    Arc::new(runtime).serve_forever().await.unwrap();
+
+    assert_eq!(script.attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(recorder.snapshot().last().unwrap(), "closed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn intake_runs_while_connected_callback_is_blocked() {
+    let signals = PeerSignals::new();
+    let script =
+        ScriptedConnector::new([ConnectAction::Peer(HelloMode::Complete, signals.clone())]);
+    let recorder = StatusRecorder::new();
+    let callback_finished = Arc::new(AtomicBool::new(false));
+    let mut runtime = build_runtime(&script, &recorder, fast_timings());
+    let callback_recorder = recorder.clone();
+    let callback_finished_inner = callback_finished.clone();
+    runtime.cfg.on_status = Some(Box::new(move |status| {
+        callback_recorder.push(status);
+        if status == "connected" {
+            std::thread::sleep(Duration::from_millis(200));
+            callback_finished_inner.store(true, Ordering::SeqCst);
+        }
+    }));
+    let runtime = Arc::new(runtime);
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("connected", 1).await;
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while signals.intakes.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("intake did not start while callback was blocked");
+    assert!(!callback_finished.load(Ordering::SeqCst));
+
+    runtime.aclose().await;
+    serving.await.unwrap().unwrap();
+    signals.abort_tasks();
+}
+
+#[tokio::test]
+async fn shutdown_interrupts_stalled_hello() {
+    let signals = PeerSignals::new();
+    let script =
+        ScriptedConnector::new([ConnectAction::Peer(HelloMode::StallBody, signals.clone())]);
+    let recorder = StatusRecorder::new();
+    let mut timings = fast_timings();
+    timings.hello = Duration::from_secs(5);
+    let runtime = Arc::new(build_runtime(&script, &recorder, timings));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    signals.hello_seen.notified().await;
+    let started = StdInstant::now();
+    runtime.aclose().await;
+    assert!(tokio::time::timeout(Duration::from_millis(150), serving)
+        .await
+        .unwrap()
+        .unwrap()
+        .is_ok());
+    assert!(started.elapsed() < Duration::from_millis(150));
+    assert!(!recorder.snapshot().contains(&"reconnecting".to_string()));
+    signals.abort_tasks();
+}
+
+#[tokio::test]
+async fn hello_body_timeout_enters_reconnecting() {
+    let signals = PeerSignals::new();
+    let script = ScriptedConnector::new([
+        ConnectAction::Peer(HelloMode::StallBody, signals.clone()),
+        ConnectAction::Hang,
+    ]);
+    let recorder = StatusRecorder::new();
+    let runtime = Arc::new(build_runtime(&script, &recorder, fast_timings()));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("reconnecting", 1).await;
+    runtime.aclose().await;
+    serving.await.unwrap().unwrap();
+    assert!(!recorder.snapshot().contains(&"connected".to_string()));
+    signals.abort_tasks();
+}
+
+#[tokio::test]
+async fn reconnecting_precedes_bounded_teardown_and_is_not_duplicated() {
+    let signals = PeerSignals::new();
+    let script = ScriptedConnector::new([
+        ConnectAction::PeerSlowTeardown(signals.clone()),
+        ConnectAction::Hang,
+    ]);
+    let recorder = StatusRecorder::new();
+    let mut timings = fast_timings();
+    timings.teardown = Duration::from_millis(200);
+    let runtime = Arc::new(build_runtime(&script, &recorder, timings));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("connected", 1).await;
+    let started = StdInstant::now();
+    recorder.wait_count("reconnecting", 1).await;
+    assert!(started.elapsed() < Duration::from_millis(100));
+    assert_eq!(
+        recorder
+            .snapshot()
+            .iter()
+            .filter(|status| status.as_str() == "reconnecting")
+            .count(),
+        1
+    );
+
+    runtime.aclose().await;
+    tokio::time::timeout(Duration::from_millis(500), serving)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    signals.abort_tasks();
+}
+
+#[tokio::test]
+async fn ping_timeout_forces_reconnect_before_another_interval() {
+    let first = PeerSignals::new();
+    let second = PeerSignals::new();
+    let script = ScriptedConnector::new([
+        ConnectAction::Peer(HelloMode::Complete, first.clone()),
+        ConnectAction::Peer(HelloMode::Complete, second.clone()),
+    ]);
+    let recorder = StatusRecorder::new();
+    let mut timings = fast_timings();
+    timings.ping_interval = Duration::from_millis(200);
+    timings.ping_ack = Duration::from_millis(30);
+    let runtime = Arc::new(build_runtime(&script, &recorder, timings));
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("connected", 1).await;
+    first.stop_forwarding();
+    let started = StdInstant::now();
+    recorder.wait_count("reconnecting", 1).await;
+    assert!(started.elapsed() < Duration::from_millis(320));
+    recorder.wait_count("connected", 2).await;
+
+    runtime.aclose().await;
+    serving.await.unwrap().unwrap();
+    assert_eq!(
+        recorder.snapshot(),
+        [
+            "connecting",
+            "connected",
+            "reconnecting",
+            "connected",
+            "closed",
+        ]
+    );
+    first.abort_tasks();
+    second.abort_tasks();
+}
+
+#[tokio::test]
+async fn three_failures_recover_and_success_resets_backoff() {
+    let first = PeerSignals::new();
+    let second = PeerSignals::new();
+    let script = ScriptedConnector::new([
+        ConnectAction::Fail,
+        ConnectAction::Fail,
+        ConnectAction::Fail,
+        ConnectAction::Peer(HelloMode::Complete, first.clone()),
+        ConnectAction::Fail,
+        ConnectAction::Peer(HelloMode::Complete, second.clone()),
+    ]);
+    let recorder = StatusRecorder::new();
+    let sleeps = Arc::new(StdMutex::new(Vec::new()));
+    let mut runtime = build_runtime(&script, &recorder, fast_timings());
+    let sleeps_for_hook = sleeps.clone();
+    runtime.test_hooks.sleeper = Some(Arc::new(move |duration| {
+        sleeps_for_hook.lock().unwrap().push(duration);
+        Box::pin(async { tokio::task::yield_now().await })
+    }));
+    let runtime = Arc::new(runtime);
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("connected", 1).await;
+    first.stop_forwarding();
+    recorder.wait_count("connected", 2).await;
+    runtime.aclose().await;
+    serving.await.unwrap().unwrap();
+
+    let requested = sleeps.lock().unwrap().clone();
+    assert_eq!(
+        requested[0..3],
+        [
+            Duration::from_millis(100),
+            Duration::from_millis(200),
+            Duration::from_millis(400),
+        ]
+    );
+    assert_eq!(requested[3], Duration::from_millis(100));
+    assert_eq!(requested[4], Duration::from_millis(200));
+    assert_eq!(
+        recorder
+            .snapshot()
+            .iter()
+            .filter(|s| *s == "connected")
+            .count(),
+        2
+    );
+    first.abort_tasks();
+    second.abort_tasks();
+}
+
+#[tokio::test]
+async fn callback_panic_does_not_prevent_recovery() {
+    let signals = PeerSignals::new();
+    let script = ScriptedConnector::new([
+        ConnectAction::Fail,
+        ConnectAction::Peer(HelloMode::Complete, signals.clone()),
+    ]);
+    let recorder = StatusRecorder::new();
+    let mut runtime = build_runtime(&script, &recorder, fast_timings());
+    let callback_recorder = recorder.clone();
+    runtime.cfg.on_status = Some(Box::new(move |status| {
+        callback_recorder.push(status);
+        if status == "reconnecting" {
+            panic!("monitor failed for reconnecting");
+        }
+    }));
+    runtime.test_hooks.sleeper = Some(Arc::new(|_| Box::pin(async {})));
+    let runtime = Arc::new(runtime);
+    let serving = tokio::spawn({
+        let runtime = runtime.clone();
+        async move { runtime.serve_forever().await }
+    });
+
+    recorder.wait_count("connected", 1).await;
+    runtime.aclose().await;
+    serving.await.unwrap().unwrap();
+    signals.abort_tasks();
+}
+
+#[test]
+fn callback_panic_log_names_the_status() {
+    let _ = log::set_logger(&TEST_LOGGER);
+    log::set_max_level(log::LevelFilter::Trace);
+    TEST_LOGGER.messages.lock().unwrap().clear();
+    let mut config = cfg();
+    config.on_status = Some(Box::new(|_| panic!("monitor failed")));
+    let runtime = TunnelRuntime::new(config);
+
+    runtime.notify_status("reconnecting");
+
+    assert!(TEST_LOGGER
+        .messages
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|message| message.contains("status reconnecting")));
+}
+
+#[test]
+fn status_callbacks_are_edge_triggered() {
+    let recorder = StatusRecorder::new();
+    let mut config = cfg();
+    let callback_recorder = recorder.clone();
+    config.on_status = Some(Box::new(move |status| callback_recorder.push(status)));
+    let runtime = TunnelRuntime::new(config);
+
+    runtime.notify_status("connecting");
+    runtime.notify_status("connecting");
+    runtime.notify_status("reconnecting");
+    runtime.notify_status("reconnecting");
+    runtime.notify_status("connected");
+
+    assert_eq!(
+        recorder.snapshot(),
+        vec!["connecting", "reconnecting", "connected"]
+    );
+}
+
+#[tokio::test]
+async fn terminal_status_matches_status_handle() {
+    for (mode, expected) in [
+        (HelloMode::Auth, LocalTunnelStatus::Closed),
+        (HelloMode::Superseded, LocalTunnelStatus::Superseded),
+    ] {
+        let signals = PeerSignals::new();
+        let script = ScriptedConnector::new([ConnectAction::Peer(mode, signals.clone())]);
+        let handle = TunnelStatusHandle::new();
+        let mut runtime = TunnelRuntime::new(cfg());
+        runtime.timings = fast_timings();
+        runtime.test_hooks.connector = Some(script.hook());
+        runtime.cfg.on_status = Some(handle.callback());
+        let result = Arc::new(runtime).serve_forever().await;
+
+        assert!(result.is_err());
+        assert_eq!(handle.status(), expected);
+        assert!(!handle.is_connected());
+        signals.abort_tasks();
+    }
+}
+
+struct DropSignal(Arc<AtomicBool>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+fn pending_task(dropped: Arc<AtomicBool>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let _signal = DropSignal(dropped);
+        pending::<()>().await;
+    })
+}
+
+#[tokio::test]
+async fn connection_task_shutdown_aborts_and_joins_driver_and_ping() {
+    let driver_dropped = Arc::new(AtomicBool::new(false));
+    let ping_dropped = Arc::new(AtomicBool::new(false));
+    let mut tasks = ConnectionTasks {
+        driver: Some(pending_task(driver_dropped.clone())),
+        ping: Some(pending_task(ping_dropped.clone())),
+    };
+    tokio::task::yield_now().await;
+
+    let pending = tasks.shutdown(Duration::from_millis(50)).await;
+
+    assert!(pending.is_empty());
+    assert!(driver_dropped.load(Ordering::SeqCst));
+    assert!(ping_dropped.load(Ordering::SeqCst));
+    assert!(tasks.driver.is_none());
+    assert!(tasks.ping.is_none());
+}
+
+#[tokio::test]
+async fn unfinished_task_remains_owned_after_bounded_teardown() {
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let handle = tokio::task::spawn_blocking(move || {
+        started_tx.send(()).unwrap();
+        std::thread::sleep(Duration::from_millis(80));
+    });
+    started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    let mut tasks = vec![OwnedTask::new("blocking test task", handle)];
+
+    shutdown_owned_tasks(&mut tasks, Duration::from_millis(5)).await;
+
+    assert_eq!(tasks.len(), 1);
+    let runtime = TunnelRuntime::new(cfg());
+    runtime.retain_tasks(&mut tasks);
+    assert!(tasks.is_empty());
+    assert_eq!(runtime.lingering().len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn connection_phase_deadline_is_shared() {
+    let started = Instant::now();
+    let deadline = started + CONNECT_TIMEOUT;
+    with_phase_timeout(deadline, "tcp", async {
+        tokio::time::sleep(Duration::from_secs(7)).await;
+        Ok(())
+    })
+    .await
+    .unwrap();
+    let err = with_phase_timeout(deadline, "tls", async {
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        Ok(())
+    })
+    .await
+    .unwrap_err();
+
+    assert_eq!(Instant::now() - started, CONNECT_TIMEOUT);
+    assert_eq!(timeout_phase(&err), Some("tls"));
+}

--- a/sdk/rust/src/tunnels/client/status.rs
+++ b/sdk/rust/src/tunnels/client/status.rs
@@ -1,0 +1,202 @@
+//! Sampleable local state for the tunnel data-plane runtime.
+
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::SystemTime;
+
+use super::runtime::StatusCallback;
+
+/// The local connection state observed by a tunnel runtime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LocalTunnelStatus {
+    /// The handle has not observed a running connection yet.
+    #[default]
+    Idle,
+    /// The initial connection is being established.
+    Connecting,
+    /// The HELLO handshake completed and the tunnel is accepting traffic.
+    Connected,
+    /// A connection was lost or establishment failed and will be retried.
+    Reconnecting,
+    /// The runtime stopped or authentication was rejected.
+    Closed,
+    /// A newer client took ownership of the tunnel.
+    Superseded,
+}
+
+/// An atomic snapshot of the runtime's local connection state.
+#[derive(Debug, Clone)]
+pub struct TunnelStatusSnapshot {
+    /// Current local runtime state.
+    pub status: LocalTunnelStatus,
+    /// Local time of the latest successful HELLO handshake.
+    pub last_connected_at: Option<SystemTime>,
+}
+
+/// Cloneable, thread-safe local liveness state for a blocking tunnel connection.
+///
+/// Pass [`callback`](Self::callback) to
+/// [`TunnelsResource::connect_with_status`](crate::tunnels::resources::TunnelsResource::connect_with_status)
+/// on a caller-owned thread, then sample a clone from another thread.
+#[derive(Debug, Clone, Default)]
+pub struct TunnelStatusHandle {
+    inner: Arc<RwLock<TunnelStatusSnapshot>>,
+}
+
+impl Default for TunnelStatusSnapshot {
+    fn default() -> Self {
+        Self {
+            status: LocalTunnelStatus::Idle,
+            last_connected_at: None,
+        }
+    }
+}
+
+impl TunnelStatusHandle {
+    /// Create a handle in the [`Idle`](LocalTunnelStatus::Idle) state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the current local runtime state.
+    pub fn status(&self) -> LocalTunnelStatus {
+        self.read().status
+    }
+
+    /// Return whether the latest observed state is `Connected`.
+    pub fn is_connected(&self) -> bool {
+        self.status() == LocalTunnelStatus::Connected
+    }
+
+    /// Return the local time of the latest successful HELLO handshake.
+    ///
+    /// The timestamp remains available while the runtime reconnects.
+    pub fn last_connected_at(&self) -> Option<SystemTime> {
+        self.read().last_connected_at
+    }
+
+    /// Read the status and timestamp under one lock.
+    pub fn snapshot(&self) -> TunnelStatusSnapshot {
+        self.read().clone()
+    }
+
+    /// Build a status callback that updates this handle before returning.
+    ///
+    /// Unknown future status strings leave the current snapshot unchanged.
+    pub fn callback(&self) -> StatusCallback {
+        let handle = self.clone();
+        Box::new(move |status| handle.update(status))
+    }
+
+    fn update(&self, status: &str) {
+        let status = match status {
+            "connecting" => LocalTunnelStatus::Connecting,
+            "connected" => LocalTunnelStatus::Connected,
+            "reconnecting" => LocalTunnelStatus::Reconnecting,
+            "closed" => LocalTunnelStatus::Closed,
+            "superseded" => LocalTunnelStatus::Superseded,
+            _ => return,
+        };
+        let mut snapshot = self.write();
+        snapshot.status = status;
+        if status == LocalTunnelStatus::Connected {
+            snapshot.last_connected_at = Some(SystemTime::now());
+        }
+    }
+
+    fn read(&self) -> RwLockReadGuard<'_, TunnelStatusSnapshot> {
+        self.inner.read().unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, TunnelStatusSnapshot> {
+        self.inner.write().unwrap_or_else(|err| err.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_tracks_lifecycle_and_retains_last_connection() {
+        let handle = TunnelStatusHandle::new();
+        assert_eq!(handle.status(), LocalTunnelStatus::Idle);
+        assert!(!handle.is_connected());
+        assert_eq!(handle.last_connected_at(), None);
+
+        let callback = handle.callback();
+        callback("connecting");
+        assert_eq!(handle.status(), LocalTunnelStatus::Connecting);
+        callback("connected");
+        let connected_at = handle.last_connected_at().unwrap();
+        assert!(handle.is_connected());
+
+        callback("reconnecting");
+        let snapshot = handle.snapshot();
+        assert_eq!(snapshot.status, LocalTunnelStatus::Reconnecting);
+        assert_eq!(snapshot.last_connected_at, Some(connected_at));
+
+        callback("future-state");
+        assert_eq!(handle.snapshot().last_connected_at, Some(connected_at));
+        assert_eq!(handle.status(), LocalTunnelStatus::Reconnecting);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        callback("connected");
+        let recovered_at = handle.last_connected_at().unwrap();
+        assert!(recovered_at > connected_at);
+        callback("superseded");
+        assert_eq!(handle.status(), LocalTunnelStatus::Superseded);
+        assert_eq!(handle.last_connected_at(), Some(recovered_at));
+    }
+
+    #[test]
+    fn poisoned_status_lock_remains_sampleable() {
+        let handle = TunnelStatusHandle::new();
+        let poisoner = handle.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.inner.write().unwrap();
+            panic!("poison status lock");
+        })
+        .join();
+
+        assert_eq!(handle.status(), LocalTunnelStatus::Idle);
+        handle.callback()("connected");
+        assert!(handle.is_connected());
+        assert!(handle.last_connected_at().is_some());
+    }
+
+    #[test]
+    fn concurrent_updates_and_snapshots_remain_consistent() {
+        let handle = TunnelStatusHandle::new();
+        handle.callback()("connected");
+        let first_connected_at = handle.last_connected_at().unwrap();
+        let mut threads = Vec::new();
+
+        for index in 0..8 {
+            let updater = handle.clone();
+            threads.push(std::thread::spawn(move || {
+                let callback = updater.callback();
+                for iteration in 0..1_000 {
+                    if (index + iteration) % 2 == 0 {
+                        callback("reconnecting");
+                    } else {
+                        callback("connected");
+                    }
+                    let snapshot = updater.snapshot();
+                    if snapshot.status == LocalTunnelStatus::Connected {
+                        assert!(snapshot.last_connected_at.is_some());
+                    }
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        handle.callback()("connected");
+        assert!(handle.is_connected());
+        assert!(handle.last_connected_at().unwrap() >= first_connected_at);
+        handle.callback()("closed");
+        assert_eq!(handle.status(), LocalTunnelStatus::Closed);
+        assert!(handle.last_connected_at().is_some());
+    }
+}

--- a/sdk/rust/src/tunnels/resources/tunnels.rs
+++ b/sdk/rust/src/tunnels/resources/tunnels.rs
@@ -178,8 +178,13 @@ impl TunnelsResource {
     }
 
     /// Like [`connect`](Self::connect), but reports data-plane state changes to
-    /// `on_status` — invoked with `"connecting"`, `"connected"`,
-    /// `"reconnecting"`, and `"closed"`. Mirrors the Python `on_status` kwarg.
+    /// `on_status`: `"connecting"`, `"connected"`, `"reconnecting"`,
+    /// `"closed"`, or `"superseded"`.
+    ///
+    /// The call remains blocking. To sample liveness elsewhere, create a
+    /// [`TunnelStatusHandle`](crate::tunnels::client::TunnelStatusHandle), pass
+    /// `handle.callback()` here on a caller-owned thread, and retain a clone.
+    /// Compose that callback with any additional monitoring in your closure.
     #[cfg(feature = "tunnels-runtime")]
     pub fn connect_with_status(
         &self,

--- a/sdk/rust/src/tunnels/resources/tunnels.rs
+++ b/sdk/rust/src/tunnels/resources/tunnels.rs
@@ -185,6 +185,8 @@ impl TunnelsResource {
     /// [`TunnelStatusHandle`](crate::tunnels::client::TunnelStatusHandle), pass
     /// `handle.callback()` here on a caller-owned thread, and retain a clone.
     /// Compose that callback with any additional monitoring in your closure.
+    /// Callbacks run inline on the runtime and must return promptly; move
+    /// blocking monitoring work onto a caller-owned thread or queue.
     #[cfg(feature = "tunnels-runtime")]
     pub fn connect_with_status(
         &self,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1216,6 +1216,37 @@ await inkbox.phoneNumbers.release(num.id);
 
 ---
 
+## Tunnels
+
+The Node-only data-plane runtime is exported separately so the main SDK remains
+browser-safe:
+
+```ts
+import { connect } from "@inkbox/sdk/tunnels/connect";
+
+const listener = await connect(inkbox, {
+  name: "my-app",
+  forwardTo: "http://127.0.0.1:8080",
+});
+
+console.log(listener.publicUrl);
+console.log(listener.status);          // idle, connecting, connected, ...
+console.log(listener.isConnected);     // local runtime liveness
+console.log(listener.lastConnectedAt); // latest successful HELLO, or null
+await listener.wait();
+```
+
+Transient connect, HELLO, transport, and PING failures retry with bounded
+establishment and exponential backoff. `status` is `idle`, `connecting`,
+`connected`, `reconnecting`, `closed`, or `superseded`; the timestamp remains
+available while reconnecting. These values describe the local listener, while
+`listener.tunnel` remains the bootstrap resource snapshot. Authentication,
+takeover, and unexpected fatal failures reject both `serveForever()` and
+`wait()`. Attach a rejection handler when calling `serveForever()` without
+awaiting it.
+
+---
+
 ## Webhooks
 
 Webhook delivery uses a dedicated subscription resource. Each

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1245,6 +1245,11 @@ takeover, and unexpected fatal failures reject both `serveForever()` and
 `wait()`. Attach a rejection handler when calling `serveForever()` without
 awaiting it.
 
+For in-process WebSocket handlers, planned drain throws `WsServerDraining`
+(`4500`) and unplanned tunnel connection loss throws `WsConnectionLost`
+(`1011`). Both extend `WsClosed` and advise the peer to reconnect. URL-forwarded
+WebSockets receive the matching CLOSE code on their local upstream connection.
+
 ---
 
 ## Webhooks

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/tunnels/client/_listener.ts
+++ b/sdk/typescript/src/tunnels/client/_listener.ts
@@ -7,11 +7,13 @@
  */
 
 import type { Tunnel } from "../types.js";
-import type { TunnelRuntime } from "./_runtime.js";
+import type { TunnelRuntime, TunnelRuntimeStatus } from "./_runtime.js";
 
 export type TunnelStatusCallback = (
-  status: "connecting" | "connected" | "reconnecting" | "closed" | "superseded",
+  status: Exclude<TunnelRuntimeStatus, "idle">,
 ) => void;
+
+export type { TunnelRuntimeStatus } from "./_runtime.js";
 
 /**
  * Options that affect how the listener behaves around process signals.
@@ -37,6 +39,12 @@ export interface TunnelListener {
   readonly publicUrl: string;
   /** Snapshot of the resource record taken at bootstrap. Not refreshed. */
   readonly tunnel: Tunnel;
+  /** Current local runtime lifecycle state. */
+  readonly status: TunnelRuntimeStatus;
+  /** Whether the local runtime currently has an active connection. */
+  readonly isConnected: boolean;
+  /** Time of the latest successful hello, retained while reconnecting. */
+  readonly lastConnectedAt: Date | null;
   /** Block until shutdown. Resolves on clean close; throws on fatal. */
   wait(): Promise<void>;
   /** Drive a graceful shutdown. Idempotent. */
@@ -53,7 +61,6 @@ export class TunnelListenerImpl implements TunnelListener {
   private readonly runtime: TunnelRuntime;
   private servePromise: Promise<void> | null = null;
   private closed = false;
-  private capturedError: unknown = null;
   private installedSigintHandler: (() => void) | null = null;
   private installedSigtermHandler: (() => void) | null = null;
   private willExitOnSignal = false;
@@ -113,25 +120,26 @@ export class TunnelListenerImpl implements TunnelListener {
     }
   }
 
-  async serveForever(): Promise<void> {
+  get status(): TunnelRuntimeStatus {
+    return this.runtime.status;
+  }
+
+  get isConnected(): boolean {
+    return this.runtime.isConnected;
+  }
+
+  get lastConnectedAt(): Date | null {
+    return this.runtime.lastConnectedAt;
+  }
+
+  serveForever(): Promise<void> {
     if (this.servePromise !== null) return this.servePromise;
-    this.servePromise = (async () => {
-      try {
-        await this.runtime.serveForever();
-      } catch (err) {
-        this.capturedError = err;
-      }
-    })();
+    this.servePromise = this.runtime.serveForever();
     return this.servePromise;
   }
 
   async wait(): Promise<void> {
     await this.serveForever();
-    if (this.capturedError !== null) {
-      const err = this.capturedError;
-      this.capturedError = null;
-      throw err;
-    }
   }
 
   async close(): Promise<void> {
@@ -154,7 +162,7 @@ export class TunnelListenerImpl implements TunnelListener {
       try {
         await this.servePromise;
       } catch {
-        /* swallow — captured in capturedError if relevant */
+        /* shutdown remains non-throwing after a terminal runtime result */
       }
     }
   }

--- a/sdk/typescript/src/tunnels/client/_listener.ts
+++ b/sdk/typescript/src/tunnels/client/_listener.ts
@@ -149,6 +149,7 @@ export class TunnelListenerImpl implements TunnelListener {
   async aclose(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
+    const settledServe = this.servePromise?.catch(() => undefined);
     await this.runtime.aclose();
     if (this.installedSigtermHandler !== null) {
       process.off("SIGTERM", this.installedSigtermHandler);
@@ -158,12 +159,6 @@ export class TunnelListenerImpl implements TunnelListener {
       process.off("SIGINT", this.installedSigintHandler);
       this.installedSigintHandler = null;
     }
-    if (this.servePromise !== null) {
-      try {
-        await this.servePromise;
-      } catch {
-        /* shutdown remains non-throwing after a terminal runtime result */
-      }
-    }
+    await settledServe;
   }
 }

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -19,6 +19,7 @@
 
 import * as http2 from "node:http2";
 import * as net from "node:net";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { setTimeout as setTimeoutPromise } from "node:timers/promises";
 import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
 
@@ -72,6 +73,7 @@ import {
 } from "./_wsframe.js";
 import {
   dispatchWsUpgradeInProcess,
+  WsConnectionLost,
   WsServerDraining,
   type InkboxWsHandler,
   type WsBridgeIO,
@@ -369,6 +371,8 @@ export class TunnelRuntime {
   private coldAttempt = 0;
   private terminalError: TunnelAuthError | null = null;
   private pendingConnection: Connection | null = null;
+  private coldGeneration = 0;
+  private readonly dispatchGeneration = new AsyncLocalStorage<number>();
 
   constructor(opts: TunnelRuntimeOpts) {
     this.tunnelId = opts.tunnelId;
@@ -443,6 +447,10 @@ export class TunnelRuntime {
         if (this.superseded) {
           this.stopSuperseded();
         }
+        if (this.stop) {
+          if (this.runtimeStatus !== "superseded") this.notifyStatus("closed");
+          return;
+        }
         consecutiveFailures += 1;
         if (err instanceof TunnelPhaseTimeoutError) {
           // eslint-disable-next-line no-console
@@ -489,6 +497,7 @@ export class TunnelRuntime {
   /** Graceful shutdown. Signals all loops to exit; closes every conn. */
   async aclose(): Promise<void> {
     this.stop = true;
+    this.coldGeneration += 1;
     if (this.runtimeStatus !== "superseded") this.notifyStatus("closed");
     this.shutdownAbort.abort();
     if (this.passthroughDispatch !== null) {
@@ -683,6 +692,7 @@ export class TunnelRuntime {
         this.notifyStatus("reconnecting");
       }
     } finally {
+      if (!this.stop) this.coldGeneration += 1;
       this.stopPingLoop(conn);
       conn.streams.clear();
       conn.bridgeStreamIds.clear();
@@ -1310,10 +1320,13 @@ export class TunnelRuntime {
       // Fire-and-forget dispatch; tracked on the runtime (not the conn) so
       // an in-flight handler survives this conn draining and can post its
       // reply on the new active conn during a handoff.
-      const task = this.dispatchEnvelope(conn, envelope).catch((err) => {
-        // eslint-disable-next-line no-console
-        console.warn(`dispatch failed request_id=${envelope!.requestId}`, err);
-      });
+      const generation = this.coldGeneration;
+      const task = this.dispatchGeneration
+        .run(generation, () => this.dispatchEnvelope(conn, envelope))
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn(`dispatch failed request_id=${envelope!.requestId}`, err);
+        });
       this.tasks.add(task);
       task.finally(() => this.tasks.delete(task));
     }
@@ -1952,23 +1965,23 @@ export class TunnelRuntime {
           const id = sid();
           if (id === null) {
             if (conn.draining) throw new WsServerDraining();
-            return;
+            throw new WsConnectionLost();
           }
           const ev = await self.nextEvent(conn, id);
           if (ev === null) {
             if (conn.draining) throw new WsServerDraining();
-            return;
+            throw new WsConnectionLost();
           }
           if (ev.kind === "data") {
             yield ev.data;
           } else if (ev.kind === "end") {
             if (conn.draining) throw new WsServerDraining();
-            return;
+            throw new WsConnectionLost();
           } else if (ev.kind === "reset") {
             // A reset while the conn is draining is the redeploy drain, not
             // a peer error — surface it typed so the handler can reconnect.
             if (conn.draining) throw new WsServerDraining();
-            throw new Error(`bridge stream reset code=${ev.code}`);
+            throw new WsConnectionLost(`bridge stream reset code=${ev.code}`);
           }
         }
       })();
@@ -2424,6 +2437,7 @@ export class TunnelRuntime {
         setTimeoutPromise(POST_ACTIVE_WAIT_MS),
       ]);
     }
+    if (!this.dispatchIsCurrent()) return;
     const target = this.pickReplyConnection(origin);
     if (target === null) {
       // eslint-disable-next-line no-console
@@ -2455,6 +2469,7 @@ export class TunnelRuntime {
     userHeaders: Array<[string, string]>,
     body: Buffer,
   ): Promise<void> {
+    if (!this.dispatchIsCurrent()) return;
     const reqHeaders: http2.OutgoingHttpHeaders = {
       [HTTP2_HEADER_METHOD]: "POST",
       [HTTP2_HEADER_SCHEME]: "https",
@@ -2515,6 +2530,11 @@ export class TunnelRuntime {
   }
 
   // --- utilities ---------------------------------------------------------
+
+  private dispatchIsCurrent(): boolean {
+    const generation = this.dispatchGeneration.getStore();
+    return generation === undefined || generation === this.coldGeneration;
+  }
 
   private notifyStatus(status: Exclude<TunnelRuntimeStatus, "idle">): void {
     if (this.runtimeStatus === status) return;

--- a/sdk/typescript/src/tunnels/client/_runtime.ts
+++ b/sdk/typescript/src/tunnels/client/_runtime.ts
@@ -90,6 +90,9 @@ export const PING_INTERVAL_MS = 20_000;
  * a dead TCP doesn't strand the runtime past the next intake.
  */
 export const PING_ACK_TIMEOUT_MS = 10_000;
+export const CONNECT_TIMEOUT_MS = 10_000;
+export const HELLO_TIMEOUT_MS = 15_000;
+export const INITIAL_BACKOFF_MS = 1_000;
 export const BACKOFF_CAP_SEC = 30.0;
 export const BACKOFF_JITTER = 0.25;
 // On drain, keep a post-GOAWAY connection alive for its in-flight bridges
@@ -131,6 +134,13 @@ export class TunnelSupersededError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "TunnelSupersededError";
+  }
+}
+
+class TunnelPhaseTimeoutError extends Error {
+  constructor(readonly phase: "connect" | "hello", timeoutMs: number) {
+    super(`tunnel ${phase} timed out after ${timeoutMs}ms`);
+    this.name = "TunnelPhaseTimeoutError";
   }
 }
 
@@ -183,8 +193,16 @@ function parseReasonJson(buf: Buffer | undefined | null): string | null {
   return null;
 }
 
+export type TunnelRuntimeStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "closed"
+  | "superseded";
+
 export type StatusCallback = (
-  status: "connecting" | "connected" | "reconnecting" | "closed" | "superseded",
+  status: Exclude<TunnelRuntimeStatus, "idle">,
 ) => void;
 
 /**
@@ -229,6 +247,13 @@ export interface TunnelRuntimeOpts {
     authority: string,
     options: http2.ClientSessionOptions | http2.SecureClientSessionOptions,
   ) => ClientHttp2Session;
+  /** Internal timeout and scheduler injection points for tests. */
+  connectTimeoutMs?: number;
+  helloTimeoutMs?: number;
+  pingIntervalMs?: number;
+  pingAckTimeoutMs?: number;
+  handoffRedialBudgetMs?: number;
+  sleep?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
 }
 
 interface StreamBus {
@@ -262,9 +287,18 @@ class Connection {
   readonly streams = new Map<number, StreamBus>();
   readonly bridgeStreamIds = new Set<number>();
   pingHandle: NodeJS.Timeout | null = null;
-  pingAbort: AbortController | null = null;
+  readonly pingAckHandles = new Set<NodeJS.Timeout>();
+  readonly closed: Promise<void>;
+  resolveClosed!: () => void;
+  closePublished = false;
+  detachTransportListeners: (() => void) | null = null;
+  cancelConnectWait: (() => void) | null = null;
 
-  constructor(readonly id: number) {}
+  constructor(readonly id: number) {
+    this.closed = new Promise<void>((resolve) => {
+      this.resolveClosed = resolve;
+    });
+  }
 
   /** Live WS/TCP bridge count — drives the drain-quiescent check. */
   get liveBridges(): number {
@@ -292,6 +326,12 @@ export class TunnelRuntime {
   private readonly onStatus?: StatusCallback;
   private readonly rng: () => number;
   private readonly http2Connect: NonNullable<TunnelRuntimeOpts["http2Connect"]>;
+  private readonly connectTimeoutMs: number;
+  private readonly helloTimeoutMs: number;
+  private readonly pingIntervalMs: number;
+  private readonly pingAckTimeoutMs: number;
+  private readonly handoffRedialBudgetMs: number;
+  private readonly sleep: NonNullable<TunnelRuntimeOpts["sleep"]>;
 
   // The pool that parks new intakes. Swapped atomically on handoff.
   private active: Connection | null = null;
@@ -323,6 +363,12 @@ export class TunnelRuntime {
   // in aclose().
   private readonly undiciAgentCache: UndiciAgentCache = createUndiciAgentCache();
   private shutdownAbort: AbortController = new AbortController();
+  private runtimeStatus: TunnelRuntimeStatus = "idle";
+  private lastConnectedAtMs: number | null = null;
+  private hasConnected = false;
+  private coldAttempt = 0;
+  private terminalError: TunnelAuthError | null = null;
+  private pendingConnection: Connection | null = null;
 
   constructor(opts: TunnelRuntimeOpts) {
     this.tunnelId = opts.tunnelId;
@@ -339,9 +385,31 @@ export class TunnelRuntime {
     this.onStatus = opts.onStatus;
     this.rng = opts.rng ?? Math.random;
     this.http2Connect = opts.http2Connect ?? http2.connect.bind(http2);
+    this.connectTimeoutMs = opts.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+    this.helloTimeoutMs = opts.helloTimeoutMs ?? HELLO_TIMEOUT_MS;
+    this.pingIntervalMs = opts.pingIntervalMs ?? PING_INTERVAL_MS;
+    this.pingAckTimeoutMs = opts.pingAckTimeoutMs ?? PING_ACK_TIMEOUT_MS;
+    this.handoffRedialBudgetMs =
+      opts.handoffRedialBudgetMs ?? HANDOFF_REDIAL_BUDGET_MS;
+    this.sleep = opts.sleep ?? ((delayMs, signal) =>
+      setTimeoutPromise(delayMs, undefined, { signal }));
   }
 
   // --- public lifecycle ---------------------------------------------------
+
+  get status(): TunnelRuntimeStatus {
+    return this.runtimeStatus;
+  }
+
+  get isConnected(): boolean {
+    return this.runtimeStatus === "connected";
+  }
+
+  get lastConnectedAt(): Date | null {
+    return this.lastConnectedAtMs === null
+      ? null
+      : new Date(this.lastConnectedAtMs);
+  }
 
   /**
    * Drive the runtime forever. Reconnects with jittered exponential
@@ -349,13 +417,17 @@ export class TunnelRuntime {
    * secret) or after `aclose()`.
    */
   async serveForever(): Promise<void> {
-    let backoff = 1.0;
+    let backoff = INITIAL_BACKOFF_MS / 1000;
     let consecutiveFailures = 0;
-    this.notifyStatus("connecting");
     while (!this.stop) {
+      this.coldAttempt += 1;
+      const attempt = this.coldAttempt;
+      if (attempt === 1) this.notifyStatus("connecting");
+      // eslint-disable-next-line no-console
+      console.info(`tunnel runtime: connection attempt #${attempt}`);
       try {
         await this.runOnce();
-        backoff = 1.0;
+        backoff = INITIAL_BACKOFF_MS / 1000;
         consecutiveFailures = 0;
       } catch (err) {
         if (err instanceof TunnelAuthError) {
@@ -372,11 +444,19 @@ export class TunnelRuntime {
           this.stopSuperseded();
         }
         consecutiveFailures += 1;
-        // eslint-disable-next-line no-console
-        console.warn(
-          `tunnel runtime: connection error (#${consecutiveFailures}); reconnecting`,
-          err,
-        );
+        if (err instanceof TunnelPhaseTimeoutError) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `tunnel runtime: ${err.phase} timeout on attempt #${attempt}; reconnecting`,
+          );
+        } else {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `tunnel runtime: connection error on attempt #${attempt} ` +
+              `(consecutive failure #${consecutiveFailures}); reconnecting`,
+            err,
+          );
+        }
         this.notifyStatus("reconnecting");
       }
       if (this.stop) {
@@ -389,10 +469,13 @@ export class TunnelRuntime {
       //   backoff = min(backoff * 2, 30.0)
       const jitter = backoff * BACKOFF_JITTER * (2 * this.rng() - 1);
       const sleepFor = Math.max(0.1, backoff + jitter);
+      const delayMs = sleepFor * 1000;
+      // eslint-disable-next-line no-console
+      console.info(
+        `tunnel runtime: retrying with attempt #${attempt + 1} in ${delayMs}ms`,
+      );
       try {
-        await setTimeoutPromise(sleepFor * 1000, undefined, {
-          signal: this.shutdownAbort.signal,
-        });
+        await this.sleep(delayMs, this.shutdownAbort.signal);
       } catch {
         // aborted by aclose()
         this.notifyStatus("closed");
@@ -406,6 +489,7 @@ export class TunnelRuntime {
   /** Graceful shutdown. Signals all loops to exit; closes every conn. */
   async aclose(): Promise<void> {
     this.stop = true;
+    if (this.runtimeStatus !== "superseded") this.notifyStatus("closed");
     this.shutdownAbort.abort();
     if (this.passthroughDispatch !== null) {
       try {
@@ -422,12 +506,14 @@ export class TunnelRuntime {
     }
     // Close active + every draining conn; stop each one's ping loop so no
     // ping loop leaks across the handoff set.
-    const conns = [this.active, ...this.draining].filter(
+    const conns = [this.active, this.pendingConnection, ...this.draining].filter(
       (c): c is Connection => c !== null,
     );
-    for (const conn of conns) {
+    for (const conn of new Set(conns)) {
       this.stopPingLoop(conn);
       await this.closeConnection(conn);
+      this.publishConnectionClosed(conn);
+      conn.session = null;
     }
   }
 
@@ -436,52 +522,132 @@ export class TunnelRuntime {
    * short grace. The intake pool parks streams indefinitely, so a plain
    * `close()` would never resolve; we GOAWAY then destroy after 250ms.
    */
-  private async closeConnection(conn: Connection): Promise<void> {
+  private async closeConnection(conn: Connection, graceMs = 250): Promise<void> {
     const session = conn.session;
-    conn.session = null;
-    if (session === null || session.closed) return;
+    if (session === null || session.closed || session.destroyed) {
+      this.publishConnectionClosed(conn);
+      return;
+    }
     try {
       session.goaway();
     } catch {
       /* swallow */
     }
+    if (graceMs <= 0) {
+      this.destroyConnection(conn);
+      return;
+    }
     await new Promise<void>((resolve) => {
       const t = setTimeout(() => {
-        try {
-          session.destroy();
-        } catch {
-          /* swallow */
-        }
-        resolve();
-      }, 250);
-      session.once("close", () => {
+        try { session.destroy(); } catch { /* swallow */ }
+        setImmediate(() => {
+          this.publishConnectionClosed(conn);
+        });
+      }, graceMs);
+      void conn.closed.then(() => {
         clearTimeout(t);
-        resolve();
+        setTimeout(resolve, 10);
       });
       try {
         session.close();
       } catch {
         clearTimeout(t);
-        try {
-          session.destroy();
-        } catch {
-          /* swallow */
-        }
-        resolve();
+        this.destroyConnection(conn);
       }
     });
   }
 
+  private publishConnectionClosed(conn: Connection): void {
+    if (!conn.closePublished) {
+      conn.closePublished = true;
+      for (const [, bus] of conn.streams) {
+        if (!bus.ended) {
+          bus.events.push({ kind: "reset", code: 0 });
+          bus.ended = true;
+          this.wake(bus);
+        }
+      }
+      conn.resolveClosed();
+    }
+    conn.detachTransportListeners?.();
+    conn.detachTransportListeners = null;
+    conn.cancelConnectWait?.();
+    conn.cancelConnectWait = null;
+  }
+
+  private destroyConnection(conn: Connection): void {
+    const session = conn.session;
+    this.publishConnectionClosed(conn);
+    try { session?.destroy(); } catch { /* swallow */ }
+  }
+
   // --- per-connection lifecycle -----------------------------------------
+
+  private async withPhaseTimeout<T>(
+    conn: Connection,
+    phase: "connect" | "hello",
+    timeoutMs: number,
+    operation: Promise<T>,
+  ): Promise<T> {
+    let timer: NodeJS.Timeout | null = null;
+    let timeoutError: TunnelPhaseTimeoutError | null = null;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        timeoutError = new TunnelPhaseTimeoutError(phase, timeoutMs);
+        this.destroyConnection(conn);
+        reject(timeoutError);
+      }, Math.max(1, timeoutMs));
+    });
+    void operation.catch(() => undefined);
+    try {
+      return await Promise.race([operation, timeout]);
+    } catch (err) {
+      if (
+        timeoutError !== null &&
+        !(err instanceof TunnelAuthError) &&
+        !(err instanceof TunnelSupersededError)
+      ) {
+        throw timeoutError;
+      }
+      throw err;
+    } finally {
+      if (timer !== null) clearTimeout(timer);
+    }
+  }
+
+  private markConnected(emitStatus: boolean): void {
+    const recovered = this.hasConnected;
+    this.hasConnected = true;
+    this.lastConnectedAtMs = Date.now();
+    if (emitStatus) {
+      this.notifyStatus("connected");
+      // eslint-disable-next-line no-console
+      console.info(
+        recovered
+          ? "tunnel runtime: connection recovered"
+          : "tunnel runtime: initial connection established",
+      );
+    }
+  }
 
   private async runOnce(): Promise<void> {
     const first = new Connection(this.nextConnId++);
     let conn = first;
     this.active = first;
     try {
-      await this.openConnection(first);
-      await this.sendHello(first);
-      this.notifyStatus("connected");
+      await this.withPhaseTimeout(
+        first,
+        "connect",
+        this.connectTimeoutMs,
+        this.openConnection(first),
+      );
+      await this.withPhaseTimeout(
+        first,
+        "hello",
+        this.helloTimeoutMs,
+        this.sendHello(first),
+      );
+      this.markConnected(true);
       this.startServing(first);
       // Supervise the active connection. A GOAWAY handoff swaps in a new
       // active conn out-of-band; follow it without going through the
@@ -496,6 +662,7 @@ export class TunnelRuntime {
         if (this.handoffInFlight && this.handoffPromise !== null) {
           await this.handoffPromise;
         }
+        if (this.terminalError !== null) throw this.terminalError;
         const next = this.active;
         if (next !== null && next !== conn && !next.draining) {
           conn = next;
@@ -510,10 +677,17 @@ export class TunnelRuntime {
           "another client connected to this tunnel; not reconnecting",
         );
       }
+      if (!this.stop) {
+        // eslint-disable-next-line no-console
+        console.warn("tunnel runtime: connected session lost; reconnecting");
+        this.notifyStatus("reconnecting");
+      }
     } finally {
       this.stopPingLoop(conn);
       conn.streams.clear();
       conn.bridgeStreamIds.clear();
+      await this.closeConnection(conn);
+      this.publishConnectionClosed(conn);
       conn.session = null;
       if (this.active === conn) this.active = null;
     }
@@ -532,18 +706,10 @@ export class TunnelRuntime {
 
   /** Resolve once the supervised conn closes OR a handoff swaps active. */
   private waitCloseOrHandoff(conn: Connection): Promise<void> {
-    const closed = new Promise<void>((resolve) => {
-      const session = conn.session;
-      if (session === null || session.closed) {
-        resolve();
-        return;
-      }
-      session.once("close", () => resolve());
-    });
     const woken = new Promise<void>((resolve) => {
       this.wakeSupervisor = resolve;
     });
-    return Promise.race([closed, woken]).finally(() => {
+    return Promise.race([conn.closed, woken]).finally(() => {
       this.wakeSupervisor = null;
     });
   }
@@ -651,6 +817,7 @@ export class TunnelRuntime {
     try {
       const newConn = await this.makeReplacementConnection();
       this.active = newConn;
+      this.markConnected(false);
       // Supervisor was watching oldConn; wake it to follow newConn.
       this.signalSupervisor();
     } catch (err) {
@@ -658,7 +825,11 @@ export class TunnelRuntime {
         // External takeover during the handoff hello: `superseded` is set, so
         // end the old conn and wake the supervisor to stop terminally (no cold
         // redial, which would boot the client that replaced us).
-        try { oldConn.session?.destroy(); } catch { /* swallow */ }
+        this.destroyConnection(oldConn);
+        this.signalSupervisor();
+      } else if (err instanceof TunnelAuthError) {
+        this.terminalError = err;
+        this.destroyConnection(oldConn);
         this.signalSupervisor();
       } else {
         // Redial budget exhausted (or auth failure): give up on
@@ -666,7 +837,7 @@ export class TunnelRuntime {
         // the old session closed so the supervisor returns.
         // eslint-disable-next-line no-console
         console.warn("tunnel runtime: handoff failed; reconnecting cold", err);
-        try { oldConn.session?.destroy(); } catch { /* swallow */ }
+        this.destroyConnection(oldConn);
         this.signalSupervisor();
       }
     } finally {
@@ -680,16 +851,38 @@ export class TunnelRuntime {
   /** Dial + hello + park a replacement, retrying transient hello failures. */
   private async makeReplacementConnection(): Promise<Connection> {
     let backoff = 0.1;
-    const start = Date.now();
+    const deadline = performance.now() + this.handoffRedialBudgetMs;
     while (!this.stop) {
+      let remaining = deadline - performance.now();
+      if (remaining <= 0) throw new Error("handoff redial budget exhausted");
       const conn = new Connection(this.nextConnId++);
+      this.pendingConnection = conn;
       try {
-        await this.openConnection(conn);
-        await this.sendHello(conn);
+        await this.withPhaseTimeout(
+          conn,
+          "connect",
+          Math.min(this.connectTimeoutMs, remaining),
+          this.openConnection(conn),
+        );
+        remaining = deadline - performance.now();
+        if (remaining <= 0) throw new Error("handoff redial budget exhausted");
+        await this.withPhaseTimeout(
+          conn,
+          "hello",
+          Math.min(this.helloTimeoutMs, remaining),
+          this.sendHello(conn),
+        );
         this.startServing(conn);
+        this.pendingConnection = null;
         return conn;
       } catch (err) {
-        try { await this.closeConnection(conn); } catch { /* swallow */ }
+        remaining = deadline - performance.now();
+        try {
+          await this.closeConnection(conn, Math.min(250, Math.max(0, remaining)));
+        } catch { /* swallow */ }
+        this.publishConnectionClosed(conn);
+        conn.session = null;
+        if (this.pendingConnection === conn) this.pendingConnection = null;
         // A rejected key or a takeover is terminal; never retry either
         // (retrying a takeover would boot the client that replaced us).
         if (err instanceof TunnelAuthError || err instanceof TunnelSupersededError) {
@@ -703,15 +896,18 @@ export class TunnelRuntime {
             "another client connected to this tunnel during handoff",
           );
         }
-        if (Date.now() - start > HANDOFF_REDIAL_BUDGET_MS) {
+        remaining = deadline - performance.now();
+        if (remaining <= 0) {
           throw new Error("handoff redial budget exhausted");
         }
         // A drain 503 on the new hello means the NLB landed us back on the
         // draining task; back off (jittered) so it re-routes us elsewhere.
         const jitter = backoff * BACKOFF_JITTER * (2 * this.rng() - 1);
-        await setTimeoutPromise(Math.max(50, (backoff + jitter) * 1000), undefined, {
-          signal: this.shutdownAbort.signal,
-        }).catch(() => undefined);
+        const delayMs = Math.min(
+          Math.max(50, (backoff + jitter) * 1000),
+          remaining,
+        );
+        await this.sleep(delayMs, this.shutdownAbort.signal).catch(() => undefined);
         backoff = Math.min(backoff * 2, 5.0);
       }
     }
@@ -727,6 +923,8 @@ export class TunnelRuntime {
       await setTimeoutPromise(250).catch(() => undefined);
     }
     await this.closeConnection(oldConn);
+    this.publishConnectionClosed(oldConn);
+    oldConn.session = null;
     oldConn.streams.clear();
     oldConn.bridgeStreamIds.clear();
     this.draining.delete(oldConn);
@@ -743,89 +941,111 @@ export class TunnelRuntime {
       // (Spike 1) — the setting line doesn't translate.
     });
     conn.session = session;
-    session.on("close", () => {
+    const socket = (() => {
+      try {
+        return (session as unknown as {
+          socket?: import("node:net").Socket;
+        }).socket ?? null;
+      } catch {
+        return null;
+      }
+    })();
+    const onSessionClose = (): void => {
       // eslint-disable-next-line no-console
       console.info("tunnel runtime: h2 session closed");
-      // Drain all open streams with a synthetic reset event so any
-      // awaiters wake up.
-      for (const [, bus] of conn.streams) {
-        if (!bus.ended) {
-          bus.events.push({ kind: "reset", code: 0 });
-          bus.ended = true;
-          this.wake(bus);
-        }
-      }
-    });
-    session.on("error", (err: Error) => {
+      this.publishConnectionClosed(conn);
+    };
+    const onSessionError = (err: Error): void => {
       // Visibility into session-fatal errors. Stream-level errors
       // surface separately via stream events; this is genuinely
       // session-terminal.
       // eslint-disable-next-line no-console
       console.warn("tunnel runtime: h2 session error", err);
-    });
-    session.on(
-      "goaway",
-      (errorCode: number, lastStreamId: number, opaqueData?: Buffer) => {
+    };
+    const onGoaway = (
+      errorCode: number,
+      lastStreamId: number,
+      opaqueData?: Buffer,
+    ): void => {
+      // eslint-disable-next-line no-console
+      console.info(
+        `tunnel runtime: GOAWAY received error_code=${errorCode} last_stream_id=${lastStreamId}`,
+      );
+      // NO_ERROR GOAWAY = drain (make-before-break handoff). A non-zero code
+      // is a takeover (stop) or a real fault (reconnect cold), classified
+      // below; setting the takeover flag here wins over the 'error'/'close'
+      // reconnect path that the same GOAWAY also drives.
+      if (errorCode === 0) {
+        this.beginHandoff(conn);
+      } else {
+        this.maybeMarkSupersededGoaway(conn, errorCode, opaqueData);
+      }
+    };
+    const onSocketClose = (hadError: boolean): void => {
+      onSocketDeath(`closed hadError=${hadError}`);
+    };
+    const onSocketError = (err: Error): void => {
+      onSocketDeath("error", err);
+    };
+    const onSocketDeath = (label: string, err?: Error): void => {
+      // eslint-disable-next-line no-console
+      console.info(
+        `tunnel runtime: underlying socket ${label}` +
+          (err !== undefined ? ` err=${err.message}` : ""),
+      );
+      if (!session.closed && !session.destroyed) {
         // eslint-disable-next-line no-console
-        console.info(
-          `tunnel runtime: GOAWAY received error_code=${errorCode} last_stream_id=${lastStreamId}`,
-        );
-        // NO_ERROR GOAWAY = drain (make-before-break handoff). A non-zero code
-        // is a takeover (stop) or a real fault (reconnect cold), classified
-        // below; setting the takeover flag here wins over the 'error'/'close'
-        // reconnect path that the same GOAWAY also drives.
-        if (errorCode === 0) {
-          this.beginHandoff(conn);
-        } else {
-          this.maybeMarkSupersededGoaway(conn, errorCode, opaqueData);
-        }
-      },
-    );
-    // Watch the underlying TCP/TLS socket directly. Node's h2 client
-    // sometimes loses the connection without emitting ``error`` or
-    // ``close`` on the session itself — the underlying socket reliably
-    // emits them. Force-destroy the session on either so
-    // ``waitForSessionClose`` resolves promptly and ``serveForever``
-    // reconnects without waiting for the ``PING_ACK_TIMEOUT_MS`` window.
-    try {
-      const sock = (session as unknown as { socket?: import("node:net").Socket }).socket;
-      const onSocketDeath = (label: string, err?: Error): void => {
-        // eslint-disable-next-line no-console
-        console.info(
-          `tunnel runtime: underlying socket ${label}` +
-            (err !== undefined ? ` err=${err.message}` : ""),
-        );
-        if (!session.closed && !session.destroyed) {
-          // Forensic — log the stack so we can see which path
-          // triggered this destroy in production.
-          // eslint-disable-next-line no-console
-          console.warn(
-            "tunnel runtime: forcing session.destroy() from socket-death",
-            new Error("trace").stack,
-          );
-          try { session.destroy(); } catch { /* swallow */ }
-        }
-      };
-      sock?.once?.("close", (hadError: boolean) => {
-        onSocketDeath(`closed hadError=${hadError}`);
-      });
-      sock?.once?.("error", (err: Error) => {
-        onSocketDeath("error", err);
-      });
-    } catch {
-      /* swallow */
-    }
+        console.warn("tunnel runtime: forcing session.destroy() from socket-death");
+        this.destroyConnection(conn);
+      }
+    };
+    session.on("close", onSessionClose);
+    session.on("error", onSessionError);
+    session.on("goaway", onGoaway);
+    socket?.once("close", onSocketClose);
+    socket?.once("error", onSocketError);
+    conn.detachTransportListeners = () => {
+      session.off("close", onSessionClose);
+      session.off("error", onSessionError);
+      session.off("goaway", onGoaway);
+      try {
+        socket?.off("close", onSocketClose);
+        socket?.off("error", onSocketError);
+      } catch {
+        /* the HTTP/2 socket proxy becomes inaccessible after disconnect */
+      }
+    };
     await new Promise<void>((resolve, reject) => {
-      const onConnect = () => {
+      let settled = false;
+      const cleanup = () => {
+        session.off("connect", onConnect);
         session.off("error", onError);
+        session.off("close", onClose);
+        conn.cancelConnectWait = null;
+      };
+      const succeed = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
         resolve();
       };
-      const onError = (err: Error) => {
-        session.off("connect", onConnect);
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
         reject(err);
       };
+      const onConnect = () => succeed();
+      const onError = (err: Error) => fail(err);
+      const onClose = () => fail(
+        new Error("h2 session closed before connect completed"),
+      );
+      conn.cancelConnectWait = () => fail(
+        new Error("h2 session closed before connect completed"),
+      );
       session.once("connect", onConnect);
       session.once("error", onError);
+      session.once("close", onClose);
     });
     // OS-level keepalive on the underlying TCP socket so a silently-
     // dropped connection (NAT timeout, NLB idle eviction, peer power-
@@ -834,23 +1054,10 @@ export class TunnelRuntime {
     // tracking (see startPingLoop) is the load-bearing detector;
     // this is defense-in-depth.
     try {
-      const sock = (session as unknown as { socket?: import("node:net").Socket }).socket;
-      sock?.setKeepAlive?.(true, 30_000);
+      socket?.setKeepAlive?.(true, 30_000);
     } catch {
       /* swallow */
     }
-  }
-
-  private waitForSessionClose(conn: Connection): Promise<void> {
-    const session = conn.session;
-    if (session === null) return Promise.resolve();
-    return new Promise<void>((resolve) => {
-      if (session.closed) {
-        resolve();
-        return;
-      }
-      session.once("close", () => resolve());
-    });
   }
 
   // --- handshake ---------------------------------------------------------
@@ -874,7 +1081,13 @@ export class TunnelRuntime {
       helloHeaders[ControlHeaders.POOL_SIZE] = String(this.poolSize);
     }
     const stream = this.openStream(conn, helloHeaders, { endStream: true });
-    const { status, body } = await this.awaitResponse(conn, stream.streamId);
+    let status: number;
+    let body: Buffer;
+    try {
+      ({ status, body } = await this.awaitResponse(conn, stream.streamId));
+    } finally {
+      conn.streams.delete(stream.streamId);
+    }
     if (status === 401 || status === 403) {
       throw new TunnelAuthError(
         `${ControlPaths.HELLO} returned ${status}; the API key was rejected (check the key matches the tunnel's identity scope, or use an admin-scoped key in the tunnel's org)`,
@@ -1047,7 +1260,8 @@ export class TunnelRuntime {
       !this.stop &&
       !conn.draining &&
       conn.session !== null &&
-      !conn.session.closed
+      !conn.session.closed &&
+      !conn.session.destroyed
     ) {
       let envelope: Envelope | null;
       try {
@@ -1057,7 +1271,7 @@ export class TunnelRuntime {
           // Another client took over: force this conn down so the supervisor
           // observes the terminal flag and stops (no reconnect).
           this.markSuperseded();
-          try { conn.session?.destroy(); } catch { /* swallow */ }
+          this.destroyConnection(conn);
           return;
         }
         if (err instanceof OwnerTokenInvalidError) {
@@ -1066,7 +1280,7 @@ export class TunnelRuntime {
             `intake slot ${slot}: owner_token rejected; ` +
               `forcing session.destroy() and reconnecting`,
           );
-          conn.session?.destroy();
+          this.destroyConnection(conn);
           return;
         }
         if (isSessionTerminalError(err) || conn.session?.destroyed) {
@@ -1084,7 +1298,7 @@ export class TunnelRuntime {
               `exiting slot`,
             err,
           );
-          try { conn.session?.destroy(); } catch { /* swallow */ }
+          this.destroyConnection(conn);
           return;
         }
         // eslint-disable-next-line no-console
@@ -1179,10 +1393,9 @@ export class TunnelRuntime {
   // --- ping loop ---------------------------------------------------------
 
   private startPingLoop(conn: Connection): void {
-    conn.pingAbort = new AbortController();
     conn.pingHandle = setInterval(() => {
       const session = conn.session;
-      if (session === null || session.closed) return;
+      if (session === null || session.closed || session.destroyed) return;
       let ackTimer: NodeJS.Timeout | null = null;
       let acked = false;
       try {
@@ -1190,6 +1403,7 @@ export class TunnelRuntime {
           acked = true;
           if (ackTimer !== null) {
             clearTimeout(ackTimer);
+            conn.pingAckHandles.delete(ackTimer);
             ackTimer = null;
           }
           if (err !== null && err !== undefined) {
@@ -1198,7 +1412,7 @@ export class TunnelRuntime {
               "tunnel runtime: PING errored; forcing session.destroy()",
               err,
             );
-            try { session.destroy(); } catch { /* swallow */ }
+            this.destroyConnection(conn);
           }
         });
       } catch (err) {
@@ -1207,9 +1421,10 @@ export class TunnelRuntime {
           "tunnel runtime: session.ping() threw synchronously; forcing destroy",
           err,
         );
-        try { session.destroy(); } catch { /* swallow */ }
+        this.destroyConnection(conn);
         return;
       }
+      if (acked) return;
       // Application-level liveness check: if the ack doesn't come
       // back within PING_ACK_TIMEOUT_MS, the underlying TCP is gone
       // (kernel send buffer absorbing writes silently is the typical
@@ -1217,16 +1432,18 @@ export class TunnelRuntime {
       // without our help). Force-destroy the session; serveForever
       // observes the close and reconnects.
       ackTimer = setTimeout(() => {
+        if (ackTimer !== null) conn.pingAckHandles.delete(ackTimer);
         if (acked) return;
         // eslint-disable-next-line no-console
         console.warn(
           `tunnel runtime: PING ack not received within ` +
-            `${PING_ACK_TIMEOUT_MS}ms; assuming dead connection, ` +
+            `${this.pingAckTimeoutMs}ms; assuming dead connection, ` +
             `forcing reconnect`,
         );
-        try { session.destroy(); } catch { /* swallow */ }
-      }, PING_ACK_TIMEOUT_MS);
-    }, PING_INTERVAL_MS);
+        this.destroyConnection(conn);
+      }, this.pingAckTimeoutMs);
+      conn.pingAckHandles.add(ackTimer);
+    }, this.pingIntervalMs);
     // Do NOT unref(): explicit cancellation in stopPingLoop().
   }
 
@@ -1235,8 +1452,8 @@ export class TunnelRuntime {
       clearInterval(conn.pingHandle);
       conn.pingHandle = null;
     }
-    conn.pingAbort?.abort();
-    conn.pingAbort = null;
+    for (const handle of conn.pingAckHandles) clearTimeout(handle);
+    conn.pingAckHandles.clear();
   }
 
   // --- envelope dispatch -------------------------------------------------
@@ -2221,7 +2438,11 @@ export class TunnelRuntime {
   /** The active conn if it can take new streams, else the origin if it can. */
   private pickReplyConnection(origin: Connection): Connection | null {
     const usable = (c: Connection | null): c is Connection =>
-      c !== null && !c.draining && c.session !== null && !c.session.closed;
+      c !== null &&
+      !c.draining &&
+      c.session !== null &&
+      !c.session.closed &&
+      !c.session.destroyed;
     if (usable(this.active)) return this.active;
     if (usable(origin)) return origin;
     return null;
@@ -2295,12 +2516,9 @@ export class TunnelRuntime {
 
   // --- utilities ---------------------------------------------------------
 
-  private notifyStatus(status:
-    | "connecting"
-    | "connected"
-    | "reconnecting"
-    | "closed"
-    | "superseded"): void {
+  private notifyStatus(status: Exclude<TunnelRuntimeStatus, "idle">): void {
+    if (this.runtimeStatus === status) return;
+    this.runtimeStatus = status;
     if (this.onStatus !== undefined) {
       try {
         this.onStatus(status);

--- a/sdk/typescript/src/tunnels/client/_ws.ts
+++ b/sdk/typescript/src/tunnels/client/_ws.ts
@@ -52,6 +52,16 @@ export class WsClosed extends Error {
   }
 }
 
+/** Abnormal close surfaced when the tunnel connection is lost. */
+export class WsConnectionLost extends WsClosed {
+  readonly code = 1011;
+  readonly reconnectAdvised = true;
+  constructor(message = "tunnel connection lost; reconnect advised") {
+    super(message);
+    this.name = "WsConnectionLost";
+  }
+}
+
 /** Application close code surfaced when the server is draining for a redeploy. */
 export const SERVER_DRAINING_WS_CLOSE_CODE = 4500;
 

--- a/sdk/typescript/src/tunnels/client/_ws_url_edge_bridge.ts
+++ b/sdk/typescript/src/tunnels/client/_ws_url_edge_bridge.ts
@@ -19,6 +19,7 @@
 
 import {
   SERVER_DRAINING_WS_CLOSE_CODE,
+  WsConnectionLost,
   WsServerDraining,
   type WsBridgeIO,
 } from "./_ws.js";
@@ -275,14 +276,16 @@ export async function pumpWsUrlEdgeBridge(
       if (bridgeClosed) break;
     }
   } catch (err) {
-    // On a server-drain close, give the SDK-owned upstream leg a clean,
-    // typed WS CLOSE (server_draining) instead of the abrupt RST the
-    // caller's socket.destroy() would otherwise send. `end(frame)` flushes
-    // the frame before the FIN so the upstream sees the code.
-    if (err instanceof WsServerDraining) {
+    // Give the upstream leg a typed CLOSE for planned drain or cold loss.
+    if (err instanceof WsServerDraining || err instanceof WsConnectionLost) {
       try {
         const codeBuf = Buffer.alloc(2);
-        codeBuf.writeUInt16BE(SERVER_DRAINING_WS_CLOSE_CODE, 0);
+        codeBuf.writeUInt16BE(
+          err instanceof WsServerDraining
+            ? SERVER_DRAINING_WS_CLOSE_CODE
+            : err.code,
+          0,
+        );
         socket.end(encodeWsFrame(WS_OPCODE_CLOSE, codeBuf, { mask: true }));
       } catch {
         /* swallow */

--- a/sdk/typescript/src/tunnels/client/index.ts
+++ b/sdk/typescript/src/tunnels/client/index.ts
@@ -66,6 +66,7 @@ export {
   SERVER_DRAINING_WS_CLOSE_CODE,
   WsAcceptDeadlineExceeded,
   WsClosed,
+  WsConnectionLost,
   WsProtocolMismatch,
   WsServerDraining,
 } from "./_ws.js";

--- a/sdk/typescript/src/tunnels/client/index.ts
+++ b/sdk/typescript/src/tunnels/client/index.ts
@@ -46,7 +46,11 @@ import {
 import type { InkboxHandler } from "./_handler.js";
 import type { InkboxWsHandler } from "./_ws.js";
 
-export type { TunnelListener, TunnelStatusCallback } from "./_listener.js";
+export type {
+  TunnelListener,
+  TunnelRuntimeStatus,
+  TunnelStatusCallback,
+} from "./_listener.js";
 export {
   ForwardTargetRefused,
   validateEnvelopePath,

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.5.14";
+export const VERSION = "0.5.15";

--- a/sdk/typescript/tests/tunnels/fake_h2_server.ts
+++ b/sdk/typescript/tests/tunnels/fake_h2_server.ts
@@ -119,6 +119,7 @@ export interface FakeH2Server {
     body: Buffer;
     sessionIdx: number;
   }>;
+  responsePostCount(requestId: string): number;
   awaitNextIntakePost(timeoutMs?: number): Promise<{ slot: number; ownerToken: string }>;
   /**
    * Resolve when an extended-CONNECT stream arrives at the given path
@@ -196,6 +197,7 @@ export async function startFakeH2Server(
   let receivedHello: http2.IncomingHttpHeaders | null = null;
   const intakePosts: Array<{ slot: number; ownerToken: string }> = [];
   const pendingResponses = new Map<string, PendingResponsePost>();
+  const responsePostCounts = new Map<string, number>();
   const intakeWaiters: PendingIntakePost[] = [];
   let nextUnclaimedIntakeIdx = 0;
   const sessions = new Set<http2.ServerHttp2Session>();
@@ -339,6 +341,10 @@ export async function startFakeH2Server(
       });
       stream.on("end", () => {
         const body = Buffer.concat(chunks);
+        responsePostCounts.set(
+          requestId,
+          (responsePostCounts.get(requestId) ?? 0) + 1,
+        );
         const pending = pendingResponses.get(requestId);
         if (pending !== undefined) {
           clearTimeout(pending.timer);
@@ -530,6 +536,9 @@ export async function startFakeH2Server(
         }, timeoutMs);
         pendingResponses.set(requestId, { resolve, reject, timer });
       });
+    },
+    responsePostCount(requestId) {
+      return responsePostCounts.get(requestId) ?? 0;
     },
     awaitNextIntakePost(timeoutMs = 5000) {
       return new Promise<{ slot: number; ownerToken: string }>(

--- a/sdk/typescript/tests/tunnels/fake_h2_server.ts
+++ b/sdk/typescript/tests/tunnels/fake_h2_server.ts
@@ -37,6 +37,13 @@ interface PendingIntakePost {
   timer: NodeJS.Timeout;
 }
 
+interface DeferredHello {
+  stream: http2.ServerHttp2Stream;
+  status: number;
+  body: Record<string, unknown>;
+  onClose: () => void;
+}
+
 export interface FakeH2ServerOpts {
   /** Override the helloResponse JSON (default: status=200 owner_token=ok). */
   helloBody?: Record<string, unknown>;
@@ -57,6 +64,13 @@ export interface FakeH2Server {
   setHelloResponseFn(
     fn: () => { status: number; body: Record<string, unknown> },
   ): void;
+  /** Leave the next HELLO stream open until releaseDeferredHellos(). */
+  deferNextHello(): void;
+  /** Destroy the next HELLO's session before sending a response. */
+  closeNextHello(): void;
+  /** Defer every HELLO while enabled. */
+  setDeferHellos(enabled: boolean): void;
+  releaseDeferredHellos(): void;
   /**
    * Queue an intake response (one-shot). The next `/_system/intake`
    * POST consumes one queued response. Pass `null` to leave a stream
@@ -76,6 +90,23 @@ export interface FakeH2Server {
   sessionCount(): number;
   /** Total `/_system/hello` POSTs seen since start. */
   helloCount(): number;
+  /** Total HELLO responses completed by the fixture. */
+  helloResponseCount(): number;
+  /** HELLO streams currently deferred without a response. */
+  pendingHelloCount(): number;
+  /** HELLO streams closed before a response completed. */
+  incompleteHelloCloseCount(): number;
+  /** Total accepted client sessions since start. */
+  acceptedSessionCount(): number;
+  /** Total client sessions that have closed since start. */
+  sessionCloseCount(): number;
+  /** Total GOAWAY frames received from clients. */
+  goawayCount(): number;
+  /** Total PING frames received from clients. */
+  pingCount(): number;
+  awaitNextPing(timeoutMs?: number): Promise<void>;
+  /** Destroy all currently live client sessions. */
+  closeActiveSessions(): void;
   injectGoaway(errorCode?: number, opaqueData?: Buffer): void;
   injectRstStream(streamId: number, errorCode: number): void;
   receivedHelloHeaders(): http2.IncomingHttpHeaders | null;
@@ -173,6 +204,21 @@ export async function startFakeH2Server(
   const sessionIndex = new Map<http2.ServerHttp2Session, number>();
   let nextSessionIndex = 0;
   let helloCounter = 0;
+  let helloResponseCounter = 0;
+  let incompleteHelloCloseCounter = 0;
+  let acceptedSessionCounter = 0;
+  let sessionCloseCounter = 0;
+  let goawayCounter = 0;
+  let pingCounter = 0;
+  let claimedPingCounter = 0;
+  let deferHellos = false;
+  const helloActions: Array<"defer" | "close"> = [];
+  const deferredHellos: DeferredHello[] = [];
+  const pingWaiters: Array<{
+    resolve: () => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
   // Bridge-stream waiters. The map is keyed by exact path string.
   const bridgeWaiters = new Map<
     string,
@@ -184,12 +230,24 @@ export async function startFakeH2Server(
   >();
 
   server.on("session", (session) => {
+    acceptedSessionCounter += 1;
     sessions.add(session);
     sessionIndex.set(session, nextSessionIndex++);
     session.on("goaway", () => {
+      goawayCounter += 1;
       for (const cb of sessionEventListeners) cb("goaway");
     });
+    session.on("ping", () => {
+      pingCounter += 1;
+      const waiter = pingWaiters.shift();
+      if (waiter !== undefined) {
+        clearTimeout(waiter.timer);
+        claimedPingCounter = pingCounter;
+        waiter.resolve();
+      }
+    });
     session.on("close", () => {
+      sessionCloseCounter += 1;
       for (const cb of sessionEventListeners) cb("close");
       sessions.delete(session);
     });
@@ -208,12 +266,36 @@ export async function startFakeH2Server(
       const computed = helloFn !== null
         ? helloFn()
         : { status: helloStatus, body: helloBody };
+      const action = helloActions.shift();
+      if (action === "defer" || deferHellos) {
+        const pending: DeferredHello = {
+          stream,
+          status: computed.status,
+          body: computed.body,
+          onClose: () => {
+            const idx = deferredHellos.indexOf(pending);
+            if (idx >= 0) {
+              deferredHellos.splice(idx, 1);
+              incompleteHelloCloseCounter += 1;
+            }
+          },
+        };
+        deferredHellos.push(pending);
+        stream.once("close", pending.onClose);
+        return;
+      }
+      if (action === "close") {
+        incompleteHelloCloseCounter += 1;
+        stream.session?.destroy();
+        return;
+      }
       stream.respond({
         ":status": computed.status,
         "content-type": "application/json",
       });
       // Write the body on every status so non-200 responses (e.g. a
       // terminal hello with a reason) carry their JSON payload.
+      helloResponseCounter += 1;
       stream.end(JSON.stringify(computed.body));
       return;
     }
@@ -315,6 +397,30 @@ export async function startFakeH2Server(
     setHelloResponseFn(fn) {
       helloFn = fn;
     },
+    deferNextHello() {
+      helloActions.push("defer");
+    },
+    closeNextHello() {
+      helloActions.push("close");
+    },
+    setDeferHellos(enabled) {
+      deferHellos = enabled;
+    },
+    releaseDeferredHellos() {
+      for (const pending of deferredHellos.splice(0)) {
+        pending.stream.off("close", pending.onClose);
+        try {
+          pending.stream.respond({
+            ":status": pending.status,
+            "content-type": "application/json",
+          });
+          helloResponseCounter += 1;
+          pending.stream.end(JSON.stringify(pending.body));
+        } catch {
+          /* stream may already be closed */
+        }
+      }
+    },
     setIntakeResponse(response) {
       // One-shot: the next intake POST consumes this response. Tests
       // that need "respond the same way to every intake" should call
@@ -341,6 +447,51 @@ export async function startFakeH2Server(
     },
     helloCount() {
       return helloCounter;
+    },
+    helloResponseCount() {
+      return helloResponseCounter;
+    },
+    pendingHelloCount() {
+      return deferredHellos.length;
+    },
+    incompleteHelloCloseCount() {
+      return incompleteHelloCloseCounter;
+    },
+    acceptedSessionCount() {
+      return acceptedSessionCounter;
+    },
+    sessionCloseCount() {
+      return sessionCloseCounter;
+    },
+    goawayCount() {
+      return goawayCounter;
+    },
+    pingCount() {
+      return pingCounter;
+    },
+    awaitNextPing(timeoutMs = 5000) {
+      return new Promise<void>((resolve, reject) => {
+        if (claimedPingCounter < pingCounter) {
+          claimedPingCounter += 1;
+          resolve();
+          return;
+        }
+        const waiter = {
+          resolve,
+          reject,
+          timer: setTimeout(() => {
+            const idx = pingWaiters.indexOf(waiter);
+            if (idx >= 0) pingWaiters.splice(idx, 1);
+            reject(new Error("awaitNextPing timed out"));
+          }, timeoutMs),
+        };
+        pingWaiters.push(waiter);
+      });
+    },
+    closeActiveSessions() {
+      for (const session of sessions) {
+        try { session.destroy(); } catch { /* swallow */ }
+      }
     },
     injectGoaway(
       errorCode = http2.constants.NGHTTP2_NO_ERROR,
@@ -423,6 +574,12 @@ export async function startFakeH2Server(
       });
     },
     async close() {
+      deferHellos = false;
+      fake.releaseDeferredHellos();
+      for (const waiter of pingWaiters.splice(0)) {
+        clearTimeout(waiter.timer);
+        waiter.reject(new Error("fake server closed"));
+      }
       // Destroy (not graceful close) so a session with a parked, never-
       // ending intake stream can't wedge server.close() on teardown.
       for (const session of sessions) {

--- a/sdk/typescript/tests/tunnels/listener.test.ts
+++ b/sdk/typescript/tests/tunnels/listener.test.ts
@@ -149,6 +149,35 @@ describe("TunnelListener — terminal runtime results", () => {
     setTimeout(() => listener.aclose(), 10);
     await listener.wait();
   });
+
+  it("handles a serve rejection before awaiting runtime cleanup", async () => {
+    const error = new TunnelAuthError("rejected during cleanup");
+    class RejectDuringCloseRuntime extends FakeRuntime {
+      override async aclose(): Promise<void> {
+        this.failWith(error);
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    }
+    const runtime = new RejectDuringCloseRuntime();
+    const { listener } = makeListener({
+      installSignalHandlers: false,
+      fakeRuntime: runtime,
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      void listener.serveForever();
+      await listener.aclose();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+      await expect(listener.wait()).rejects.toBe(error);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
 });
 
 describe("TunnelListener — local liveness", () => {

--- a/sdk/typescript/tests/tunnels/listener.test.ts
+++ b/sdk/typescript/tests/tunnels/listener.test.ts
@@ -13,6 +13,8 @@ import {
 import {
   TunnelAuthError,
   TunnelRuntime,
+  TunnelSupersededError,
+  type TunnelRuntimeStatus,
 } from "../../src/tunnels/client/_runtime.js";
 import type { Tunnel } from "../../src/tunnels/types.js";
 import { TLSMode, TunnelStatus } from "../../src/tunnels/types.js";
@@ -44,6 +46,9 @@ class FakeRuntime {
   private rejectServe: ((err: unknown) => void) | null = null;
   private servePromise: Promise<void>;
   closed = false;
+  status: TunnelRuntimeStatus = "idle";
+  isConnected = false;
+  private connectedAt: Date | null = null;
 
   constructor() {
     this.servePromise = new Promise<void>((resolve, reject) => {
@@ -58,7 +63,19 @@ class FakeRuntime {
 
   async aclose(): Promise<void> {
     this.closed = true;
+    this.status = "closed";
+    this.isConnected = false;
     this.resolveServe?.();
+  }
+
+  get lastConnectedAt(): Date | null {
+    return this.connectedAt === null ? null : new Date(this.connectedAt);
+  }
+
+  setConnected(at: Date): void {
+    this.status = "connected";
+    this.isConnected = true;
+    this.connectedAt = new Date(at);
   }
 
   failWith(err: unknown): void {
@@ -99,23 +116,63 @@ afterEach(() => {
   for (const l of preTestSigint) process.on("SIGINT", l);
 });
 
-describe("TunnelListener — wait() captures and re-raises runtime errors", () => {
-  it("re-raises captured runtime errors on wait()", async () => {
+describe("TunnelListener — terminal runtime results", () => {
+  it("rejects serveForever() and every wait() with the same runtime error", async () => {
     const runtime = new FakeRuntime();
     const { listener } = makeListener({
       installSignalHandlers: false,
       fakeRuntime: runtime,
     });
-    runtime.failWith(new TunnelAuthError("invalid secret"));
-    await expect(listener.wait()).rejects.toBeInstanceOf(TunnelAuthError);
-    // Subsequent wait() returns clean (the error is consumed once).
-    await listener.wait();
+    const error = new TunnelAuthError("invalid key");
+    const servePromise = listener.serveForever();
+    runtime.failWith(error);
+    await expect(servePromise).rejects.toBe(error);
+    await expect(listener.wait()).rejects.toBe(error);
+    await expect(listener.wait()).rejects.toBe(error);
+  });
+
+  it("preserves a takeover error across serveForever() and wait()", async () => {
+    const runtime = new FakeRuntime();
+    const { listener } = makeListener({
+      installSignalHandlers: false,
+      fakeRuntime: runtime,
+    });
+    const error = new TunnelSupersededError("taken over");
+    const servePromise = listener.serveForever();
+    runtime.failWith(error);
+    await expect(servePromise).rejects.toBe(error);
+    await expect(listener.wait()).rejects.toBe(error);
   });
 
   it("clean shutdown returns without error", async () => {
     const { listener } = makeListener({ installSignalHandlers: false });
     setTimeout(() => listener.aclose(), 10);
     await listener.wait();
+  });
+});
+
+describe("TunnelListener — local liveness", () => {
+  it("samples status and returns defensive Date values", async () => {
+    const runtime = new FakeRuntime();
+    const { listener } = makeListener({
+      installSignalHandlers: false,
+      fakeRuntime: runtime,
+    });
+    expect(listener.status).toBe("idle");
+    expect(listener.isConnected).toBe(false);
+    expect(listener.lastConnectedAt).toBeNull();
+
+    const connectedAt = new Date("2026-08-10T12:00:00.000Z");
+    runtime.setConnected(connectedAt);
+    const sampled = listener.lastConnectedAt!;
+    sampled.setTime(0);
+    expect(listener.status).toBe("connected");
+    expect(listener.isConnected).toBe(true);
+    expect(listener.lastConnectedAt?.getTime()).toBe(connectedAt.getTime());
+
+    await listener.aclose();
+    expect(listener.status).toBe("closed");
+    expect(listener.isConnected).toBe(false);
   });
 });
 

--- a/sdk/typescript/tests/tunnels/runtime_drain.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_drain.test.ts
@@ -93,6 +93,8 @@ describe("TunnelRuntime — make-before-break on NO_ERROR GOAWAY", () => {
     const first = await fakeServer.awaitNextIntakePost(3000);
     expect(first.ownerToken).toBe("tok-1");
     expect(fakeServer.helloCount()).toBe(1);
+    const firstConnectedAt = runtime.lastConnectedAt!;
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
     // Drain signal: NO_ERROR GOAWAY on the live session.
     fakeServer.injectGoaway(http2.constants.NGHTTP2_NO_ERROR);
@@ -111,6 +113,11 @@ describe("TunnelRuntime — make-before-break on NO_ERROR GOAWAY", () => {
     // Make-before-break is NOT a reconnect: the status never regressed to
     // "reconnecting" across the handoff.
     expect(statuses).not.toContain("reconnecting");
+    expect(runtime.status).toBe("connected");
+    expect(runtime.isConnected).toBe(true);
+    expect(runtime.lastConnectedAt!.getTime()).toBeGreaterThan(
+      firstConnectedAt.getTime(),
+    );
 
     await runtime.aclose();
     await servePromise;

--- a/sdk/typescript/tests/tunnels/runtime_reconnect.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_reconnect.test.ts
@@ -1,0 +1,504 @@
+import { EventEmitter } from "node:events";
+import * as http2 from "node:http2";
+import * as net from "node:net";
+import * as tls from "node:tls";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TunnelRuntime,
+  type TunnelRuntimeOpts,
+} from "../../src/tunnels/client/_runtime.js";
+import * as supportedConnectApi from "../../src/tunnels/client/index.js";
+import { startFakeH2Server, type FakeH2Server } from "./fake_h2_server.js";
+
+let fakeServer: FakeH2Server;
+
+beforeEach(async () => {
+  fakeServer = await startFakeH2Server();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  await fakeServer.close();
+});
+
+function realConnect(
+  authority: string,
+  options: http2.ClientSessionOptions | http2.SecureClientSessionOptions,
+): http2.ClientHttp2Session {
+  return http2.connect(authority, {
+    ...(options as object),
+    rejectUnauthorized: false,
+    ca: undefined,
+  } as tls.ConnectionOptions & http2.SecureClientSessionOptions);
+}
+
+function makeRuntime(overrides: Partial<TunnelRuntimeOpts> = {}): TunnelRuntime {
+  return new TunnelRuntime({
+    tunnelId: "11111111-1111-1111-1111-111111111111",
+    apiKey: "ApiKey_test",
+    zone: fakeServer.authority,
+    publicHost: "my-agent.example.com",
+    poolSize: null,
+    dispatch: { forwardTo: "http://127.0.0.1:1" },
+    http2Connect: realConnect,
+    connectTimeoutMs: 80,
+    helloTimeoutMs: 80,
+    sleep: async () => Promise.resolve(),
+    ...overrides,
+  });
+}
+
+function destroyActiveClientSession(runtime: TunnelRuntime): void {
+  const active = (runtime as unknown as {
+    active: { session: http2.ClientHttp2Session | null } | null;
+  }).active;
+  active?.session?.destroy();
+}
+
+class StalledSession extends EventEmitter {
+  closed = false;
+  destroyed = false;
+  destroyCount = 0;
+  socket = new EventEmitter();
+
+  destroy(): void {
+    this.destroyCount += 1;
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.closed = true;
+  }
+
+  close(): void {
+    this.destroy();
+  }
+
+  goaway(): void {}
+}
+
+class FailedSession extends StalledSession {
+  failSoon(): void {
+    queueMicrotask(() => {
+      if (this.destroyed) return;
+      this.closed = true;
+      this.destroyed = true;
+      this.emit("error", new Error("scripted dial failure"));
+      this.emit("close");
+    });
+  }
+}
+
+class DirectionalProxy {
+  private readonly server = net.createServer();
+  private readonly sockets = new Set<net.Socket>();
+  private forwardServerToClient = true;
+  authority = "";
+
+  constructor(private readonly upstreamPort: number) {}
+
+  async start(): Promise<void> {
+    this.server.on("connection", (client) => {
+      const upstream = net.connect(this.upstreamPort, "127.0.0.1");
+      this.sockets.add(client);
+      this.sockets.add(upstream);
+      client.on("data", (chunk) => {
+        if (!upstream.destroyed) upstream.write(chunk);
+      });
+      upstream.on("data", (chunk) => {
+        if (this.forwardServerToClient && !client.destroyed) client.write(chunk);
+      });
+      const closeBoth = (): void => {
+        client.destroy();
+        upstream.destroy();
+        this.sockets.delete(client);
+        this.sockets.delete(upstream);
+      };
+      client.on("error", closeBoth);
+      upstream.on("error", closeBoth);
+      client.on("close", closeBoth);
+      upstream.on("close", closeBoth);
+    });
+    await new Promise<void>((resolve, reject) => {
+      this.server.listen(0, "127.0.0.1", resolve);
+      this.server.once("error", reject);
+    });
+    const address = this.server.address() as net.AddressInfo;
+    this.authority = `127.0.0.1:${address.port}`;
+  }
+
+  setServerToClientForwarding(enabled: boolean): void {
+    this.forwardServerToClient = enabled;
+  }
+
+  async close(): Promise<void> {
+    for (const socket of this.sockets) socket.destroy();
+    this.sockets.clear();
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("condition timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("TunnelRuntime reconnect establishment", () => {
+  it("keeps runtime test controls out of the supported connect export", () => {
+    expect(supportedConnectApi).not.toHaveProperty("TunnelRuntime");
+    expect(supportedConnectApi).not.toHaveProperty("CONNECT_TIMEOUT_MS");
+    expect(supportedConnectApi).not.toHaveProperty("HELLO_TIMEOUT_MS");
+  });
+
+  it("wakes stream waiters before detaching transport listeners", () => {
+    const order: string[] = [];
+    const bus = {
+      events: [] as Array<{ kind: "reset"; code: number }>,
+      waiter: () => order.push("wake"),
+      ended: false,
+      rstCode: null,
+    };
+    const conn = {
+      streams: new Map([[1, bus]]),
+      closePublished: false,
+      resolveClosed: () => order.push("closed"),
+      detachTransportListeners: () => order.push("detach"),
+      cancelConnectWait: null,
+    };
+    const runtime = makeRuntime() as unknown as {
+      publishConnectionClosed: (value: typeof conn) => void;
+    };
+
+    runtime.publishConnectionClosed(conn);
+
+    expect(order).toEqual(["wake", "closed", "detach"]);
+    expect(bus.ended).toBe(true);
+    expect(bus.events).toEqual([{ kind: "reset", code: 0 }]);
+  });
+
+  it("times out a stalled dial, destroys it once, and recovers", async () => {
+    const stalled = new StalledSession();
+    const statuses: string[] = [];
+    const sleeps: number[] = [];
+    let calls = 0;
+    const runtime = makeRuntime({
+      connectTimeoutMs: 25,
+      onStatus: (status) => statuses.push(status),
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+        await Promise.resolve();
+      },
+      http2Connect: (authority, options) => {
+        calls += 1;
+        return calls === 1
+          ? stalled as unknown as http2.ClientHttp2Session
+          : realConnect(authority, options);
+      },
+    });
+
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+
+    expect(stalled.destroyCount).toBe(1);
+    expect(stalled.listenerCount("close")).toBe(0);
+    expect(stalled.listenerCount("error")).toBe(0);
+    expect(stalled.listenerCount("goaway")).toBe(0);
+    expect(stalled.socket.listenerCount("close")).toBe(0);
+    expect(stalled.socket.listenerCount("error")).toBe(0);
+    expect(statuses).toEqual(expect.arrayContaining(["connecting", "reconnecting", "connected"]));
+    expect(sleeps).toHaveLength(1);
+    expect(runtime.status).toBe("connected");
+    expect(runtime.isConnected).toBe(true);
+    expect(runtime.lastConnectedAt).toBeInstanceOf(Date);
+
+    const helloCount = fakeServer.helloCount();
+    stalled.on("error", () => undefined);
+    stalled.emit("goaway", 0x1201, 0, Buffer.from('{"reason":"superseded"}'));
+    stalled.socket.emit("close", false);
+    stalled.emit("error", new Error("late error"));
+    await Promise.resolve();
+    expect(stalled.destroyCount).toBe(1);
+    expect(fakeServer.helloCount()).toBe(helloCount);
+    expect(runtime.status).toBe("connected");
+
+    await runtime.aclose();
+    await servePromise;
+  });
+
+  it.each(["timeout", "early close"] as const)(
+    "recovers after HELLO %s without retaining the failed session",
+    async (failure) => {
+      if (failure === "timeout") fakeServer.deferNextHello();
+      else fakeServer.closeNextHello();
+      const runtime = makeRuntime({ helloTimeoutMs: 30 });
+      const servePromise = runtime.serveForever();
+
+      await fakeServer.awaitNextIntakePost(2_000);
+      expect(fakeServer.helloCount()).toBeGreaterThanOrEqual(2);
+      expect(fakeServer.acceptedSessionCount()).toBeGreaterThanOrEqual(2);
+      expect(fakeServer.sessionCount()).toBe(1);
+      expect(fakeServer.pendingHelloCount()).toBe(0);
+      expect(fakeServer.incompleteHelloCloseCount()).toBe(1);
+      expect(fakeServer.helloResponseCount()).toBe(1);
+      expect(fakeServer.sessionCloseCount()).toBe(1);
+      expect(runtime.status).toBe("connected");
+
+      await runtime.aclose();
+      await servePromise;
+    },
+  );
+
+  it("logs the failed phase and attempt without credentials", async () => {
+    fakeServer.deferNextHello();
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const sleeps: number[] = [];
+    const runtime = makeRuntime({
+      helloTimeoutMs: 25,
+      rng: () => 0.5,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+        await Promise.resolve();
+      },
+    });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+
+    const output = [...info.mock.calls, ...warn.mock.calls]
+      .flat()
+      .map(String)
+      .join("\n");
+    expect(output).toMatch(/connection attempt #1/);
+    expect(output).toMatch(/hello timeout on attempt #1/);
+    expect(output).toMatch(/attempt #2 in 1000ms/);
+    expect(output).not.toContain("ApiKey_test");
+    expect(sleeps[0]).toBe(1_000);
+
+    await runtime.aclose();
+    await servePromise;
+  });
+
+  it("keeps the last connection timestamp while cold and advances it on recovery", async () => {
+    const statuses: string[] = [];
+    const runtime = makeRuntime({ onStatus: (status) => statuses.push(status) });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+    const first = runtime.lastConnectedAt!;
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    destroyActiveClientSession(runtime);
+    await fakeServer.awaitNextIntakePost(2_000);
+
+    expect(statuses).toContain("reconnecting");
+    expect(runtime.status).toBe("connected");
+    expect(runtime.lastConnectedAt!.getTime()).toBeGreaterThan(first.getTime());
+
+    await runtime.aclose();
+    await servePromise;
+  });
+
+  it("isolates status callback failures and still reconnects", async () => {
+    let connected = 0;
+    const runtime = makeRuntime({
+      onStatus: (status) => {
+        if (status === "connected") connected += 1;
+        if (status === "reconnecting") throw new Error("observer failed");
+      },
+    });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+    destroyActiveClientSession(runtime);
+    await fakeServer.awaitNextIntakePost(2_000);
+    expect(connected).toBe(2);
+
+    await runtime.aclose();
+    await servePromise;
+  });
+});
+
+describe("TunnelRuntime integrated recovery", () => {
+  it("recovers from a missed PING through three failed redials", async () => {
+    const proxy = new DirectionalProxy(fakeServer.port);
+    await proxy.start();
+    const statuses: string[] = [];
+    const sleeps: number[] = [];
+    const realSessions: http2.ClientHttp2Session[] = [];
+    let connectCalls = 0;
+    const runtime = makeRuntime({
+      zone: proxy.authority,
+      pingIntervalMs: 50,
+      pingAckTimeoutMs: 25,
+      rng: () => 0.5,
+      onStatus: (status) => statuses.push(status),
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+        await Promise.resolve();
+      },
+      http2Connect: (authority, options) => {
+        connectCalls += 1;
+        if (connectCalls >= 2 && connectCalls <= 4) {
+          const failed = new FailedSession();
+          failed.failSoon();
+          return failed as unknown as http2.ClientHttp2Session;
+        }
+        if (connectCalls === 5) proxy.setServerToClientForwarding(true);
+        const session = realConnect(authority, options);
+        realSessions.push(session);
+        return session;
+      },
+    });
+    const servePromise = runtime.serveForever();
+    try {
+      await fakeServer.awaitNextIntakePost(2_000);
+      proxy.setServerToClientForwarding(false);
+      await fakeServer.awaitNextPing(2_000);
+      await fakeServer.awaitNextIntakePost(2_000);
+      await fakeServer.awaitNextPing(2_000);
+
+      expect(connectCalls).toBe(5);
+      expect(sleeps.slice(0, 4)).toEqual([1_000, 2_000, 4_000, 8_000]);
+      expect(statuses).toEqual([
+        "connecting",
+        "connected",
+        "reconnecting",
+        "connected",
+      ]);
+      expect(fakeServer.acceptedSessionCount()).toBe(2);
+      expect(fakeServer.helloResponseCount()).toBe(2);
+      expect(fakeServer.pendingHelloCount()).toBe(0);
+      expect(realSessions[0].destroyed).toBe(true);
+      expect(runtime.status).toBe("connected");
+      expect(runtime.isConnected).toBe(true);
+    } finally {
+      await runtime.aclose();
+      await servePromise;
+      await proxy.close();
+    }
+  }, 10_000);
+
+  it("falls back to cold recovery after a GOAWAY handoff exhausts its budget", async () => {
+    const statuses: string[] = [];
+    let releaseColdSleep: () => void = () => undefined;
+    const coldSleep = new Promise<void>((resolve) => {
+      releaseColdSleep = resolve;
+    });
+    const runtime = makeRuntime({
+      helloTimeoutMs: 25,
+      handoffRedialBudgetMs: 80,
+      rng: () => 0.5,
+      onStatus: (status) => statuses.push(status),
+      sleep: async (delayMs) => {
+        if (delayMs >= 500) await coldSleep;
+        else await Promise.resolve();
+      },
+    });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+    fakeServer.setDeferHellos(true);
+    fakeServer.injectGoaway(http2.constants.NGHTTP2_NO_ERROR);
+
+    await waitFor(() => runtime.status === "reconnecting");
+    expect(statuses).toEqual(["connecting", "connected", "reconnecting"]);
+    expect(fakeServer.incompleteHelloCloseCount()).toBeGreaterThan(0);
+    expect(fakeServer.sessionCloseCount()).toBeGreaterThan(0);
+
+    fakeServer.setDeferHellos(false);
+    releaseColdSleep();
+    await fakeServer.awaitNextIntakePost(2_000);
+    await waitFor(() => fakeServer.pendingHelloCount() === 0);
+
+    expect(statuses).toEqual([
+      "connecting",
+      "connected",
+      "reconnecting",
+      "connected",
+    ]);
+    expect(fakeServer.helloResponseCount()).toBe(2);
+    expect(fakeServer.pendingHelloCount()).toBe(0);
+    expect(fakeServer.sessionCount()).toBe(1);
+
+    await runtime.aclose();
+    await servePromise;
+  }, 10_000);
+});
+
+describe("TunnelRuntime bounded handoff", () => {
+  it("bounds a stalled replacement HELLO by the handoff budget", async () => {
+    const sessions: StalledSession[] = [];
+    const runtime = makeRuntime({
+      helloTimeoutMs: 20,
+      handoffRedialBudgetMs: 70,
+      sleep: async () => Promise.resolve(),
+    }) as unknown as {
+      openConnection: (conn: { session: http2.ClientHttp2Session | null }) => Promise<void>;
+      sendHello: () => Promise<void>;
+      makeReplacementConnection: () => Promise<unknown>;
+    };
+    runtime.openConnection = async (conn) => {
+      const session = new StalledSession();
+      sessions.push(session);
+      conn.session = session as unknown as http2.ClientHttp2Session;
+    };
+    runtime.sendHello = () => new Promise<void>(() => undefined);
+
+    const started = performance.now();
+    await expect(runtime.makeReplacementConnection()).rejects.toThrow(
+      "handoff redial budget exhausted",
+    );
+    expect(performance.now() - started).toBeLessThan(300);
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(sessions.every((session) => session.destroyCount === 1)).toBe(true);
+  });
+});
+
+describe("TunnelRuntime PING acknowledgement deadline", () => {
+  it("destroys at the acknowledgement deadline and clears acknowledged timers", async () => {
+    vi.useFakeTimers();
+    const callbacks: Array<(err?: Error | null) => void> = [];
+    const session = {
+      closed: false,
+      destroyed: false,
+      destroy: vi.fn(),
+      ping: (callback: (err?: Error | null) => void) => callbacks.push(callback),
+    };
+    const conn = {
+      session,
+      pingHandle: null,
+      pingAckHandles: new Set<NodeJS.Timeout>(),
+      streams: new Map(),
+      closePublished: false,
+      resolveClosed: () => undefined,
+      detachTransportListeners: null,
+      cancelConnectWait: null,
+    };
+    const runtime = makeRuntime({
+      pingIntervalMs: 50,
+      pingAckTimeoutMs: 20,
+    }) as unknown as {
+      startPingLoop: (value: typeof conn) => void;
+      stopPingLoop: (value: typeof conn) => void;
+    };
+
+    runtime.startPingLoop(conn);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(callbacks).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(19);
+    expect(session.destroy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(session.destroy).toHaveBeenCalledTimes(1);
+
+    session.destroy.mockClear();
+    await vi.advanceTimersByTimeAsync(30);
+    expect(callbacks).toHaveLength(2);
+    callbacks[1](null);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(session.destroy).not.toHaveBeenCalled();
+    runtime.stopPingLoop(conn);
+  });
+});

--- a/sdk/typescript/tests/tunnels/runtime_reconnect.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_reconnect.test.ts
@@ -5,6 +5,7 @@ import * as tls from "node:tls";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  TunnelAuthError,
   TunnelRuntime,
   type TunnelRuntimeOpts,
 } from "../../src/tunnels/client/_runtime.js";
@@ -231,6 +232,39 @@ describe("TunnelRuntime reconnect establishment", () => {
     await servePromise;
   });
 
+  it("closes during a stalled dial without emitting reconnecting", async () => {
+    const stalled = new StalledSession();
+    const statuses: string[] = [];
+    const runtime = makeRuntime({
+      connectTimeoutMs: 1_000,
+      onStatus: (status) => statuses.push(status),
+      http2Connect: () => stalled as unknown as http2.ClientHttp2Session,
+    });
+    const servePromise = runtime.serveForever();
+    await waitFor(() => stalled.listenerCount("connect") > 0);
+
+    await runtime.aclose();
+    await servePromise;
+
+    expect(statuses).toEqual(["connecting", "closed"]);
+  });
+
+  it("closes during a pending HELLO without emitting reconnecting", async () => {
+    fakeServer.deferNextHello();
+    const statuses: string[] = [];
+    const runtime = makeRuntime({
+      helloTimeoutMs: 1_000,
+      onStatus: (status) => statuses.push(status),
+    });
+    const servePromise = runtime.serveForever();
+    await waitFor(() => fakeServer.pendingHelloCount() === 1);
+
+    await runtime.aclose();
+    await servePromise;
+
+    expect(statuses).toEqual(["connecting", "closed"]);
+  });
+
   it.each(["timeout", "early close"] as const)(
     "recovers after HELLO %s without retaining the failed session",
     async (failure) => {
@@ -428,6 +462,112 @@ describe("TunnelRuntime integrated recovery", () => {
   }, 10_000);
 });
 
+describe("TunnelRuntime cold-generation fencing", () => {
+  it("drops a handler reply released after cold recovery", async () => {
+    let releaseHandler: () => void = () => undefined;
+    let markStarted: () => void = () => undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    fakeServer.setIntakeResponse({
+      status: 200,
+      headers: [
+        ["inkbox-request-id", "req-stale-cold"],
+        ["inkbox-method", "GET"],
+        ["inkbox-path", "/slow"],
+        ["inkbox-route-kind", "webhook"],
+      ],
+      body: Buffer.alloc(0),
+    });
+    const runtime = makeRuntime({
+      dispatch: {
+        httpHandler: async () => {
+          markStarted();
+          await handlerGate;
+          return new Response("stale");
+        },
+      },
+    });
+    const servePromise = runtime.serveForever();
+    await handlerStarted;
+
+    destroyActiveClientSession(runtime);
+    await waitFor(() => fakeServer.helloCount() >= 2 && runtime.isConnected);
+    releaseHandler();
+    await waitFor(
+      () => (runtime as unknown as { tasks: Set<unknown> }).tasks.size === 0,
+    );
+
+    expect(fakeServer.responsePostCount("req-stale-cold")).toBe(0);
+    await runtime.aclose();
+    await servePromise;
+  });
+
+  it("drops a reply waiting on a handoff that falls back cold", async () => {
+    let releaseHandler: () => void = () => undefined;
+    let markStarted: () => void = () => undefined;
+    let releaseColdSleep: () => void = () => undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const coldSleep = new Promise<void>((resolve) => {
+      releaseColdSleep = resolve;
+    });
+    fakeServer.setIntakeResponse({
+      status: 200,
+      headers: [
+        ["inkbox-request-id", "req-stale-handoff"],
+        ["inkbox-method", "GET"],
+        ["inkbox-path", "/slow"],
+        ["inkbox-route-kind", "webhook"],
+      ],
+      body: Buffer.alloc(0),
+    });
+    const runtime = makeRuntime({
+      helloTimeoutMs: 25,
+      handoffRedialBudgetMs: 80,
+      dispatch: {
+        httpHandler: async () => {
+          markStarted();
+          await handlerGate;
+          return new Response("stale");
+        },
+      },
+      sleep: async (delayMs) => {
+        if (delayMs >= 500) await coldSleep;
+        else await Promise.resolve();
+      },
+    });
+    const servePromise = runtime.serveForever();
+    await handlerStarted;
+    fakeServer.setDeferHellos(true);
+    fakeServer.injectGoaway(http2.constants.NGHTTP2_NO_ERROR);
+    await waitFor(
+      () => (runtime as unknown as { handoffInFlight: boolean }).handoffInFlight,
+    );
+    await waitFor(() => fakeServer.helloCount() >= 2);
+    releaseHandler();
+    await waitFor(() => runtime.status === "reconnecting");
+
+    fakeServer.setDeferHellos(false);
+    releaseColdSleep();
+    await waitFor(() => runtime.status === "connected");
+    await waitFor(
+      () => (runtime as unknown as { tasks: Set<unknown> }).tasks.size === 0,
+    );
+
+    expect(fakeServer.responsePostCount("req-stale-handoff")).toBe(0);
+    await runtime.aclose();
+    await servePromise;
+  }, 10_000);
+});
+
 describe("TunnelRuntime bounded handoff", () => {
   it("bounds a stalled replacement HELLO by the handoff budget", async () => {
     const sessions: StalledSession[] = [];
@@ -454,6 +594,22 @@ describe("TunnelRuntime bounded handoff", () => {
     expect(performance.now() - started).toBeLessThan(300);
     expect(sessions.length).toBeGreaterThan(0);
     expect(sessions.every((session) => session.destroyCount === 1)).toBe(true);
+  });
+
+  it("treats authentication rejection during handoff as terminal", async () => {
+    const statuses: string[] = [];
+    const runtime = makeRuntime({
+      onStatus: (status) => statuses.push(status),
+    });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitNextIntakePost(2_000);
+    fakeServer.setHelloResponse(401, {});
+    fakeServer.injectGoaway(http2.constants.NGHTTP2_NO_ERROR);
+
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelAuthError);
+    expect(statuses).toEqual(["connecting", "connected", "closed"]);
+    expect(fakeServer.helloCount()).toBe(2);
+    await runtime.aclose();
   });
 });
 

--- a/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
+++ b/sdk/typescript/tests/tunnels/runtime_superseded.test.ts
@@ -15,6 +15,9 @@ import {
   TunnelRuntime,
   TunnelSupersededError,
 } from "../../src/tunnels/client/_runtime.js";
+import { TunnelListenerImpl } from "../../src/tunnels/client/_listener.js";
+import type { Tunnel } from "../../src/tunnels/types.js";
+import { TLSMode, TunnelStatus } from "../../src/tunnels/types.js";
 import { startFakeH2Server, type FakeH2Server } from "./fake_h2_server.js";
 
 let fakeServer: FakeH2Server;
@@ -56,6 +59,28 @@ function helloOk(): void {
 
 const SUPERSEDED_DEBUG = Buffer.from('{"reason":"superseded"}');
 
+function tunnelResource(): Tunnel {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    organizationId: "org_test",
+    tunnelName: "my-agent",
+    tlsMode: TLSMode.EDGE,
+    certPem: null,
+    certFingerprintSha256: null,
+    certExpiresAt: null,
+    status: TunnelStatus.ACTIVE,
+    lastConnectedAt: null,
+    lastConnectedIpAddr: null,
+    lastDisconnectedAt: null,
+    currentlyConnected: false,
+    publicHost: "my-agent.example.com",
+    zone: fakeServer.authority,
+    metadata: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
 describe("TunnelRuntime — superseded (takeover) is terminal", () => {
   it("stops and does not reconnect on a superseded GOAWAY (code + reason)", async () => {
     helloOk();
@@ -72,6 +97,27 @@ describe("TunnelRuntime — superseded (takeover) is terminal", () => {
     expect(statuses).toContain("superseded");
     // No cold redial after a takeover.
     expect(fakeServer.helloCount()).toBe(1);
+  }, 15_000);
+
+  it("listener close preserves superseded after a real takeover", async () => {
+    helloOk();
+    const runtime = makeRuntime();
+    const listener = new TunnelListenerImpl({
+      publicHost: "my-agent.example.com",
+      tunnel: tunnelResource(),
+      runtime,
+      listenerOpts: { installSignalHandlers: false },
+    });
+    const servePromise = listener.serveForever();
+    await fakeServer.awaitNextIntakePost(3_000);
+    fakeServer.injectGoaway(SUPERSEDED_GOAWAY_ERROR_CODE, SUPERSEDED_DEBUG);
+
+    await expect(servePromise).rejects.toBeInstanceOf(TunnelSupersededError);
+    expect(listener.status).toBe("superseded");
+    expect(listener.isConnected).toBe(false);
+    await listener.aclose();
+    expect(listener.status).toBe("superseded");
+    expect(listener.isConnected).toBe(false);
   }, 15_000);
 
   it("is terminal on the dedicated code alone (debug blob lost)", async () => {

--- a/sdk/typescript/tests/tunnels/ws_dispatch.test.ts
+++ b/sdk/typescript/tests/tunnels/ws_dispatch.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as http2 from "node:http2";
 import { TunnelRuntime } from "../../src/tunnels/client/_runtime.js";
+import { WsConnectionLost } from "../../src/tunnels/client/_ws.js";
 import {
   WS_OPCODE_BINARY,
   WS_OPCODE_CLOSE,
@@ -199,6 +200,66 @@ describe("WS dispatch — peer-initiated CLOSE", () => {
       await new Promise((r) => setTimeout(r, 25));
     }
     expect(iteratorDone).toBe(true);
+
+    await runtime.aclose();
+    await servePromise;
+  }, 10_000);
+});
+
+describe("WS dispatch — cold connection loss", () => {
+  it("surfaces a typed 1011 outcome to a callable handler", async () => {
+    let resolveObserved: (err: unknown) => void = () => undefined;
+    let resolveAccepted: () => void = () => undefined;
+    const observed = new Promise<unknown>((resolve) => {
+      resolveObserved = resolve;
+    });
+    const accepted = new Promise<void>((resolve) => {
+      resolveAccepted = resolve;
+    });
+    const wsHandler = async (
+      ws: import("../../src/tunnels/client/_ws.js").InkboxWebSocket,
+    ): Promise<void> => {
+      await ws.accept();
+      resolveAccepted();
+      try {
+        await ws[Symbol.asyncIterator]().next();
+      } catch (err) {
+        resolveObserved(err);
+      }
+    };
+    fakeServer.setIntakeResponse({
+      status: 200,
+      headers: [
+        ["inkbox-request-id", "req-ws-cold"],
+        ["inkbox-method", "GET"],
+        ["inkbox-path", "/ws"],
+        ["inkbox-route-kind", "ws-upgrade"],
+        ["inkbox-ws-id", "ws-cold"],
+      ],
+      body: Buffer.alloc(0),
+    });
+    const runtime = makeRuntime({ wsHandler });
+    const servePromise = runtime.serveForever();
+    await fakeServer.awaitResponsePost("req-ws-cold", 5_000);
+    const bridgeStream = await fakeServer.awaitNextBridgeStream(
+      "/_system/ws/ws-cold",
+      5_000,
+    );
+    bridgeStream.respond({ ":status": 200 });
+    await accepted;
+    const active = (runtime as unknown as {
+      active: { session: http2.ClientHttp2Session | null } | null;
+    }).active;
+    active?.session?.destroy();
+
+    const err = await Promise.race([
+      observed,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("cold WS close timed out")), 2_000),
+      ),
+    ]);
+    expect(err).toBeInstanceOf(WsConnectionLost);
+    expect((err as WsConnectionLost).code).toBe(1011);
 
     await runtime.aclose();
     await servePromise;

--- a/sdk/typescript/tests/tunnels/ws_edge_url_drain.test.ts
+++ b/sdk/typescript/tests/tunnels/ws_edge_url_drain.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import * as net from "node:net";
 import { pumpWsUrlEdgeBridge } from "../../src/tunnels/client/_ws_url_edge_bridge.js";
 import {
+  WsConnectionLost,
   WsServerDraining,
   type WsBridgeIO,
 } from "../../src/tunnels/client/_ws.js";
@@ -61,5 +62,48 @@ describe("pumpWsUrlEdgeBridge — server drain", () => {
     }
     expect(closeCode).toBe(4500);
     server.close();
+  });
+
+  it("sends an abnormal 1011 CLOSE to the upstream leg on cold loss", async () => {
+    const received: Buffer[] = [];
+    const server = net.createServer((s) => {
+      s.on("data", (c: Buffer) => received.push(c));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const port = (server.address() as net.AddressInfo).port;
+    const sock = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve) => sock.once("connect", resolve));
+    const bridge: WsBridgeIO = {
+      async sendFrame() {},
+      recv() {
+        return (async function* () {
+          throw new WsConnectionLost();
+        })();
+      },
+      async closeStream() {},
+      async postUpgradeReply() {},
+      async rejectUpgrade() {},
+    };
+
+    await pumpWsUrlEdgeBridge({
+      upstream: {
+        socket: sock,
+        leftover: Buffer.alloc(0),
+        headers: [],
+        subprotocol: null,
+      },
+      bridge,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const decoded = decodeClientFrame(received, { requireMask: true });
+    expect(decoded.kind).toBe("frame");
+    if (decoded.kind === "frame") {
+      expect(decoded.opcode).toBe(WS_OPCODE_CLOSE);
+      expect(decoded.payload.readUInt16BE(0)).toBe(1011);
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 });

--- a/skills/README.md
+++ b/skills/README.md
@@ -59,7 +59,7 @@ Once the skills are installed, your coding agent will automatically know how to 
 | **inkbox-cli** | TypeScript / Node ≥ 22 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, iMessage, A2A history, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |
 | **inkbox-all** | Language-agnostic | Index of all Inkbox skills in this repository, including example skills and links for choosing the right one |
 | **inkbox-agent-self-signup** | Language-agnostic | Shared reference for the agent self-signup flow — SDK examples (Python & TS) and direct API (curl) |
-| **inkbox-tunnels** | Python and TypeScript | Connect local HTTP and WebSocket handlers to an identity's public tunnel |
+| **inkbox-tunnels** | Python, TypeScript, and Rust | Connect a local process to an identity's public tunnel and observe runtime liveness |
 
 ## Documentation
 

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -46,7 +46,7 @@ directly in argv.
 
 - `inkbox-tunnels`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-tunnels/SKILL.md
-  Tunnels reference for both SDKs — bring a local server online behind a public Inkbox URL via `inkbox.tunnels.connect(...)`. Tunnels are an identity property (provisioned atomically by `createIdentity`); covers edge vs passthrough TLS, the same-API-key data-plane auth, URL forwarding, and in-process Fetch/ASGI/WebSocket handlers.
+  Tunnels reference for Python, TypeScript, and Rust — bring a local process online behind a public Inkbox URL, observe local runtime liveness, and recover from transient failures. Tunnels are an identity property (provisioned atomically by identity creation); Python and TypeScript also cover in-process HTTP/WebSocket handlers and make-before-break drain.
 
 ## Example Skills
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -1147,6 +1147,8 @@ async with ...:
 `closed`, or `superseded`. `listener.is_connected` is local runtime liveness;
 `listener.last_connected_at` is an aware UTC timestamp retained while
 reconnecting. `listener.tunnel` remains the bootstrap resource snapshot.
+`listener.close()` raises `TimeoutError` if its runtime thread cannot stop within
+30 seconds.
 
 Tunnels are provisioned atomically by `inkbox.create_identity(...)`; there is no standalone `create` / `delete` / `restore` / `rotate_secret` surface. For passthrough, opt in at create time: `inkbox.create_identity("my-app", tunnel={"tls_mode": "passthrough"})` — `tls_mode` is fixed at create.
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -1116,6 +1116,7 @@ listener = inkbox.tunnels.connect(
     forward_to="http://127.0.0.1:8080",
 )
 print(listener.public_url)        # https://my-app.inkboxwire.com
+print(listener.status, listener.is_connected, listener.last_connected_at)
 listener.wait()                   # blocks until close()/Ctrl-C
 
 # Forward to an in-process ASGI app (FastAPI / Starlette / your own)
@@ -1141,6 +1142,11 @@ async with ...:
 ```
 
 `wait()`/`close()` and `serve_forever()`/`aclose()` are mutually exclusive — pick one pair.
+
+`listener.status` is `idle`, `connecting`, `connected`, `reconnecting`,
+`closed`, or `superseded`. `listener.is_connected` is local runtime liveness;
+`listener.last_connected_at` is an aware UTC timestamp retained while
+reconnecting. `listener.tunnel` remains the bootstrap resource snapshot.
 
 Tunnels are provisioned atomically by `inkbox.create_identity(...)`; there is no standalone `create` / `delete` / `restore` / `rotate_secret` surface. For passthrough, opt in at create time: `inkbox.create_identity("my-app", tunnel={"tls_mode": "passthrough"})` — `tls_mode` is fixed at create.
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -1122,6 +1122,7 @@ const listener = await connect(inkbox, {
   forwardTo: "http://127.0.0.1:8080",
 });
 console.log(listener.publicUrl);    // https://my-app.inkboxwire.com
+console.log(listener.status, listener.isConnected, listener.lastConnectedAt);
 await listener.wait();              // until SIGINT/SIGTERM
 
 // In-process Fetch-API HTTP handler
@@ -1153,6 +1154,13 @@ await connect(inkbox, {
 ```
 
 Tunnels are provisioned atomically by `inkbox.createIdentity(...)`; there is no standalone `create` / `delete` / `restore` / `rotateSecret` surface.
+
+`listener.status` is `idle`, `connecting`, `connected`, `reconnecting`,
+`closed`, or `superseded`. `listener.isConnected` is local runtime liveness;
+`listener.lastConnectedAt` remains set while reconnecting. `listener.tunnel`
+remains the bootstrap resource snapshot. `serveForever()` and `wait()` both
+reject on terminal failures, so attach a rejection handler to a fire-and-forget
+`serveForever()` call.
 
 Reads + edit:
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -1162,6 +1162,10 @@ remains the bootstrap resource snapshot. `serveForever()` and `wait()` both
 reject on terminal failures, so attach a rejection handler to a fire-and-forget
 `serveForever()` call.
 
+In-process WebSocket handlers receive `WsServerDraining` (`4500`) for planned
+drain and `WsConnectionLost` (`1011`) for cold connection loss. Both extend
+`WsClosed` and advise reconnection.
+
 Reads + edit:
 
 ```typescript

--- a/skills/inkbox-tunnels/SKILL.md
+++ b/skills/inkbox-tunnels/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inkbox-tunnels
-description: Use when bringing a local server online behind a public Inkbox URL via `inkbox.tunnels.connect(...)` — covers edge vs passthrough TLS, URL forwarding, and in-process Fetch/ASGI/WebSocket handlers in both Python and TypeScript SDKs.
+description: Use when bringing a local server online behind a public Inkbox URL — covers Python, TypeScript, and Rust tunnel runtimes, edge vs passthrough TLS, forwarding, handlers, and local liveness.
 user-invocable: false
 ---
 
@@ -67,7 +67,7 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
     listener = inkbox.tunnels.connect(
         name="my-app",
         forward_to="http://127.0.0.1:8080",
-        # on_status fires "connecting" -> "connected" -> "reconnecting" -> "closed"
+        # on_status may also report "superseded" after a newer client takes over.
         on_status=lambda s: print("tunnel:", s),
     )
     print(listener.public_url)   # https://my-app.inkboxwire.com
@@ -130,6 +130,14 @@ asyncio.run(main())
 
 `wait()`/`close()` and `serve_forever()`/`aclose()` are mutually exclusive — pick one pair.
 
+Sample local liveness at any time with `listener.status`,
+`listener.is_connected`, and `listener.last_connected_at`. Status is `idle`,
+`connecting`, `connected`, `reconnecting`, `closed`, or `superseded`. The
+timestamp is an aware UTC `datetime` and remains available while reconnecting.
+These are local observations; `listener.tunnel` is the bootstrap resource
+snapshot. Status callbacks are edge-triggered and do not repeat
+`reconnecting` for each failed attempt in the same outage.
+
 ### Control-plane reads + edit
 
 ```python
@@ -151,7 +159,7 @@ There is no `create`, `delete`, `restore`, `force_delete`, or `rotate_secret` he
 |---|---|---|
 | `pool_size` | server-decided | parked-intake pool, 1–32 |
 | `state_dir` | `~/.inkbox/tunnels/{name}` | where state + passthrough cert live |
-| `on_status` | `None` | callback for `"connecting"` / `"connected"` / `"reconnecting"` / `"closed"` |
+| `on_status` | `None` | callback for `"connecting"` / `"connected"` / `"reconnecting"` / `"closed"` / `"superseded"` |
 | `allow_remote_forwarding` | `False` | bypass loopback-only allowlist for `forward_to` (review SSRF first) |
 | `forward_to_verify_tls` | `True` | for `https://` upstream forwards |
 
@@ -183,6 +191,13 @@ const listener = await connect(inkbox, {
 console.log(listener.publicUrl);   // https://my-app.inkboxwire.com
 await listener.wait();              // until Ctrl-C / SIGTERM
 ```
+
+Sample local liveness with `listener.status`, `listener.isConnected`, and
+`listener.lastConnectedAt`. The same six states as Python are exposed. The
+timestamp remains set while reconnecting, and `listener.tunnel` remains the
+bootstrap resource snapshot. `serveForever()` and `wait()` both reject on
+terminal authentication, takeover, or unexpected fatal errors. Status callbacks
+are edge-triggered and do not repeat a state until it changes.
 
 ### In-process Fetch-API handler
 
@@ -262,11 +277,41 @@ Tunnels are provisioned atomically by `inkbox.createIdentity(...)`; there is no 
 |---|---|---|
 | `poolSize` | server-decided | 1–32 |
 | `stateDir` | `~/.inkbox/tunnels/{name}` | state.json + passthrough cert |
-| `onStatus` | — | `"connecting"` / `"connected"` / `"reconnecting"` / `"closed"` |
+| `onStatus` | — | `"connecting"` / `"connected"` / `"reconnecting"` / `"closed"` / `"superseded"` |
 | `allowRemoteForwarding` | `false` | bypass loopback-only allowlist |
 | `forwardToVerifyTls` | `true` | for `https://` upstream forwards |
 | `forwardToCaBundle` | — | extra CA(s) for upstream TLS verification |
 | `installSignalHandlers` | `true` on main | clean shutdown on SIGINT/SIGTERM |
+
+---
+
+## Rust
+
+Enable the `tunnels-runtime` feature. Rust keeps a blocking connect API and does
+not create an OS thread; run it on a caller-owned thread. A cloneable
+`TunnelStatusHandle` provides the same local states:
+
+```rust
+use inkbox::tunnels::client::TunnelStatusHandle;
+
+let status = TunnelStatusHandle::new();
+let runtime_status = status.clone();
+let client = inkbox.clone();
+std::thread::spawn(move || {
+    client.tunnels().connect_with_status(
+        "my-app",
+        "http://127.0.0.1:8080",
+        runtime_status.callback(),
+    )
+});
+
+let snapshot = status.snapshot();
+println!("{:?} {:?}", snapshot.status, snapshot.last_connected_at);
+```
+
+Rust bounds establishment and retries transient failures with cold reconnect.
+It does not implement the make-before-break drain behavior described below for
+Python and TypeScript. Its status callback is edge-triggered like the other SDKs.
 
 ---
 

--- a/skills/inkbox-tunnels/SKILL.md
+++ b/skills/inkbox-tunnels/SKILL.md
@@ -271,6 +271,11 @@ await inkbox.tunnels.signCsr("tunnel-uuid", { csrPem });
 
 Tunnels are provisioned atomically by `inkbox.createIdentity(...)`; there is no standalone `create` / `delete` / `restore` / `forceDelete` / `rotateSecret` surface.
 
+For in-process WebSockets, catch `WsServerDraining` (`4500`) for planned handoff
+and `WsConnectionLost` (`1011`) for cold connection loss. Both extend
+`WsClosed` and set `reconnectAdvised = true`. URL-forwarded WebSockets receive
+the same close codes on the local upstream leg.
+
 ### Common `connect()` options
 
 | option | default | notes |
@@ -297,7 +302,7 @@ use inkbox::tunnels::client::TunnelStatusHandle;
 let status = TunnelStatusHandle::new();
 let runtime_status = status.clone();
 let client = inkbox.clone();
-std::thread::spawn(move || {
+let tunnel_thread = std::thread::spawn(move || {
     client.tunnels().connect_with_status(
         "my-app",
         "http://127.0.0.1:8080",
@@ -307,11 +312,18 @@ std::thread::spawn(move || {
 
 let snapshot = status.snapshot();
 println!("{:?} {:?}", snapshot.status, snapshot.last_connected_at);
+
+// Join when shutdown is expected so bootstrap/runtime errors are surfaced.
+if let Err(error) = tunnel_thread.join().expect("tunnel thread panicked") {
+    eprintln!("tunnel stopped: {error}");
+}
 ```
 
 Rust bounds establishment and retries transient failures with cold reconnect.
 It does not implement the make-before-break drain behavior described below for
-Python and TypeScript. Its status callback is edge-triggered like the other SDKs.
+Python and TypeScript. Its status callback is edge-triggered like the other SDKs
+and must return promptly. The handle remains `Idle` if bootstrap fails before
+the runtime starts, so retain and inspect the thread result.
 
 ---
 


### PR DESCRIPTION
## Executive Summary

This PR makes long-running tunnel connections recover predictably across the Python, TypeScript, and Rust SDKs.

- Bounds connection establishment, HELLO, PING recovery, and task cleanup.
- Adds sampleable local liveness to Python and TypeScript listeners plus a Rust status handle.
- Ships deterministic recovery coverage, updated public guidance, and lockstep version 0.5.15.

## Description

Python and TypeScript retain make-before-break planned handoff while hardening cold recovery, waiter release, stale-response rejection, terminal error propagation, and lifecycle observability. Rust retains its blocking cold-reconnect model while adding interruptible establishment, explicit task ownership, bounded teardown, callback isolation, and a cloneable thread-safe status handle.

Status callbacks are edge-triggered across all three SDKs. Public READMEs, tunnel skills, package metadata, lockfiles, and the canonical changelog are updated; local `*PLAN.md` work artifacts are ignored.

## Reason

Transport loss or stalled establishment could strand tunnel work or delay recovery without a reliable local liveness signal. These changes make failure handling finite, observable, and consistently testable across SDKs.

## Decisions

- **Recovery ownership:** Keep one cold-retry owner per runtime so helpers fail and clean up without starting competing retry loops.
- **Planned drains:** Preserve Python and TypeScript make-before-break handoff and typed bridge drain semantics; keep Rust cold-reconnect only.
- **Liveness API:** Expose listener properties in Python and TypeScript, and use a cloneable status handle for Rust so its blocking API and caller-owned thread model remain unchanged.
- **Callback cadence:** Make lifecycle callbacks edge-triggered while retaining attempt-level detail in logs.
- **Compatibility:** TypeScript `serveForever()` now rejects terminal failures consistently with `wait()`; Python `close()` raises if its runtime thread exceeds the shutdown bound.

## Testing

- Python `TunnelListener` recovery and liveness: `uv run pytest` passed 1024 tests with 3 skipped; `uv run ruff check inkbox tests` passed.
- TypeScript `connect()`, `serveForever()`, and `wait()`: `npm test` passed 1031 tests with 3 skipped; build and bundle verification passed.
- Rust `TunnelRuntime` and `TunnelStatusHandle`: all-feature tests passed 309 tests; no-default-feature tests passed 231 tests; formatting and strict Clippy passed.
- CLI lockstep release metadata: `npm test` passed 106 tests.
- Complete public diff: whitespace, version consistency, and credential/internal-reference checks passed.