### PR TITLE
Add agent contact sharing controls

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 
 ## 0.6.0 — Dedicated iMessage lines
 
+### Added
+
+- Agent identities expose `contact_sharing_enabled` for automatic name and
+  optional photo sharing on an attached dedicated iMessage line. It defaults to
+  enabled and remains configurable when no line is attached. Python and
+  TypeScript support it in identity create/update options; Rust exposes
+  `set_contact_sharing_enabled`; the CLI adds
+  `--contact-sharing-enabled true|false`.
+
 ### Changed
 
 - iMessage number claims no longer take a line-type selector. Python and Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 
 - Agent identities expose `contact_sharing_enabled` for automatic name and
   optional photo sharing on an attached dedicated iMessage line. It defaults to
-  enabled and remains configurable when no line is attached. Python and
-  TypeScript and Rust support it during identity creation and update; Rust also
-  exposes `set_contact_sharing_enabled`; the CLI adds
+  enabled and remains configurable when no line is attached. Python,
+  TypeScript, and Rust support it during identity creation and update. Rust also
+  exposes `set_contact_sharing_enabled` plus backward-compatible methods for
+  atomically opting out while creating or updating a dedicated-line claim. The CLI adds
   `--contact-sharing-enabled true|false`.
 
 ## 0.6.0 — Dedicated iMessage lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
-## 0.6.0 — Dedicated iMessage lines
+## 0.6.1 — Automatic iMessage contact sharing
 
 ### Added
 
 - Agent identities expose `contact_sharing_enabled` for automatic name and
   optional photo sharing on an attached dedicated iMessage line. It defaults to
   enabled and remains configurable when no line is attached. Python and
-  TypeScript support it in identity create/update options; Rust exposes
-  `set_contact_sharing_enabled`; the CLI adds
+  TypeScript and Rust support it during identity creation and update; Rust also
+  exposes `set_contact_sharing_enabled`; the CLI adds
   `--contact-sharing-enabled true|false`.
+
+## 0.6.0 — Dedicated iMessage lines
 
 ### Changed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 — Automatic iMessage contact sharing
+
+- Identity create and update accept `--contact-sharing-enabled true|false`.
+- CLI and SDK dependency versions moved in lockstep to 0.6.1.
+
 ## 0.6.0 — Dedicated iMessage lines
 
 - iMessage help and bundled guidance now describe shared service and one

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.0",
+        "@inkbox/sdk": "^0.6.1",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.0",
+    "@inkbox/sdk": "^0.6.1",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.0";
+export const CLI_VERSION = "0.6.1";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -358,6 +358,7 @@ export function registerIdentityCommands(program: Command): void {
             mailbox: id.mailbox?.emailAddress ?? null,
             phoneNumber: id.phoneNumber?.number ?? null,
             imessageEnabled: id.imessageEnabled,
+            contactSharingEnabled: id.contactSharingEnabled,
             imessageFilterMode: id.imessageFilterMode,
             mailFilterMode: id.mailFilterMode,
             phoneFilterMode: id.phoneFilterMode,
@@ -398,6 +399,10 @@ export function registerIdentityCommands(program: Command): void {
       false,
     )
     .option(
+      "--contact-sharing-enabled <bool>",
+      "Share the identity's name and optional avatar from its dedicated iMessage line: true or false.",
+    )
+    .option(
       "--email-local-part <part>",
       "Requested mailbox local part. On the platform domain the server forces this to the handle.",
     )
@@ -422,6 +427,7 @@ export function registerIdentityCommands(program: Command): void {
           displayName?: string;
           description?: string;
           imessageEnabled?: boolean;
+          contactSharingEnabled?: string;
           emailLocalPart?: string;
           sendingDomain?: string;
           platformDomain?: boolean;
@@ -434,12 +440,16 @@ export function registerIdentityCommands(program: Command): void {
         if (cmdOpts.tlsMode !== undefined && cmdOpts.tlsMode !== "edge" && cmdOpts.tlsMode !== "passthrough") {
           throw new Error("--tls-mode must be 'edge' or 'passthrough'");
         }
+        if (cmdOpts.contactSharingEnabled !== undefined && cmdOpts.contactSharingEnabled !== "true" && cmdOpts.contactSharingEnabled !== "false") {
+          throw new Error("--contact-sharing-enabled must be 'true' or 'false'");
+        }
         const opts = getGlobalOpts(this);
         const inkbox = createClient(opts);
         const createOpts: {
           displayName?: string;
           description?: string | null;
           imessageEnabled?: boolean;
+          contactSharingEnabled?: boolean;
           emailLocalPart?: string;
           sendingDomain?: string | null;
           tunnel?: { tlsMode?: "edge" | "passthrough" };
@@ -447,6 +457,9 @@ export function registerIdentityCommands(program: Command): void {
         if (cmdOpts.displayName !== undefined) createOpts.displayName = cmdOpts.displayName;
         if (cmdOpts.description !== undefined) createOpts.description = cmdOpts.description;
         if (cmdOpts.imessageEnabled) createOpts.imessageEnabled = true;
+        if (cmdOpts.contactSharingEnabled !== undefined) {
+          createOpts.contactSharingEnabled = cmdOpts.contactSharingEnabled === "true";
+        }
         if (cmdOpts.emailLocalPart !== undefined) createOpts.emailLocalPart = cmdOpts.emailLocalPart;
         if (cmdOpts.sendingDomain !== undefined) {
           createOpts.sendingDomain = cmdOpts.sendingDomain;
@@ -465,6 +478,7 @@ export function registerIdentityCommands(program: Command): void {
             description: id.description,
             mailbox: id.mailbox?.emailAddress ?? null,
             imessageEnabled: id.imessageEnabled,
+            contactSharingEnabled: id.contactSharingEnabled,
             tunnel: id.tunnel
               ? {
                   id: id.tunnel.id,
@@ -505,6 +519,7 @@ export function registerIdentityCommands(program: Command): void {
     .option("--description <text>", "New description (pass '' to clear)")
     .option("--clear-description", "Explicitly clear the description (sends null)", false)
     .option("--imessage-enabled <bool>", "Toggle identity-level iMessage reachability: true or false")
+    .option("--contact-sharing-enabled <bool>", "Toggle automatic name and optional photo sharing on a dedicated iMessage line: true or false")
     .option("--imessage-filter-mode <mode>", "iMessage contact-rule mode: whitelist or blacklist (admin-only)")
     .option("--mail-filter-mode <mode>", "Mail contact-rule mode: whitelist or blacklist (admin-only)")
     .option("--phone-filter-mode <mode>", "Phone contact-rule mode: whitelist or blacklist (admin-only; identity must have a phone number)")
@@ -518,6 +533,7 @@ export function registerIdentityCommands(program: Command): void {
           description?: string;
           clearDescription?: boolean;
           imessageEnabled?: string;
+          contactSharingEnabled?: string;
           imessageFilterMode?: string;
           mailFilterMode?: string;
           phoneFilterMode?: string;
@@ -528,6 +544,9 @@ export function registerIdentityCommands(program: Command): void {
         }
         if (cmdOpts.imessageEnabled !== undefined && cmdOpts.imessageEnabled !== "true" && cmdOpts.imessageEnabled !== "false") {
           throw new Error("--imessage-enabled must be 'true' or 'false'");
+        }
+        if (cmdOpts.contactSharingEnabled !== undefined && cmdOpts.contactSharingEnabled !== "true" && cmdOpts.contactSharingEnabled !== "false") {
+          throw new Error("--contact-sharing-enabled must be 'true' or 'false'");
         }
         for (const [flag, value] of [
           ["--imessage-filter-mode", cmdOpts.imessageFilterMode],
@@ -546,6 +565,7 @@ export function registerIdentityCommands(program: Command): void {
           displayName?: string | null;
           description?: string | null;
           imessageEnabled?: boolean;
+          contactSharingEnabled?: boolean;
           imessageFilterMode?: "whitelist" | "blacklist";
           mailFilterMode?: "whitelist" | "blacklist";
           phoneFilterMode?: "whitelist" | "blacklist";
@@ -561,6 +581,9 @@ export function registerIdentityCommands(program: Command): void {
         }
         if (cmdOpts.imessageEnabled !== undefined) {
           updateOpts.imessageEnabled = cmdOpts.imessageEnabled === "true";
+        }
+        if (cmdOpts.contactSharingEnabled !== undefined) {
+          updateOpts.contactSharingEnabled = cmdOpts.contactSharingEnabled === "true";
         }
         if (cmdOpts.imessageFilterMode !== undefined) {
           updateOpts.imessageFilterMode = cmdOpts.imessageFilterMode as "whitelist" | "blacklist";
@@ -594,6 +617,7 @@ export function registerIdentityCommands(program: Command): void {
             mailbox: id.mailbox?.emailAddress ?? null,
             phoneNumber: id.phoneNumber?.number ?? null,
             imessageEnabled: id.imessageEnabled,
+            contactSharingEnabled: id.contactSharingEnabled,
             imessageFilterMode: id.imessageFilterMode,
             mailFilterMode: id.mailFilterMode,
             phoneFilterMode: id.phoneFilterMode,

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 — Automatic iMessage contact sharing
+
+- Identity create and update accept `contact_sharing_enabled`; dedicated lines
+  share the identity's display name or handle and optional avatar by default.
+
 ## 0.6.0 — Dedicated iMessage lines
 
 - `imessages.claim_number()` now takes only `idempotency_key` and sends a

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -166,6 +166,11 @@ class AgentIdentity:
         return self._data.imessage_enabled
 
     @property
+    def contact_sharing_enabled(self) -> bool:
+        """Whether an attached dedicated iMessage line shares this profile."""
+        return self._data.contact_sharing_enabled
+
+    @property
     def imessage_filter_mode(self) -> FilterMode:
         """Whitelist/blacklist mode for this identity's iMessage contact rules."""
         return self._data.imessage_filter_mode
@@ -1915,6 +1920,7 @@ class AgentIdentity:
         display_name: Any = _UNSET,
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
+        contact_sharing_enabled: bool | None = None,
         imessage_number_id: UUID | str | None = _UNSET,  # type: ignore[assignment]
         claim_imessage_number: Literal[True] | None = None,
         idempotency_key: str | None = None,
@@ -1935,6 +1941,8 @@ class AgentIdentity:
             display_name: New display name, or ``None`` to clear.
             description: New description, or ``None`` to clear.
             imessage_enabled: Toggle iMessage reachability.
+            contact_sharing_enabled: Toggle automatic name and optional photo
+                sharing for an attached dedicated iMessage line.
             imessage_number_id: Attach an already-owned dedicated line by
                 UUID, pass ``None`` to move back to the shared service, or
                 omit to keep the current attachment.
@@ -1962,6 +1970,8 @@ class AgentIdentity:
             update_kwargs["description"] = description
         if imessage_enabled is not None:
             update_kwargs["imessage_enabled"] = imessage_enabled
+        if contact_sharing_enabled is not None:
+            update_kwargs["contact_sharing_enabled"] = contact_sharing_enabled
         if imessage_number_id is not _UNSET:
             update_kwargs["imessage_number_id"] = imessage_number_id
         if claim_imessage_number is not None:

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -492,6 +492,7 @@ class Inkbox:
         display_name: str | None = None,
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
+        contact_sharing_enabled: bool | None = None,
         claim_imessage_number: Literal[True] | None = None,
         email_local_part: str | None = None,
         sending_domain: str | None = _UNSET,  # type: ignore[assignment]
@@ -516,6 +517,8 @@ class Inkbox:
                 ``None`` to leave the column null; omit to defer to the
                 server default. Never surfaces in outbound mail.
             imessage_enabled: Whether this identity can use iMessage.
+            contact_sharing_enabled: Whether an attached dedicated iMessage
+                line automatically shares the identity's name and optional avatar.
                 Defaults server-side to ``False``; pass ``True`` to opt in.
             claim_imessage_number: Claim and attach a dedicated iMessage line
                 atomically. Requires
@@ -550,6 +553,7 @@ class Inkbox:
             display_name=display_name,
             description=description,
             imessage_enabled=imessage_enabled,
+            contact_sharing_enabled=contact_sharing_enabled,
             claim_imessage_number=claim_imessage_number,
             mailbox=mailbox,
             tunnel=tunnel,

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -517,6 +517,7 @@ class Inkbox:
                 ``None`` to leave the column null; omit to defer to the
                 server default. Never surfaces in outbound mail.
             imessage_enabled: Whether this identity can use iMessage.
+                Defaults server-side to ``False``; pass ``True`` to opt in.
             contact_sharing_enabled: Whether an attached dedicated iMessage
                 line automatically shares the identity's name and optional avatar.
                 Defaults server-side to ``True``; pass ``False`` to opt out.

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -519,7 +519,7 @@ class Inkbox:
             imessage_enabled: Whether this identity can use iMessage.
             contact_sharing_enabled: Whether an attached dedicated iMessage
                 line automatically shares the identity's name and optional avatar.
-                Defaults server-side to ``False``; pass ``True`` to opt in.
+                Defaults server-side to ``True``; pass ``False`` to opt out.
             claim_imessage_number: Claim and attach a dedicated iMessage line
                 atomically. Requires
                 ``imessage_enabled=True``.

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -38,6 +38,7 @@ class IdentitiesResource:
         display_name: str | None = None,
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
+        contact_sharing_enabled: bool | None = None,
         claim_imessage_number: Literal[True] | None = None,
         mailbox: IdentityMailboxCreateOptions | None = None,
         tunnel: IdentityTunnelCreateOptions | None = None,
@@ -59,6 +60,9 @@ class IdentitiesResource:
                 to the server default.
             imessage_enabled: Whether the identity can use iMessage. Omit to
                 defer to the server default (``False``).
+            contact_sharing_enabled: Whether an attached dedicated iMessage
+                line automatically shares this identity's name and optional
+                avatar. Omit to defer to the server default (``True``).
             claim_imessage_number: Claim and attach a new dedicated iMessage
                 line atomically. Requires
                 ``imessage_enabled=True``.
@@ -80,6 +84,8 @@ class IdentitiesResource:
             body["description"] = description
         if imessage_enabled is not None:
             body["imessage_enabled"] = imessage_enabled
+        if contact_sharing_enabled is not None:
+            body["contact_sharing_enabled"] = contact_sharing_enabled
         if claim_imessage_number is True:
             if imessage_enabled is not True:
                 raise ValueError(
@@ -120,6 +126,7 @@ class IdentitiesResource:
         display_name: Any = _UNSET,
         description: Any = _UNSET,
         imessage_enabled: bool | None = None,
+        contact_sharing_enabled: bool | None = None,
         imessage_number_id: UUID | str | None = _UNSET,  # type: ignore[assignment]
         claim_imessage_number: Literal[True] | None = None,
         idempotency_key: str | None = None,
@@ -141,6 +148,8 @@ class IdentitiesResource:
             display_name: New display name, or ``None`` to clear.
             description: New description, or ``None`` to clear.
             imessage_enabled: Toggle iMessage reachability.
+            contact_sharing_enabled: Toggle automatic name and optional photo
+                sharing for an attached dedicated iMessage line.
             imessage_number_id: Attach an already-owned dedicated line by
                 UUID, pass ``None`` to move back to the shared service, or
                 omit to leave the current attachment unchanged.
@@ -168,6 +177,8 @@ class IdentitiesResource:
             body["description"] = description
         if imessage_enabled is not None:
             body["imessage_enabled"] = imessage_enabled
+        if contact_sharing_enabled is not None:
+            body["contact_sharing_enabled"] = contact_sharing_enabled
         if claim_imessage_number is True and imessage_number_id is not _UNSET:
             raise ValueError(
                 "claim_imessage_number and imessage_number_id cannot be set together"

--- a/sdk/python/inkbox/identities/types.py
+++ b/sdk/python/inkbox/identities/types.py
@@ -278,6 +278,7 @@ class AgentIdentitySummary:
     created_at: datetime
     updated_at: datetime
     imessage_enabled: bool = False
+    contact_sharing_enabled: bool = True
     imessage_filter_mode: FilterMode = FilterMode.BLACKLIST
     mail_filter_mode: FilterMode = FilterMode.BLACKLIST
     phone_filter_mode: FilterMode = FilterMode.BLACKLIST
@@ -306,6 +307,7 @@ class AgentIdentitySummary:
             created_at=datetime.fromisoformat(d["created_at"]),
             updated_at=datetime.fromisoformat(d["updated_at"]),
             imessage_enabled=d.get("imessage_enabled", False),
+            contact_sharing_enabled=d.get("contact_sharing_enabled", True),
             imessage_filter_mode=FilterMode(d.get("imessage_filter_mode") or "blacklist"),
             mail_filter_mode=FilterMode(d.get("mail_filter_mode") or "blacklist"),
             phone_filter_mode=FilterMode(d.get("phone_filter_mode") or "blacklist"),

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_identities.py
+++ b/sdk/python/tests/test_identities.py
@@ -362,3 +362,16 @@ class TestIdentitiesIMessageFields:
             f"/{HANDLE}",
             json={"imessage_enabled": True, "imessage_filter_mode": "whitelist"},
         )
+
+    def test_create_and_update_send_contact_sharing_toggle(self):
+        res, http = _resource()
+        http.post.return_value = IDENTITY_DICT
+        http.patch.return_value = IDENTITY_DICT
+
+        res.create(agent_handle=HANDLE, contact_sharing_enabled=False)
+        assert http.post.call_args.kwargs["json"]["contact_sharing_enabled"] is False
+
+        res.update(HANDLE, contact_sharing_enabled=True)
+        http.patch.assert_called_once_with(
+            f"/{HANDLE}", json={"contact_sharing_enabled": True}
+        )

--- a/sdk/python/tests/test_identities_types.py
+++ b/sdk/python/tests/test_identities_types.py
@@ -156,12 +156,14 @@ class TestIdentityIMessageFields:
             "description": None,
             "email_address": None,
             "imessage_enabled": True,
+            "contact_sharing_enabled": False,
             "imessage_filter_mode": "whitelist",
             "created_at": "2026-06-01T00:00:00+00:00",
             "updated_at": "2026-06-01T00:00:00+00:00",
         }
         summary = AgentIdentitySummary._from_dict(d)
         assert summary.imessage_enabled is True
+        assert summary.contact_sharing_enabled is False
         assert summary.imessage_filter_mode is FilterMode.WHITELIST
 
     def test_summary_defaults_imessage_fields_when_absent(self):
@@ -180,6 +182,7 @@ class TestIdentityIMessageFields:
         }
         summary = AgentIdentitySummary._from_dict(d)
         assert summary.imessage_enabled is False
+        assert summary.contact_sharing_enabled is True
         assert summary.imessage_filter_mode is FilterMode.BLACKLIST
 
 

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -300,11 +300,12 @@ A number can also be claimed and attached atomically while creating an identity:
 ```rust
 use inkbox::identities::Unset;
 
-let identity = inkbox.create_identity_with_imessage_number(
+let identity = inkbox.create_identity_with_contact_sharing_and_imessage_number(
     "support-bot",
     None,
     Unset::Omit,
     Some(true),
+    Some(false), // opt out of automatic contact sharing
     None,
     Unset::Omit,
     None,

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1580,19 +1580,55 @@ impl AgentIdentity {
         claim_imessage_number: Option<bool>,
         idempotency_key: Option<&str>,
     ) -> Result<()> {
-        let data = self.inkbox.identities().update_with_imessage_number(
-            &self.agent_handle(),
+        self.update_with_contact_sharing_and_imessage_number(
             new_handle,
             display_name,
             description,
             imessage_enabled,
+            None,
             imessage_filter_mode,
             mail_filter_mode,
             phone_filter_mode,
             imessage_number_id,
             claim_imessage_number,
             idempotency_key,
-        )?;
+        )
+    }
+
+    /// Update this identity while explicitly controlling automatic contact
+    /// sharing and optionally changing its dedicated iMessage line atomically.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_with_contact_sharing_and_imessage_number(
+        &self,
+        new_handle: Option<&str>,
+        display_name: Unset<String>,
+        description: Unset<String>,
+        imessage_enabled: Option<bool>,
+        contact_sharing_enabled: Option<bool>,
+        imessage_filter_mode: Option<&str>,
+        mail_filter_mode: Option<&str>,
+        phone_filter_mode: Option<&str>,
+        imessage_number_id: Unset<Uuid>,
+        claim_imessage_number: Option<bool>,
+        idempotency_key: Option<&str>,
+    ) -> Result<()> {
+        let data = self
+            .inkbox
+            .identities()
+            .update_with_contact_sharing_and_imessage_number(
+                &self.agent_handle(),
+                new_handle,
+                display_name,
+                description,
+                imessage_enabled,
+                contact_sharing_enabled,
+                imessage_filter_mode,
+                mail_filter_mode,
+                phone_filter_mode,
+                imessage_number_id,
+                claim_imessage_number,
+                idempotency_key,
+            )?;
         *self.mailbox.borrow_mut() = data.mailbox.clone();
         *self.phone_number.borrow_mut() = data.phone_number.clone();
         *self.tunnel.borrow_mut() = data.tunnel.clone();

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -197,6 +197,25 @@ impl AgentIdentity {
         self.data.borrow().summary.imessage_enabled
     }
 
+    /// Whether an attached dedicated iMessage line automatically shares this profile.
+    pub fn contact_sharing_enabled(&self) -> bool {
+        self.data.borrow().summary.contact_sharing_enabled
+    }
+
+    /// Toggle automatic name and optional photo sharing for this identity's
+    /// attached dedicated iMessage line.
+    pub fn set_contact_sharing_enabled(&self, enabled: bool) -> Result<()> {
+        let data = self
+            .inkbox
+            .identities()
+            .set_contact_sharing_enabled(&self.agent_handle(), enabled)?;
+        *self.mailbox.borrow_mut() = data.mailbox.clone();
+        *self.phone_number.borrow_mut() = data.phone_number.clone();
+        *self.tunnel.borrow_mut() = data.tunnel.clone();
+        *self.data.borrow_mut() = data;
+        Ok(())
+    }
+
     /// Whitelist/blacklist mode for this identity's iMessage contact rules.
     pub fn imessage_filter_mode(&self) -> FilterMode {
         self.data.borrow().summary.imessage_filter_mode

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -482,6 +482,38 @@ impl Inkbox {
         vault_secret_ids: Option<&VaultSecretIds>,
         claim_imessage_number: Option<bool>,
     ) -> Result<AgentIdentity> {
+        self.create_identity_with_contact_sharing_and_imessage_number(
+            agent_handle,
+            display_name,
+            description,
+            imessage_enabled,
+            None,
+            email_local_part,
+            sending_domain,
+            tunnel,
+            phone_number,
+            vault_secret_ids,
+            claim_imessage_number,
+        )
+    }
+
+    /// Create an identity while explicitly controlling automatic contact
+    /// sharing and optionally claiming a dedicated iMessage number atomically.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_identity_with_contact_sharing_and_imessage_number(
+        self: &Arc<Self>,
+        agent_handle: &str,
+        display_name: Option<&str>,
+        description: Unset<String>,
+        imessage_enabled: Option<bool>,
+        contact_sharing_enabled: Option<bool>,
+        email_local_part: Option<&str>,
+        sending_domain: Unset<String>,
+        tunnel: Option<&IdentityTunnelCreateOptions>,
+        phone_number: Option<&IdentityPhoneNumberCreateOptions>,
+        vault_secret_ids: Option<&VaultSecretIds>,
+        claim_imessage_number: Option<bool>,
+    ) -> Result<AgentIdentity> {
         // Assemble the nested mailbox spec only when a mailbox field was given,
         // matching the Python `mailbox_kwargs` construction.
         let mailbox = if email_local_part.is_some() || !sending_domain.is_omit() {
@@ -492,17 +524,20 @@ impl Inkbox {
         } else {
             None
         };
-        let data = self.identities.create_with_imessage_number(
-            agent_handle,
-            display_name,
-            description,
-            imessage_enabled,
-            mailbox.as_ref(),
-            tunnel,
-            phone_number,
-            vault_secret_ids,
-            claim_imessage_number,
-        )?;
+        let data = self
+            .identities
+            .create_with_contact_sharing_and_imessage_number(
+                agent_handle,
+                display_name,
+                description,
+                imessage_enabled,
+                contact_sharing_enabled,
+                mailbox.as_ref(),
+                tunnel,
+                phone_number,
+                vault_secret_ids,
+                claim_imessage_number,
+            )?;
         Ok(AgentIdentity::new(data, self.clone()))
     }
 

--- a/sdk/rust/src/identities/resources/identities.rs
+++ b/sdk/rust/src/identities/resources/identities.rs
@@ -170,6 +170,21 @@ impl IdentitiesResource {
         AgentIdentityData::from_value(data)
     }
 
+    /// Toggle automatic name and optional photo sharing for an attached
+    /// dedicated iMessage line.
+    pub fn set_contact_sharing_enabled(
+        &self,
+        agent_handle: &str,
+        enabled: bool,
+    ) -> Result<AgentIdentityData> {
+        let body = serde_json::json!({ "contact_sharing_enabled": enabled });
+        let data = self
+            .http
+            .patch(&format!("/{agent_handle}"), &body)
+            .map_err(map_identity_conflict_error)?;
+        AgentIdentityData::from_value(data)
+    }
+
     /// Update an identity's handle, display name, description, iMessage
     /// reachability and contact-rule filter modes.
     ///
@@ -441,8 +456,30 @@ mod tests {
 
         mock.assert();
         assert_eq!(identities[0].agent_handle, "support-bot");
+        assert!(identities[0].contact_sharing_enabled);
         assert!(identities[0].mailbox.is_none());
         assert!(identities[0].tunnel.is_none());
+    }
+
+    #[test]
+    fn updates_contact_sharing_without_changing_existing_update_signatures() {
+        let server = MockServer::start();
+        let mut response = identity_list_detail_json();
+        response["contact_sharing_enabled"] = json!(false);
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::PATCH)
+                .path("/api/v1/identities/support-bot")
+                .json_body(json!({ "contact_sharing_enabled": false }));
+            then.status(200).json_body(response);
+        });
+
+        let data = client(&server)
+            .identities()
+            .set_contact_sharing_enabled("support-bot", false)
+            .unwrap();
+
+        mock.assert();
+        assert!(!data.contact_sharing_enabled);
     }
 
     #[test]

--- a/sdk/rust/src/identities/resources/identities.rs
+++ b/sdk/rust/src/identities/resources/identities.rs
@@ -287,6 +287,40 @@ impl IdentitiesResource {
         claim_imessage_number: Option<bool>,
         idempotency_key: Option<&str>,
     ) -> Result<AgentIdentityData> {
+        self.update_with_contact_sharing_and_imessage_number(
+            agent_handle,
+            new_handle,
+            display_name,
+            description,
+            imessage_enabled,
+            None,
+            imessage_filter_mode,
+            mail_filter_mode,
+            phone_filter_mode,
+            imessage_number_id,
+            claim_imessage_number,
+            idempotency_key,
+        )
+    }
+
+    /// Update an identity while explicitly controlling automatic contact
+    /// sharing and optionally changing its dedicated iMessage line atomically.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_with_contact_sharing_and_imessage_number(
+        &self,
+        agent_handle: &str,
+        new_handle: Option<&str>,
+        display_name: Unset<String>,
+        description: Unset<String>,
+        imessage_enabled: Option<bool>,
+        contact_sharing_enabled: Option<bool>,
+        imessage_filter_mode: Option<&str>,
+        mail_filter_mode: Option<&str>,
+        phone_filter_mode: Option<&str>,
+        imessage_number_id: Unset<Uuid>,
+        claim_imessage_number: Option<bool>,
+        idempotency_key: Option<&str>,
+    ) -> Result<AgentIdentityData> {
         if claim_imessage_number == Some(false) {
             return Err(crate::error::InkboxError::InvalidArgument(
                 "claim_imessage_number only accepts true when supplied".into(),
@@ -339,6 +373,9 @@ impl IdentitiesResource {
         }
         if let Some(flag) = imessage_enabled {
             body.insert("imessage_enabled".into(), Value::Bool(flag));
+        }
+        if let Some(flag) = contact_sharing_enabled {
+            body.insert("contact_sharing_enabled".into(), Value::Bool(flag));
         }
         if let Unset::Value(number_id) = imessage_number_id {
             body.insert(
@@ -688,6 +725,40 @@ mod tests {
             )
             .unwrap();
         clear.assert();
+    }
+
+    #[test]
+    fn update_can_atomically_claim_with_contact_sharing_disabled() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("PATCH")
+                .path("/api/v1/identities/support-bot")
+                .header("Idempotency-Key", "identity-claim-contact-sharing-123")
+                .json_body(json!({
+                    "contact_sharing_enabled": false,
+                    "claim_imessage_number": true
+                }));
+            then.status(200).json_body(identity_json());
+        });
+
+        client(&server)
+            .identities()
+            .update_with_contact_sharing_and_imessage_number(
+                "support-bot",
+                None,
+                Unset::Omit,
+                Unset::Omit,
+                None,
+                Some(false),
+                None,
+                None,
+                None,
+                Unset::Omit,
+                Some(true),
+                Some("identity-claim-contact-sharing-123"),
+            )
+            .unwrap();
+        mock.assert();
     }
 
     #[test]

--- a/sdk/rust/src/identities/resources/identities.rs
+++ b/sdk/rust/src/identities/resources/identities.rs
@@ -90,6 +90,36 @@ impl IdentitiesResource {
         vault_secret_ids: Option<&VaultSecretIds>,
         claim_imessage_number: Option<bool>,
     ) -> Result<AgentIdentityData> {
+        self.create_with_contact_sharing_and_imessage_number(
+            agent_handle,
+            display_name,
+            description,
+            imessage_enabled,
+            None,
+            mailbox,
+            tunnel,
+            phone_number,
+            vault_secret_ids,
+            claim_imessage_number,
+        )
+    }
+
+    /// Create an identity while explicitly controlling automatic contact
+    /// sharing and optionally claiming a dedicated iMessage number atomically.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_with_contact_sharing_and_imessage_number(
+        &self,
+        agent_handle: &str,
+        display_name: Option<&str>,
+        description: Unset<String>,
+        imessage_enabled: Option<bool>,
+        contact_sharing_enabled: Option<bool>,
+        mailbox: Option<&IdentityMailboxCreateOptions>,
+        tunnel: Option<&IdentityTunnelCreateOptions>,
+        phone_number: Option<&IdentityPhoneNumberCreateOptions>,
+        vault_secret_ids: Option<&VaultSecretIds>,
+        claim_imessage_number: Option<bool>,
+    ) -> Result<AgentIdentityData> {
         if claim_imessage_number == Some(false) {
             return Err(crate::error::InkboxError::InvalidArgument(
                 "claim_imessage_number only accepts true when supplied".into(),
@@ -122,6 +152,9 @@ impl IdentitiesResource {
         }
         if let Some(flag) = imessage_enabled {
             body.insert("imessage_enabled".into(), Value::Bool(flag));
+        }
+        if let Some(flag) = contact_sharing_enabled {
+            body.insert("contact_sharing_enabled".into(), Value::Bool(flag));
         }
         if claim_imessage_number == Some(true) {
             body.insert("claim_imessage_number".into(), Value::Bool(true));
@@ -491,6 +524,7 @@ mod tests {
                 .json_body(json!({
                     "agent_handle": "support-bot",
                     "imessage_enabled": true,
+                    "contact_sharing_enabled": false,
                     "claim_imessage_number": true
                 }));
             then.status(201).json_body(identity_json());
@@ -498,11 +532,12 @@ mod tests {
 
         let data = client(&server)
             .identities()
-            .create_with_imessage_number(
+            .create_with_contact_sharing_and_imessage_number(
                 "support-bot",
                 None,
                 Unset::Omit,
                 Some(true),
+                Some(false),
                 None,
                 None,
                 None,

--- a/sdk/rust/src/identities/types.rs
+++ b/sdk/rust/src/identities/types.rs
@@ -239,6 +239,10 @@ fn default_filter_mode_blacklist() -> FilterMode {
     FilterMode::Blacklist
 }
 
+fn default_contact_sharing_enabled() -> bool {
+    true
+}
+
 /// Mailbox channel linked to an agent identity.
 ///
 /// `agent_identity_id` mirrors the same field on [`crate::mail::types::Mailbox`];
@@ -359,6 +363,10 @@ pub struct AgentIdentitySummary {
     /// Defaults to `false` when the server omits the field.
     #[serde(default)]
     pub imessage_enabled: bool,
+    /// Whether an attached dedicated iMessage line automatically shares this
+    /// identity's name and optional avatar. Defaults to `true` when absent.
+    #[serde(default = "default_contact_sharing_enabled")]
+    pub contact_sharing_enabled: bool,
     /// Defaults to `blacklist` when absent.
     #[serde(default = "default_filter_mode_blacklist")]
     pub imessage_filter_mode: FilterMode,

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 — Automatic iMessage contact sharing
+
+- Identity create and update accept `contactSharingEnabled`; dedicated lines
+  share the identity's display name or handle and optional avatar by default.
+
 ## 0.6.0 — Dedicated iMessage lines
 
 - `imessages.claimNumber()` now takes only `idempotencyKey` and sends a

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -139,6 +139,9 @@ export class AgentIdentity {
   /** Whether this identity can be reached over iMessage. */
   get imessageEnabled(): boolean { return this._data.imessageEnabled; }
 
+  /** Whether an attached dedicated iMessage line automatically shares this profile. */
+  get contactSharingEnabled(): boolean { return this._data.contactSharingEnabled; }
+
   /** Whitelist/blacklist mode for this identity's iMessage contact rules. */
   get imessageFilterMode(): FilterMode { return this._data.imessageFilterMode; }
 
@@ -1204,6 +1207,8 @@ export class AgentIdentity {
    * @param options.displayName - New display name, or `null` to clear.
    * @param options.description - New description, or `null` to clear.
    * @param options.imessageEnabled - Toggle identity-level iMessage reachability.
+   * @param options.contactSharingEnabled - Toggle automatic name and optional
+   *   photo sharing for an attached dedicated iMessage line.
    * @param options.imessageNumberId - Attach an already-owned dedicated line,
    *   or pass `null` to return to shared service.
    * @param options.claimIMessageNumber - Claim and atomically attach or swap to

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -43,6 +43,8 @@ export class IdentitiesResource {
    * @param options.imessageEnabled - Whether the identity can be reached
    *   over iMessage. Omit to defer to the server
    *   default (`false`).
+   * @param options.contactSharingEnabled - Whether an attached dedicated
+   *   iMessage line shares the identity's name and optional avatar.
    * @param options.claimIMessageNumber - Claim a dedicated iMessage line and
    *   attach atomically. Requires `imessageEnabled: true`.
    * @param options.mailbox - Optional nested mailbox spec. Mailbox is
@@ -57,6 +59,7 @@ export class IdentitiesResource {
     displayName?: string;
     description?: string | null;
     imessageEnabled?: boolean;
+    contactSharingEnabled?: boolean;
     claimIMessageNumber?: true;
     mailbox?: IdentityMailboxCreateOptions;
     tunnel?: IdentityTunnelCreateOptions;
@@ -73,6 +76,7 @@ export class IdentitiesResource {
     if (options.displayName !== undefined) body["display_name"] = options.displayName;
     if (options.description !== undefined) body["description"] = options.description;
     if (options.imessageEnabled !== undefined) body["imessage_enabled"] = options.imessageEnabled;
+    if (options.contactSharingEnabled !== undefined) body["contact_sharing_enabled"] = options.contactSharingEnabled;
     if (options.claimIMessageNumber === true) {
       body["claim_imessage_number"] = true;
     }
@@ -118,6 +122,8 @@ export class IdentitiesResource {
    * @param options.displayName - New display name, or `null` to clear.
    * @param options.description - New description, or `null` to clear.
    * @param options.imessageEnabled - Toggle identity-level iMessage reachability.
+   * @param options.contactSharingEnabled - Toggle automatic name and optional
+   *   photo sharing for an attached dedicated iMessage line.
    * @param options.imessageNumberId - Attach an owned dedicated line, or
    *   pass `null` to return to shared service.
    * @param options.claimIMessageNumber - Claim and attach a new dedicated line.
@@ -164,6 +170,7 @@ export class IdentitiesResource {
     if (options.displayName !== undefined) body["display_name"] = options.displayName;
     if (options.description !== undefined) body["description"] = options.description;
     if (options.imessageEnabled !== undefined) body["imessage_enabled"] = options.imessageEnabled;
+    if (options.contactSharingEnabled !== undefined) body["contact_sharing_enabled"] = options.contactSharingEnabled;
     if ("imessageNumberId" in options) body["imessage_number_id"] = options.imessageNumberId;
     if (options.claimIMessageNumber === true) {
       body["claim_imessage_number"] = true;

--- a/sdk/typescript/src/identities/types.ts
+++ b/sdk/typescript/src/identities/types.ts
@@ -56,6 +56,8 @@ export interface CreateIdentityOptions {
    * service. Defaults server-side to `false`; pass `true` to opt in.
    */
   imessageEnabled?: boolean;
+  /** Automatically share this identity's name and optional avatar on an attached dedicated iMessage line. */
+  contactSharingEnabled?: boolean;
   /**
    * Claim and attach a dedicated iMessage line atomically during identity
    * creation. Requires `imessageEnabled: true`.
@@ -81,6 +83,8 @@ export interface UpdateIdentityOptions {
   displayName?: string | null;
   description?: string | null;
   imessageEnabled?: boolean;
+  /** Toggle automatic name and optional photo sharing for an attached dedicated iMessage line. */
+  contactSharingEnabled?: boolean;
   /**
    * Attach an already-owned dedicated line by id, atomically swap lines,
    * or pass `null` to return to the shared iMessage service.
@@ -162,6 +166,7 @@ export interface AgentIdentitySummary {
    * may also carry an attached dedicated line.
    */
   imessageEnabled: boolean;
+  contactSharingEnabled: boolean;
   /** Whitelist/blacklist mode for this identity's iMessage contact rules. */
   imessageFilterMode: FilterMode;
   /**
@@ -249,6 +254,7 @@ export interface RawAgentIdentitySummary {
   description: string | null;
   email_address: string | null;
   imessage_enabled?: boolean;
+  contact_sharing_enabled?: boolean;
   imessage_filter_mode?: string | null;
   mail_filter_mode?: string | null;
   phone_filter_mode?: string | null;
@@ -319,6 +325,7 @@ export function parseAgentIdentitySummary(r: RawAgentIdentitySummary): AgentIden
     description: r.description ?? null,
     emailAddress: r.email_address,
     imessageEnabled: r.imessage_enabled ?? false,
+    contactSharingEnabled: r.contact_sharing_enabled ?? true,
     imessageFilterMode: (r.imessage_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     mailFilterMode: (r.mail_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,
     phoneFilterMode: (r.phone_filter_mode as FilterMode) ?? FilterModeEnum.BLACKLIST,

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -440,6 +440,8 @@ export class Inkbox {
    * @param options.imessageEnabled - Whether this identity can be reached
    *   over iMessage. Defaults server-side to `false`;
    *   pass `true` to opt in.
+   * @param options.contactSharingEnabled - Whether an attached dedicated
+   *   iMessage line shares the identity's name and optional avatar.
    * @param options.claimIMessageNumber - Claim and attach a dedicated iMessage
    *   line atomically. Requires `imessageEnabled: true`.
    * @param options.emailLocalPart - Optional requested mailbox local part.
@@ -475,6 +477,7 @@ export class Inkbox {
     if (options.displayName !== undefined) createArgs.displayName = options.displayName;
     if (options.description !== undefined) createArgs.description = options.description;
     if (options.imessageEnabled !== undefined) createArgs.imessageEnabled = options.imessageEnabled;
+    if (options.contactSharingEnabled !== undefined) createArgs.contactSharingEnabled = options.contactSharingEnabled;
     if (options.claimIMessageNumber === true) {
       createArgs.claimIMessageNumber = true;
     }

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.0";
+export const VERSION = "0.6.1";

--- a/sdk/typescript/tests/identities/identities.test.ts
+++ b/sdk/typescript/tests/identities/identities.test.ts
@@ -116,6 +116,24 @@ describe("IdentitiesResource.create", () => {
     expect(identity.imessageNumber?.type).toBe("dedicated_outbound");
   });
 
+  it("sends the contact-sharing toggle on create and update", async () => {
+    const http = mockHttp();
+    vi.mocked(http.post).mockResolvedValue(RAW_IDENTITY_DETAIL);
+    vi.mocked(http.patch).mockResolvedValue(RAW_IDENTITY_DETAIL);
+    const res = new IdentitiesResource(http);
+
+    await res.create({ agentHandle: HANDLE, contactSharingEnabled: false });
+    expect(http.post).toHaveBeenCalledWith("/", {
+      agent_handle: HANDLE,
+      contact_sharing_enabled: false,
+    });
+
+    await res.update(HANDLE, { contactSharingEnabled: true });
+    expect(http.patch).toHaveBeenCalledWith(`/${HANDLE}`, {
+      contact_sharing_enabled: true,
+    });
+  });
+
   it("requires iMessage to be enabled when claiming during create", async () => {
     const http = mockHttp();
     const res = new IdentitiesResource(http);

--- a/sdk/typescript/tests/imessage.test.ts
+++ b/sdk/typescript/tests/imessage.test.ts
@@ -720,11 +720,13 @@ describe("identity iMessage fields", () => {
       description: null,
       email_address: null,
       imessage_enabled: true,
+      contact_sharing_enabled: false,
       imessage_filter_mode: "whitelist",
       created_at: "2026-06-01T00:00:00Z",
       updated_at: "2026-06-01T00:00:00Z",
     });
     expect(summary.imessageEnabled).toBe(true);
+    expect(summary.contactSharingEnabled).toBe(false);
     expect(summary.imessageFilterMode).toBe("whitelist");
   });
 
@@ -741,6 +743,7 @@ describe("identity iMessage fields", () => {
       updated_at: "2026-06-01T00:00:00Z",
     });
     expect(summary.imessageEnabled).toBe(false);
+    expect(summary.contactSharingEnabled).toBe(true);
     expect(summary.imessageFilterMode).toBe("blacklist");
   });
 });

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -111,12 +111,16 @@ inkbox signup status
 inkbox identity list
 inkbox identity get <handle>
 inkbox identity create <handle> [--display-name <name>] [--description <text>]
+                                 [--imessage-enabled]
+                                 [--contact-sharing-enabled true|false]
                                  [--email-local-part <part>]
                                  [--sending-domain <name> | --platform-domain]
                                  [--tls-mode edge|passthrough]
 inkbox identity delete <handle>
 inkbox identity update <handle> [--new-handle <handle>] [--display-name <name>]
                                  [--description <text> | --clear-description]
+                                 [--imessage-enabled true|false]
+                                 [--contact-sharing-enabled true|false]
                                  [--mail-filter-mode whitelist|blacklist]
                                  [--phone-filter-mode whitelist|blacklist]
 inkbox identity refresh <handle>
@@ -125,6 +129,13 @@ inkbox identity refresh <handle>
 `--mail-filter-mode` / `--phone-filter-mode` set the identity's contact-rule mode (admin-only). Unlike the deprecated `mailbox update --filter-mode` / `number update --filter-mode`, the identity path does **not** print a change notice. `--phone-filter-mode` requires the identity to have a phone number (else a 422).
 
 `identity create` atomically provisions the mailbox AND the tunnel. The JSON output includes both (`mailbox`, `tunnel.publicHost`, `tunnel.tlsMode`).
+
+New identities default contact sharing to enabled. If a dedicated iMessage
+line is attached, it automatically offers the identity's display name (or
+handle as fallback) and optional avatar. Use
+`--contact-sharing-enabled false` during identity creation to opt out, or
+`inkbox identity update <handle> --contact-sharing-enabled false` to disable it
+later. Pass `true` to enable it again.
 
 `--sending-domain <name>` binds the agent's mailbox to a verified custom domain (bare name, e.g. `mail.acme.com`); `--platform-domain` forces the platform sending domain; the two are mutually exclusive. `--tls-mode` defaults to `edge` and is fixed at create time (changing it later requires deleting the identity + recreating).
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -473,13 +473,22 @@ separate attach call after an atomic claim. `imessage_number_id=None` is
 intentional wire data that moves an identity back to shared service; omitting
 the argument leaves its attachment unchanged.
 
+New identities default `contact_sharing_enabled=True`. When a dedicated line
+is attached, it automatically offers the identity's display name (or handle as
+fallback) and optional avatar. Pass `contact_sharing_enabled=False` during
+creation to opt out before the line is claimed, or update the identity later
+to enable or disable sharing.
+
 ```python
 dedicated_identity = inkbox.create_identity(
     "dedicated-agent",
     imessage_enabled=True,
+    contact_sharing_enabled=False,  # opt out before claiming the line
     claim_imessage_number=True,
 )
 print(dedicated_identity.imessage_number.number)
+
+dedicated_identity.update(contact_sharing_enabled=True)  # enable later
 
 identity.update(
     claim_imessage_number=True,

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -472,6 +472,12 @@ console.log(identity.imessageEnabled, identity.imessageFilterMode);
 
 Messaging (identity convenience methods; `inkbox.imessages` is the org-level resource with the same operations plus `agentIdentityId` / `isBlocked` filters):
 
+New identities default `contactSharingEnabled: true`. When a dedicated line
+is attached, it automatically offers the identity's display name (or handle as
+fallback) and optional avatar. Set `contactSharingEnabled: false` in the same
+create request as `claimIMessageNumber: true` to opt out before the line is
+claimed. The identity can be updated later to enable or disable sharing.
+
 ```typescript
 import { IMessageSendStyle } from "@inkbox/sdk";
 
@@ -479,8 +485,10 @@ import { IMessageSendStyle } from "@inkbox/sdk";
 const sent = await identity.sendIMessage({ to: "+15551234567", text: "Hello over iMessage" });
 const dedicatedIdentity = await inkbox.createIdentity("dedicated-agent", {
   imessageEnabled: true,
+  contactSharingEnabled: false, // opt out before claiming the line
   claimIMessageNumber: true,
 });
+await dedicatedIdentity.update({ contactSharingEnabled: true }); // enable later
 const group = await dedicatedIdentity.sendIMessage({
   to: ["+15551234567", "+15557654321"],
   text: "Hello group",


### PR DESCRIPTION
## Executive Summary

Releases identity-level automatic iMessage contact-sharing controls across Python, TypeScript, Rust, CLI, and the bundled Claude plugin as version `0.6.1`.

## Description

Identity responses expose `contact_sharing_enabled`. Python and TypeScript create/update options forward it, the CLI exposes explicit enable/disable flags, and Rust provides update plus an additive `create_identity_with_contact_sharing_and_imessage_number` method for atomic dedicated-line opt-out without breaking the released `0.6.0` method signatures.

All release manifests, lockfiles, User-Agent constants, plugin metadata, and changelogs move in lockstep to `0.6.1`; the released `0.6.0` changelog entry remains unchanged.

## Decisions

- Keep the preference on the identity because it follows the agent between dedicated lines.
- Document the server default as enabled and use explicit `false` for opt-out.
- Add a new Rust method rather than changing a released positional signature.

## Testing

- Python focused identity suites: 45 passed; Ruff passed.
- TypeScript SDK: 1,076 passed, 3 skipped.
- CLI: 127 passed; TypeScript build passed.
- Rust: 249 tests passed; atomic create request coverage verifies `contact_sharing_enabled: false` is sent with the line claim.
- Release parity tests verify every package/plugin version and User-Agent constant is `0.6.1`.
