### PR TITLE
Add iMessage tapback removal to the SDKs and CLI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   `removeIMessageReaction(reactionId)`, Rust `remove_imessage_reaction`, and
   `inkbox imessage unreact <reaction-id> -i <handle>`. Pass the reaction id from
   the send result or from a message's live `reactions`. Only the sender can take
-  a tapback back. One Inkbox already shows as gone succeeds without contacting
+  a tapback back. A tapback Inkbox already shows as gone succeeds without contacting
   the messaging network, and a failed removal leaves the tapback in place rather
   than clearing it locally, so the call can be retried.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.2 — Undo an iMessage tapback
+
+### Added
+
+- Take back a tapback an agent sent, from every surface: Python
+  `remove_imessage_reaction(reaction_id)`, TypeScript
+  `removeIMessageReaction(reactionId)`, Rust `remove_imessage_reaction`, and
+  `inkbox imessage unreact <reaction-id> -i <handle>`. Pass the reaction id from
+  the send result or from a message's live `reactions`. Only the sender can take
+  a tapback back, and removing one that is already gone succeeds without doing
+  anything, so a retry after an error is always safe.
+
 ## 0.6.1 — Automatic iMessage contact sharing
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   `removeIMessageReaction(reactionId)`, Rust `remove_imessage_reaction`, and
   `inkbox imessage unreact <reaction-id> -i <handle>`. Pass the reaction id from
   the send result or from a message's live `reactions`. Only the sender can take
-  a tapback back, and removing one that is already gone succeeds without doing
-  anything, so a retry after an error is always safe.
+  a tapback back. One Inkbox already shows as gone succeeds without contacting
+  the messaging network, and a failed removal leaves the tapback in place rather
+  than clearing it locally, so the call can be retried.
 
 ## 0.6.1 — Automatic iMessage contact sharing
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.2 — Undo an iMessage tapback
+
+### Added
+
+- `inkbox imessage unreact <reaction-id> -i <handle>` takes back a tapback the
+  identity sent. Removing one that is already gone succeeds without doing
+  anything, so a retry after an error is always safe.
+- CLI and SDK dependency versions moved in lockstep to 0.6.2.
+
 ## 0.6.1 — Automatic iMessage contact sharing
 
 - Identity create and update accept `--contact-sharing-enabled true|false`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - `inkbox imessage unreact <reaction-id> -i <handle>` takes back a tapback the
-  identity sent. Removing one that is already gone succeeds without doing
-  anything, so a retry after an error is always safe.
+  identity sent. A failed removal leaves the tapback in place rather than
+  clearing it locally, so the call can be retried.
 - CLI and SDK dependency versions moved in lockstep to 0.6.2.
 
 ## 0.6.1 — Automatic iMessage contact sharing

--- a/cli/README.md
+++ b/cli/README.md
@@ -365,6 +365,8 @@ inkbox imessage react <message-id> -i <handle>  # React to an inbound 1:1 or gro
   --reaction <kind>                          #   love, like, dislike, laugh, emphasize, question, eyes
   --part-index <n>                           #   Part of a multi-part message (default: 0)
 
+inkbox imessage unreact <reaction-id> -i <handle>  # Take back a tapback this identity sent
+
 inkbox imessage mark-conversation-read <conversation-id> -i <handle>  # One-to-one only
 inkbox imessage typing <conversation-id> -i <handle>                  # One-to-one only
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.1",
+        "@inkbox/sdk": "^0.6.2",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.1",
+    "@inkbox/sdk": "^0.6.2",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.1";
+export const CLI_VERSION = "0.6.2";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/imessage.ts
+++ b/cli/src/commands/imessage.ts
@@ -502,6 +502,24 @@ export function registerIMessageCommands(program: Command): void {
     );
 
   imessage
+    .command("unreact <reaction-id>")
+    .description("Take back a tapback this identity sent")
+    .requiredOption("-i, --identity <handle>", "Agent identity handle")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        reactionId: string,
+        cmdOpts: { identity: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const identity = await inkbox.getIdentity(cmdOpts.identity);
+        await identity.removeIMessageReaction(reactionId);
+        output({ id: reactionId, removed: true }, { json: !!opts.json });
+      }),
+    );
+
+  imessage
     .command("mark-conversation-read <conversation-id>")
     .description("Send a one-to-one read receipt and mark inbound messages read")
     .requiredOption("-i, --identity <handle>", "Agent identity handle")

--- a/cli/tests/imessage-command.test.mjs
+++ b/cli/tests/imessage-command.test.mjs
@@ -29,6 +29,17 @@ test("iMessage reaction choices match the named outbound allowlist", () => {
   assert.equal(reactionOption?.mandatory, true);
 });
 
+test("iMessage unreact is registered and requires an identity", () => {
+  const program = new Command();
+  registerIMessageCommands(program);
+  const imessage = program.commands.find((command) => command.name() === "imessage");
+  const unreact = imessage?.commands.find((command) => command.name() === "unreact");
+  assert.ok(unreact, "unreact command is registered");
+  assert.equal(unreact?.registeredArguments?.[0]?.name(), "reaction-id");
+  const identity = unreact?.options.find((option) => option.long === "--identity");
+  assert.equal(identity?.mandatory, true);
+});
+
 test("buildIMessageSendOptions preserves a scalar recipient", () => {
   assert.deepEqual(buildIMessageSendOptions({
     identity: "support-bot",

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.2 — Undo an iMessage tapback
+
+### Added
+
+- `AgentIdentity.remove_imessage_reaction(reaction_id)` takes back a tapback the
+  identity sent. Removing one that is already gone succeeds without doing
+  anything, so a retry after an error is always safe.
+
 ## 0.6.1 — Automatic iMessage contact sharing
 
 - Identity create and update accept `contact_sharing_enabled`; dedicated lines

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - `AgentIdentity.remove_imessage_reaction(reaction_id)` takes back a tapback the
-  identity sent. Removing one that is already gone succeeds without doing
-  anything, so a retry after an error is always safe.
+  identity sent. A failed removal leaves the tapback in place rather than
+  clearing it locally, so the call can be retried.
 
 ## 0.6.1 — Automatic iMessage contact sharing
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -653,7 +653,11 @@ connections = identity.list_imessage_assignments()
 # named reactions include "eyes" ("custom" is rejected locally on send), and a
 # new tapback replaces your previous one on the same message part. Group read
 # receipts and typing indicators remain unsupported and return 409.
-identity.send_imessage_reaction(message_id=msgs[0].id, reaction="like")
+sent_reaction = identity.send_imessage_reaction(message_id=msgs[0].id, reaction="like")
+
+# Take your own tapback back. Only the sender can; a failed removal leaves it in
+# place rather than clearing it locally, so the call can be retried.
+identity.remove_imessage_reaction(sent_reaction.id)
 
 # Read receipts, typing indicator, media.
 identity.mark_imessage_conversation_read(convos[0].id)

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -1380,6 +1380,18 @@ class AgentIdentity:
             part_index=part_index,
         )
 
+    def remove_imessage_reaction(self, reaction_id: UUID | str) -> None:
+        """Take back a tapback this identity sent.
+
+        Removing a tapback that is already gone does nothing, and a failed
+        removal leaves it in place, so retrying is always safe.
+
+        Args:
+            reaction_id: UUID of the reaction to take back.
+        """
+        self._require_imessage()
+        self._inkbox._imessages.remove_reaction(reaction_id)
+
     def mark_imessage_conversation_read(
         self, conversation_id: UUID | str
     ) -> IMessageMarkReadResult:

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -1383,7 +1383,8 @@ class AgentIdentity:
     def remove_imessage_reaction(self, reaction_id: UUID | str) -> None:
         """Take back a tapback this identity sent.
 
-        A tapback Inkbox already shows as gone succeeds without contacting the
+        Only the sender can remove a tapback, so one the other party sent is
+        rejected. A tapback Inkbox already shows as gone succeeds without contacting the
         messaging network, and a failed removal leaves it in place rather than
         clearing it locally, so the call can be retried.
 

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -1383,8 +1383,9 @@ class AgentIdentity:
     def remove_imessage_reaction(self, reaction_id: UUID | str) -> None:
         """Take back a tapback this identity sent.
 
-        Removing a tapback that is already gone does nothing, and a failed
-        removal leaves it in place, so retrying is always safe.
+        A tapback Inkbox already shows as gone succeeds without contacting the
+        messaging network, and a failed removal leaves it in place rather than
+        clearing it locally, so the call can be retried.
 
         Args:
             reaction_id: UUID of the reaction to take back.

--- a/sdk/python/inkbox/imessage/resources/imessages.py
+++ b/sdk/python/inkbox/imessage/resources/imessages.py
@@ -363,10 +363,10 @@ class IMessagesResource:
         """Take back a tapback this agent sent.
 
         Only the sender can remove a tapback, so a reaction the other party
-        sent is rejected. Removing one that is already gone -- taken back
-        already, or replaced by a newer tapback -- succeeds and does nothing,
-        and a failed removal leaves the tapback in place, so retrying is
-        always safe.
+        sent is rejected. A tapback Inkbox already shows as gone -- taken back
+        already, or replaced by a newer one -- succeeds without contacting the
+        messaging network. A failed removal leaves the tapback in place rather
+        than clearing it locally, so the call can be retried.
 
         Args:
             reaction_id: UUID of the reaction to take back.

--- a/sdk/python/inkbox/imessage/resources/imessages.py
+++ b/sdk/python/inkbox/imessage/resources/imessages.py
@@ -359,6 +359,20 @@ class IMessagesResource:
         data = self._http.post("/reactions", json=body)
         return IMessageReaction._from_dict(data)
 
+    def remove_reaction(self, reaction_id: UUID | str) -> None:
+        """Take back a tapback this agent sent.
+
+        Only the sender can remove a tapback, so a reaction the other party
+        sent is rejected. Removing one that is already gone -- taken back
+        already, or replaced by a newer tapback -- succeeds and does nothing,
+        and a failed removal leaves the tapback in place, so retrying is
+        always safe.
+
+        Args:
+            reaction_id: UUID of the reaction to take back.
+        """
+        self._http.delete(f"/reactions/{reaction_id}")
+
     def mark_conversation_read(
         self,
         conversation_id: UUID | str,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.1"
+version = "0.6.2"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_imessage.py
+++ b/sdk/python/tests/test_imessage.py
@@ -26,6 +26,7 @@ CONVO_ID = "cccc1111-0000-0000-0000-000000000001"
 MSG_ID = "dddd4444-0000-0000-0000-000000000001"
 IDENTITY_ID = "eeee5555-0000-0000-0000-000000000001"
 RULE_ID = "ffff6666-0000-0000-0000-000000000001"
+REACTION_ID = "aaaa7777-0000-0000-0000-000000000001"
 REMOTE = "+15551234567"
 GROUP_REMOTE = "+15557654321"
 HANDLE = "support-bot"
@@ -122,7 +123,7 @@ GROUP_CONVERSATION_DICT = {
 }
 
 IMESSAGE_REACTION_DICT = {
-    "id": "aaaa7777-0000-0000-0000-000000000001",
+    "id": REACTION_ID,
     "conversation_id": CONVO_ID,
     "assignment_id": "bbbb2222-0000-0000-0000-000000000001",
     "target_message_id": MSG_ID,
@@ -453,6 +454,16 @@ class TestIMessageActions:
             client._imessages.send_reaction(message_id=MSG_ID, reaction=reaction)
 
         transport.post.assert_not_called()
+
+    def test_remove_reaction(self, client, transport):
+        client._imessages.remove_reaction(REACTION_ID)
+
+        transport.delete.assert_called_once_with(f"/reactions/{REACTION_ID}")
+
+    def test_remove_reaction_accepts_a_uuid_object(self, client, transport):
+        client._imessages.remove_reaction(UUID(REACTION_ID))
+
+        transport.delete.assert_called_once_with(f"/reactions/{REACTION_ID}")
 
     def test_mark_conversation_read(self, client, transport):
         transport.post.return_value = {

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -372,7 +372,10 @@ and changes the status to `Ready`.
 `send_imessage_reaction` supports inbound one-to-one and group messages by
 message id. The sendable named reactions are `love`, `like`, `dislike`,
 `laugh`, `emphasize`, `question`, and `eyes`; arbitrary custom emoji remain
-inbound-only. Group read receipts and typing indicators remain unsupported.
+inbound-only. `remove_imessage_reaction` takes back a tapback this identity
+sent, by reaction id; only the sender can, and a failed removal leaves it in
+place rather than clearing it locally, so the call can be retried. Group read
+receipts and typing indicators remain unsupported.
 
 Static (no-client) helpers for the public agent-signup flow live on `Inkbox`:
 `Inkbox::signup`, `verify_signup`, `resend_signup_verification`,

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1322,6 +1322,18 @@ impl AgentIdentity {
             .send_reaction(message_id, reaction, part_index)
     }
 
+    /// Take back a tapback this identity sent.
+    ///
+    /// Removing a tapback that is already gone does nothing, and a failed
+    /// removal leaves it in place, so retrying is always safe.
+    ///
+    /// # Arguments
+    /// * `reaction_id` - UUID of the reaction to take back.
+    pub fn remove_imessage_reaction(&self, reaction_id: &Uuid) -> Result<()> {
+        self.require_imessage()?;
+        self.inkbox.imessages().remove_reaction(reaction_id)
+    }
+
     /// Send a one-to-one read receipt and mark inbound messages read.
     /// Group conversations return 409.
     pub fn mark_imessage_conversation_read(

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1324,8 +1324,9 @@ impl AgentIdentity {
 
     /// Take back a tapback this identity sent.
     ///
-    /// Removing a tapback that is already gone does nothing, and a failed
-    /// removal leaves it in place, so retrying is always safe.
+    /// A tapback Inkbox already shows as gone succeeds without contacting the
+    /// messaging network, and a failed removal leaves it in place rather than
+    /// clearing it locally, so the call can be retried.
     ///
     /// # Arguments
     /// * `reaction_id` - UUID of the reaction to take back.

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1324,9 +1324,10 @@ impl AgentIdentity {
 
     /// Take back a tapback this identity sent.
     ///
-    /// A tapback Inkbox already shows as gone succeeds without contacting the
-    /// messaging network, and a failed removal leaves it in place rather than
-    /// clearing it locally, so the call can be retried.
+    /// Only the sender can remove a tapback, so one the other party sent is
+    /// rejected. A tapback Inkbox already shows as gone succeeds without
+    /// contacting the messaging network, and a failed removal leaves it in
+    /// place rather than clearing it locally, so the call can be retried.
     ///
     /// # Arguments
     /// * `reaction_id` - UUID of the reaction to take back.

--- a/sdk/rust/src/imessage/resources/imessages.rs
+++ b/sdk/rust/src/imessage/resources/imessages.rs
@@ -488,10 +488,10 @@ impl IMessagesResource {
     /// Take back a tapback this agent sent.
     ///
     /// Only the sender can remove a tapback, so a reaction the other party
-    /// sent is rejected. Removing one that is already gone -- taken back
-    /// already, or replaced by a newer tapback -- succeeds and does nothing,
-    /// and a failed removal leaves the tapback in place, so retrying is
-    /// always safe.
+    /// sent is rejected. A tapback Inkbox already shows as gone -- taken back
+    /// already, or replaced by a newer one -- succeeds without contacting the
+    /// messaging network. A failed removal leaves the tapback in place rather
+    /// than clearing it locally, so the call can be retried.
     ///
     /// # Arguments
     /// * `reaction_id` - UUID of the reaction to take back.

--- a/sdk/rust/src/imessage/resources/imessages.rs
+++ b/sdk/rust/src/imessage/resources/imessages.rs
@@ -485,6 +485,20 @@ impl IMessagesResource {
         Ok(serde_json::from_value(data)?)
     }
 
+    /// Take back a tapback this agent sent.
+    ///
+    /// Only the sender can remove a tapback, so a reaction the other party
+    /// sent is rejected. Removing one that is already gone -- taken back
+    /// already, or replaced by a newer tapback -- succeeds and does nothing,
+    /// and a failed removal leaves the tapback in place, so retrying is
+    /// always safe.
+    ///
+    /// # Arguments
+    /// * `reaction_id` - UUID of the reaction to take back.
+    pub fn remove_reaction(&self, reaction_id: &Uuid) -> Result<()> {
+        self.http.delete(&format!("/reactions/{reaction_id}"))
+    }
+
     /// Send a one-to-one read receipt and mark inbound messages read locally.
     /// Group conversations return 409.
     ///
@@ -902,6 +916,24 @@ mod tests {
         mock.assert();
         assert_eq!(reaction.assignment_id, None);
         assert_eq!(reaction.reaction, IMessageReactionType::Eyes);
+    }
+
+    #[test]
+    fn remove_reaction_deletes_the_reaction_by_id() {
+        let server = MockServer::start();
+        let reaction_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let mock = server.mock(|when, then| {
+            when.method(DELETE)
+                .path(format!("/api/v1/imessage/reactions/{reaction_id}"));
+            then.status(204);
+        });
+
+        client(&server)
+            .imessages()
+            .remove_reaction(&reaction_id)
+            .unwrap();
+
+        mock.assert();
     }
 
     #[test]

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.2 — Undo an iMessage tapback
+
+### Added
+
+- `AgentIdentity.removeIMessageReaction(reactionId)` takes back a tapback the
+  identity sent. Removing one that is already gone succeeds without doing
+  anything, so a retry after an error is always safe.
+
 ## 0.6.1 — Automatic iMessage contact sharing
 
 - Identity create and update accept `contactSharingEnabled`; dedicated lines

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - `AgentIdentity.removeIMessageReaction(reactionId)` takes back a tapback the
-  identity sent. Removing one that is already gone succeeds without doing
-  anything, so a retry after an error is always safe.
+  identity sent. A failed removal leaves the tapback in place rather than
+  clearing it locally, so the call can be retried.
 
 ## 0.6.1 — Automatic iMessage contact sharing
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -636,7 +636,11 @@ const connections = await identity.listIMessageAssignments();
 // named reactions include "eyes" ("custom" is rejected locally on send), and a
 // new tapback replaces your previous one on the same message part. Group read
 // receipts and typing indicators remain unsupported and return 409.
-await identity.sendIMessageReaction({ messageId: msgs[0].id, reaction: "like" });
+const sentReaction = await identity.sendIMessageReaction({ messageId: msgs[0].id, reaction: "like" });
+
+// Take your own tapback back. Only the sender can; a failed removal leaves it in
+// place rather than clearing it locally, so the call can be retried.
+await identity.removeIMessageReaction(sentReaction.id);
 
 // Read receipts, typing indicator, media.
 await identity.markIMessageConversationRead(convos[0].id);

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -1047,6 +1047,19 @@ export class AgentIdentity {
   }
 
   /**
+   * Take back a tapback this identity sent.
+   *
+   * Removing a tapback that is already gone does nothing, and a failed
+   * removal leaves it in place, so retrying is always safe.
+   *
+   * @param reactionId - UUID of the reaction to take back.
+   */
+  async removeIMessageReaction(reactionId: string): Promise<void> {
+    this._requireIMessage();
+    await this._inkbox._imessages.removeReaction(reactionId);
+  }
+
+  /**
    * Send a one-to-one read receipt and mark inbound messages read.
    * Group conversations return 409.
    *

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -1049,8 +1049,9 @@ export class AgentIdentity {
   /**
    * Take back a tapback this identity sent.
    *
-   * A tapback Inkbox already shows as gone succeeds without contacting the
-   * messaging network, and a failed removal leaves it in place rather than
+   * Only the sender can remove a tapback, so one the other party sent is
+   * rejected. A tapback Inkbox already shows as gone succeeds without contacting
+   * the messaging network, and a failed removal leaves it in place rather than
    * clearing it locally, so the call can be retried.
    *
    * @param reactionId - UUID of the reaction to take back.

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -1049,8 +1049,9 @@ export class AgentIdentity {
   /**
    * Take back a tapback this identity sent.
    *
-   * Removing a tapback that is already gone does nothing, and a failed
-   * removal leaves it in place, so retrying is always safe.
+   * A tapback Inkbox already shows as gone succeeds without contacting the
+   * messaging network, and a failed removal leaves it in place rather than
+   * clearing it locally, so the call can be retried.
    *
    * @param reactionId - UUID of the reaction to take back.
    */

--- a/sdk/typescript/src/imessage/resources/imessages.ts
+++ b/sdk/typescript/src/imessage/resources/imessages.ts
@@ -365,9 +365,10 @@ export class IMessagesResource {
    * Take back a tapback this agent sent.
    *
    * Only the sender can remove a tapback, so a reaction the other party sent
-   * is rejected. Removing one that is already gone — taken back already, or
-   * replaced by a newer tapback — succeeds and does nothing, and a failed
-   * removal leaves the tapback in place, so retrying is always safe.
+   * is rejected. A tapback Inkbox already shows as gone — taken back already,
+   * or replaced by a newer one — succeeds without contacting the messaging
+   * network. A failed removal leaves the tapback in place rather than clearing
+   * it locally, so the call can be retried.
    *
    * @param reactionId - UUID of the reaction to take back.
    */

--- a/sdk/typescript/src/imessage/resources/imessages.ts
+++ b/sdk/typescript/src/imessage/resources/imessages.ts
@@ -362,6 +362,20 @@ export class IMessagesResource {
   }
 
   /**
+   * Take back a tapback this agent sent.
+   *
+   * Only the sender can remove a tapback, so a reaction the other party sent
+   * is rejected. Removing one that is already gone — taken back already, or
+   * replaced by a newer tapback — succeeds and does nothing, and a failed
+   * removal leaves the tapback in place, so retrying is always safe.
+   *
+   * @param reactionId - UUID of the reaction to take back.
+   */
+  async removeReaction(reactionId: string): Promise<void> {
+    await this.http.delete(`/reactions/${reactionId}`);
+  }
+
+  /**
    * Send a one-to-one read receipt and mark inbound messages read locally.
    * Group conversations return 409.
    *

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.1";
+export const VERSION = "0.6.2";

--- a/sdk/typescript/tests/imessage.test.ts
+++ b/sdk/typescript/tests/imessage.test.ts
@@ -106,8 +106,9 @@ const GROUP_CONVERSATION_DICT = {
   group_creation_status: "creating",
 };
 
+const REACTION_ID = "aaaa7777-0000-0000-0000-000000000001";
 const REACTION_DICT = {
-  id: "aaaa7777-0000-0000-0000-000000000001",
+  id: REACTION_ID,
   conversation_id: CONVO_ID,
   assignment_id: "bbbb2222-0000-0000-0000-000000000001",
   target_message_id: MSG_ID,
@@ -472,6 +473,24 @@ describe("IMessagesResource", () => {
     });
     expect(reaction.assignmentId).toBeNull();
     expect(reaction.reaction).toBe(IMessageReactionType.EYES);
+  });
+
+  it("removeReaction deletes the reaction by id", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      headers: { get() { return null; }, getSetCookie() { return []; } } as unknown as Headers,
+      json: () => Promise.resolve(undefined),
+    } as Response);
+    const resource = new IMessagesResource(new HttpTransport("k", BASE));
+
+    await resource.removeReaction(REACTION_ID);
+
+    const { url, init } = lastCall();
+    expect(url).toBe(`${BASE}/reactions/${REACTION_ID}`);
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
   });
 
   it.each([IMessageReactionType.CUSTOM, "\u{1F440}"])(

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -364,6 +364,7 @@ inkbox imessage assignments -i <handle> --limit 20   # active connections, newes
 inkbox imessage conversations -i <handle> --limit 20 --include-groups
 inkbox imessage conversation <conversation-id> -i <handle> --limit 50
 inkbox imessage react <message-id> -i <handle> --reaction like
+inkbox imessage unreact <reaction-id> -i <handle>   # take your own tapback back
 inkbox imessage mark-conversation-read <conversation-id> -i <handle>
 inkbox imessage typing <conversation-id> -i <handle>
 inkbox imessage upload-media ./photo.jpg -i <handle> --content-type image/jpeg
@@ -381,7 +382,11 @@ Group conversation output includes `groupCreationStatus` (`creating`,
 conversation; send again by conversation id to retry. `react` supports inbound
 one-to-one and group messages. Its named choices are `love`, `like`, `dislike`,
 `laugh`, `emphasize`, `question`, and `eyes`; arbitrary custom emoji are
-inbound-only. Read receipts and typing remain one-to-one only.
+inbound-only. `unreact` takes back a tapback this identity sent, addressed by
+the reaction id from `react` or from a message's live `reactions`; only the
+sender can, and removing one that is already gone succeeds without doing
+anything, so retrying after an error is safe. Read receipts and typing remain
+one-to-one only.
 Group creation and conversation-id replies accept the same 13 expressive styles
 as one-to-one sends, with or without `--media-url`.
 

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -384,8 +384,8 @@ one-to-one and group messages. Its named choices are `love`, `like`, `dislike`,
 `laugh`, `emphasize`, `question`, and `eyes`; arbitrary custom emoji are
 inbound-only. `unreact` takes back a tapback this identity sent, addressed by
 the reaction id from `react` or from a message's live `reactions`; only the
-sender can, and removing one that is already gone succeeds without doing
-anything, so retrying after an error is safe. Read receipts and typing remain
+sender can. A failed removal leaves the tapback in place rather than clearing it
+locally, so the call can be retried. Read receipts and typing remain
 one-to-one only.
 Group creation and conversation-id replies accept the same 13 expressive styles
 as one-to-one sends, with or without `--media-url`.

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -550,11 +550,15 @@ for a in connections:
 # accept seven named reactions (love, like, dislike, laugh, emphasize,
 # question, eyes); inbound can also be "custom" with the literal emoji in
 # custom_emoji. Arbitrary custom emoji are not sendable.
-identity.send_imessage_reaction(message_id=msgs[0].id, reaction="like")
+sent_reaction = identity.send_imessage_reaction(message_id=msgs[0].id, reaction="like")
 
 # Live tapbacks come back on message reads, oldest first.
 for r in msgs[0].reactions or []:
     print(r.direction, r.reaction, r.custom_emoji)
+
+# Take your own tapback back. Only the sender can; removing one that is already
+# gone does nothing, so retrying after an error is safe.
+identity.remove_imessage_reaction(sent_reaction.id)
 
 # Read receipts + typing indicator are one-to-one only; groups return 409.
 identity.mark_imessage_conversation_read(sent.conversation_id)

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -556,8 +556,8 @@ sent_reaction = identity.send_imessage_reaction(message_id=msgs[0].id, reaction=
 for r in msgs[0].reactions or []:
     print(r.direction, r.reaction, r.custom_emoji)
 
-# Take your own tapback back. Only the sender can; removing one that is already
-# gone does nothing, so retrying after an error is safe.
+# Take your own tapback back. Only the sender can. A failed removal leaves the
+# tapback in place rather than clearing it locally, so the call can be retried.
 identity.remove_imessage_reaction(sent_reaction.id)
 
 # Read receipts + typing indicator are one-to-one only; groups return 409.

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -528,12 +528,16 @@ for (const a of connections) {
 // accept seven named reactions (love, like, dislike, laugh, emphasize,
 // question, eyes); inbound can also be "custom" with the literal emoji in
 // customEmoji. Arbitrary custom emoji are not sendable.
-await identity.sendIMessageReaction({ messageId: msgs[0].id, reaction: "like" });
+const sentReaction = await identity.sendIMessageReaction({ messageId: msgs[0].id, reaction: "like" });
 
 // Live tapbacks come back on message reads, oldest first.
 for (const r of msgs[0].reactions ?? []) {
   console.log(r.direction, r.reaction, r.customEmoji);
 }
+
+// Take your own tapback back. Only the sender can; removing one that is already
+// gone does nothing, so retrying after an error is safe.
+await identity.removeIMessageReaction(sentReaction.id);
 
 // Read receipts + typing indicator are one-to-one only; groups return 409.
 await identity.markIMessageConversationRead(sent.conversationId);

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -535,8 +535,8 @@ for (const r of msgs[0].reactions ?? []) {
   console.log(r.direction, r.reaction, r.customEmoji);
 }
 
-// Take your own tapback back. Only the sender can; removing one that is already
-// gone does nothing, so retrying after an error is safe.
+// Take your own tapback back. Only the sender can. A failed removal leaves the
+// tapback in place rather than clearing it locally, so the call can be retried.
 await identity.removeIMessageReaction(sentReaction.id);
 
 // Read receipts + typing indicator are one-to-one only; groups return 409.


### PR DESCRIPTION
## Summary

Agents could send an iMessage tapback but never take one back. This adds removal to every surface, addressed by the reaction id that the send result and message reads already carry.

| Surface | Call |
|---|---|
| Python | `identity.remove_imessage_reaction(reaction_id)` |
| TypeScript | `await identity.removeIMessageReaction(reactionId)` |
| Rust | `identity.remove_imessage_reaction(&reaction_id)?` |
| CLI | `inkbox imessage unreact <reaction-id> -i <handle>` |

Each delegates to a new `remove_reaction` / `removeReaction` on the iMessage resource.

Two behaviors worth knowing, and the docstrings say both:

- **Only the sender can take a tapback back.** A reaction the other party sent is rejected.
- **A tapback Inkbox already shows as gone succeeds without contacting the messaging network** — whether you took it back already or a newer tapback replaced it. There is no "already removed" error to handle.
- **A failed removal leaves the tapback in place rather than clearing it locally**, so the call can be retried. Note what is *not* claimed: the retry re-issues the removal, and how the messaging network treats a removal for a tapback it has already dropped is not something the wording promises. An unconfirmed failure can therefore leave a reaction reading as live until a retry succeeds.

## Version

0.6.1 → **0.6.2**, in lockstep across `sdk/python/pyproject.toml`, `sdk/typescript/package.json`, `sdk/rust/Cargo.toml`, `cli/package.json`, and `.claude-plugin/plugin.json` — plus the two User-Agent constants (`sdk/typescript/src/version.ts`, `cli/src/client.ts`), the CLI's `@inkbox/sdk` dependency range, and all four lockfiles. Changelog entries are in `CHANGELOG.md` and the three per-package logs.

Additive only: no existing signature, argument, or return type changes.

## Skills

`inkbox-python`, `inkbox-ts`, and `inkbox-cli` now show the removal alongside the send in their tapback sections, including the retry-safety note. The Python and TypeScript samples bind the send result so the id has an obvious source.

## Testing

- **Python** — `uv run pytest`: 1066 passed, 3 skipped. New cases cover the `DELETE` path and a `UUID` argument alongside a string.
- **TypeScript** — `npx vitest run`: 77 files, 1077 passed, 3 skipped. New case asserts the method, URL, and that no body is sent.
- **Rust** — `cargo test`: all pass, including a new mocked 204 removal. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- **CLI** — `npx tsc --noEmit` clean after rebuilding the TypeScript SDK, and `inkbox imessage unreact --help` renders the command. (The CLI resolves types through a symlink to `sdk/typescript/dist`, so a stale local build reports errors for this branch *and* for #154's `contactSharingEnabled` until you run `npm run build` in `sdk/typescript`.)

To try it against a live identity with iMessage enabled and a contact who has messaged first:

```bash
inkbox imessage react <inbound-message-id> -i <handle> --reaction like
inkbox imessage unreact <reaction-id> -i <handle>
```

The tapback appears and then clears on the recipient's device, and it drops out of the message's `reactions` on the next read. Running `unreact` a second time returns success without sending anything, since the reaction already reads as removed.

## Requires

The removal endpoint must be live in the target environment. Against an older deployment these calls return 404.




## Review follow-ups

- **Package READMEs updated.** They are what PyPI, npm, and crates.io render, and they still described tapbacks as send-only. All four tapback sections now show removal, and the CLI command list gains `inkbox imessage unreact <reaction-id> -i <handle>`.
- **Garbled release-note sentence fixed** in the root `CHANGELOG.md`.
- **`unreact` now has a registration test** alongside the existing `react` one, pinning the `reaction-id` argument and the required identity flag.
- **Identity-level docstrings carry the sender-only clause**, since that is the 422 callers will actually hit and the identity method is the one they use.

Left as-is: `inkbox imessage unreact` prints `{ id, removed }` while the MCP tool returns `{ reaction_id, removed }`. The CLI is internally consistent (`react` prints `id`), so changing it would be the odd one out.
