### PR TITLE
`0.6.4`: Retry connection setup in the Python SDK

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.4 — Retry connection setup
+
+### Changed
+
+- The Python SDK now retries connection setup before giving up, so a connection
+  that is reset or dropped while it is still being established no longer
+  surfaces as an immediate error. Only connection setup is retried; a request
+  that has already been sent is never resent, so this is safe for every method.
+- Applies to the main API client, the one-shot `Inkbox.signup` request, and the
+  A2A client. The tunnel runtime is unchanged and keeps its own reconnect
+  handling.
+
+### Compatibility
+
+- No API changes. Callers that already handle `httpx.ConnectError` keep working;
+  it is simply raised less often.
+
 ## 0.6.3 — Incoming call forwarding
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.3",
+        "@inkbox/sdk": "^0.6.4",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.3",
+    "@inkbox/sdk": "^0.6.4",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.3";
+export const CLI_VERSION = "0.6.4";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/sdk/python/inkbox/_http.py
+++ b/sdk/python/inkbox/_http.py
@@ -26,6 +26,8 @@ from inkbox.exceptions import (
 from inkbox.error_guidance import parse_agent_support
 
 _DEFAULT_TIMEOUT = 30.0
+# Retries connection setup only; the request has not been sent yet, so any method is safe.
+CONNECT_RETRIES = 2
 
 
 def _sdk_version() -> str:
@@ -61,6 +63,7 @@ class HttpTransport:
             base_url=base_url,
             headers=headers,
             timeout=timeout,
+            transport=httpx.HTTPTransport(retries=CONNECT_RETRIES),
         )
         self._cookie_jar = cookie_jar or CookieJar()
 

--- a/sdk/python/inkbox/a2a/client.py
+++ b/sdk/python/inkbox/a2a/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
+from inkbox._http import CONNECT_RETRIES
 from inkbox.a2a.types import (
     A2ACard,
     A2AResolvedTarget,
@@ -64,7 +65,11 @@ class A2AClient:
     ) -> None:
         self._api_key = api_key
         self._platform_origin = _origin(platform_base_url)
-        self._client = httpx.Client(timeout=timeout, follow_redirects=False)
+        self._client = httpx.Client(
+            timeout=timeout,
+            follow_redirects=False,
+            transport=httpx.HTTPTransport(retries=CONNECT_RETRIES),
+        )
         self._next_id = 0
 
     def close(self) -> None:

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 import httpx
 
-from inkbox._http import HttpTransport, sdk_user_agent
+from inkbox._http import CONNECT_RETRIES, HttpTransport, sdk_user_agent
 from inkbox._config import resolve_client_settings
 from inkbox._cookies import CookieJar
 from inkbox.a2a.resource import A2AResource
@@ -635,7 +635,10 @@ class Inkbox:
         if api_key:
             headers["X-API-Key"] = api_key
 
-        with httpx.Client(timeout=timeout) as client:
+        with httpx.Client(
+            timeout=timeout,
+            transport=httpx.HTTPTransport(retries=CONNECT_RETRIES),
+        ) as client:
             resp = client.request(method, url, headers=headers, json=json)
 
         if resp.status_code >= 400:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.3"
+version = "0.6.4"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_http_connect_retries.py
+++ b/sdk/python/tests/test_http_connect_retries.py
@@ -1,0 +1,69 @@
+"""
+sdk/python/tests/test_http_connect_retries.py
+
+The SDK's httpx clients must retry connection setup; httpx does not by default.
+"""
+
+from unittest.mock import patch
+
+import httpx
+
+from inkbox import Inkbox
+from inkbox._http import CONNECT_RETRIES, HttpTransport
+from inkbox.a2a.client import A2AClient
+
+
+def _captured_retries(build) -> list[int]:
+    real = httpx.HTTPTransport
+    seen: list[int] = []
+
+    def _record(*args, **kwargs):
+        seen.append(kwargs.get("retries", 0))
+        return real(*args, **kwargs)
+
+    with patch("httpx.HTTPTransport", side_effect=_record):
+        build()
+    return seen
+
+
+class TestConnectRetries:
+    def test_connect_retries_is_positive(self):
+        assert CONNECT_RETRIES > 0
+
+    def test_api_transport_retries_connection_setup(self):
+        seen = _captured_retries(
+            lambda: HttpTransport(api_key="sk-test", base_url="https://example.invalid")
+        )
+
+        assert seen == [CONNECT_RETRIES]
+
+    def test_a2a_client_retries_connection_setup(self):
+        seen = _captured_retries(
+            lambda: A2AClient(api_key="sk-test", platform_base_url="https://example.invalid")
+        )
+
+        assert seen == [CONNECT_RETRIES]
+
+    def test_one_shot_request_retries_connection_setup(self):
+        # `Inkbox.signup` runs through the one-shot helper, which builds its own
+        # client rather than reusing HttpTransport.
+        seen = _captured_retries(
+            lambda: _swallow_connect_error(
+                lambda: Inkbox._one_shot_request(
+                    "POST",
+                    "/api/v1/agent-signup/",
+                    json={},
+                    base_url="https://127.0.0.1:1",
+                    timeout=0.01,
+                )
+            )
+        )
+
+        assert seen == [CONNECT_RETRIES]
+
+
+def _swallow_connect_error(call) -> None:
+    try:
+        call()
+    except httpx.HTTPError:
+        pass

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.3";
+export const VERSION = "0.6.4";

--- a/tests/integration/python/test_sdk_signup.py
+++ b/tests/integration/python/test_sdk_signup.py
@@ -6,6 +6,7 @@ Live agent-signup coverage for the Python SDK.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import httpx
@@ -15,15 +16,24 @@ from conftest import SdkIntegrationContext, log_step
 from inkbox import Inkbox
 
 
-def _approve_all_pending(jwt_client: httpx.Client, org_id: str) -> None:
-    """Claim every unclaimed agent linked to the pooled human, freeing the cap.
+# The signup human is shared, so this list can also hold an agent that a
+# concurrently running suite created moments ago. Only agents older than this
+# count as leftovers worth claiming.
+_LEFTOVER_MIN_AGE = timedelta(minutes=10)
+
+
+def _approve_stale_pending(jwt_client: httpx.Client, org_id: str) -> None:
+    """Claim leftover unclaimed agents linked to the signup human, freeing the cap.
 
     Best-effort: a leftover that won't approve is skipped, since freeing even
     one slot is enough for the subsequent signup to succeed.
     """
+    cutoff = datetime.now(timezone.utc) - _LEFTOVER_MIN_AGE
     resp = jwt_client.get("/agent-signup/pending")
     resp.raise_for_status()
     for agent in resp.json().get("agents", []):
+        if datetime.fromisoformat(agent["created_at"]) > cutoff:
+            continue
         try:
             jwt_client.post(
                 f"/agent-signup/{agent['identity_id']}/approve",
@@ -67,11 +77,11 @@ def test_python_sdk_signup_accepts_custom_handle_and_email_local_part(
         headers={"Authorization": f"Bearer {jwt}"},
         timeout=cfg.http_timeout,
     ) as jwt_client:
-        # The bootstrap human is a shared pooled creator, so unclaimed agents
-        # leaked by earlier failed runs accumulate against a per-email cap and
-        # would 429 this signup. Claim any leftovers first to free the cap.
-        log_step(ctx, "drain leftover unclaimed agents for the pooled human")
-        _approve_all_pending(jwt_client, ctx.bootstrap.org_id)
+        # The signup human is shared, so unclaimed agents leaked by earlier
+        # failed runs accumulate against a per-email cap and would 429 this
+        # signup. Claim those leftovers first to free the cap.
+        log_step(ctx, "drain stale unclaimed agents for the signup human")
+        _approve_stale_pending(jwt_client, ctx.bootstrap.org_id)
 
         log_step(ctx, "sign up agent with explicit handle and email local part")
         signup = Inkbox.signup(

--- a/tests/integration/typescript/sdk_signup.test.ts
+++ b/tests/integration/typescript/sdk_signup.test.ts
@@ -12,10 +12,15 @@ import {
   type BootstrapResult,
 } from "./helpers.js";
 
-// Approve (claim) every unclaimed agent currently linked to the pooled human,
-// dropping its per-email unclaimed count to zero. Best-effort: a leftover that
-// won't approve is skipped, since freeing even one slot is enough to sign up.
-async function approveAllPending(
+// The signup human is shared, so the pending list can also hold an agent that a
+// concurrently running suite created moments ago. Only agents older than this
+// count as leftovers worth claiming.
+const LEFTOVER_MIN_AGE_MS = 10 * 60 * 1000;
+
+// Approve (claim) leftover unclaimed agents linked to the signup human, freeing
+// its per-email unclaimed count. Best-effort: a leftover that won't approve is
+// skipped, since freeing even one slot is enough to sign up.
+async function approveStalePending(
   apiUrl: string,
   authHeaders: Record<string, string>,
   orgId: string,
@@ -23,7 +28,9 @@ async function approveAllPending(
   const resp = await fetch(`${apiUrl}/agent-signup/pending`, { headers: authHeaders });
   if (!resp.ok) return;
   const { agents } = await resp.json();
+  const cutoff = Date.now() - LEFTOVER_MIN_AGE_MS;
   for (const agent of agents ?? []) {
+    if (Date.parse(agent.created_at) > cutoff) continue;
     try {
       await fetch(`${apiUrl}/agent-signup/${agent.identity_id}/approve`, {
         method: "POST",
@@ -76,11 +83,11 @@ describe("TypeScript SDK signup", { timeout: 300_000 }, () => {
     const jwt = (await jwtResp.json()).jwt as string;
     const authHeaders = { Authorization: `Bearer ${jwt}` };
 
-    // The bootstrap human is a shared pooled creator, so unclaimed agents
-    // leaked by earlier failed runs accumulate against a per-email cap and
-    // would 429 this signup. Claim any leftovers first to free the cap.
-    logStep(config, "drain leftover unclaimed agents for the pooled human");
-    await approveAllPending(apiUrl, authHeaders, bootstrap.orgId);
+    // The signup human is shared, so unclaimed agents leaked by earlier failed
+    // runs accumulate against a per-email cap and would 429 this signup. Claim
+    // those leftovers first to free the cap.
+    logStep(config, "drain stale unclaimed agents for the signup human");
+    await approveStalePending(apiUrl, authHeaders, bootstrap.orgId);
 
     logStep(config, "sign up agent with explicit handle and email local part");
     const signup = await Inkbox.signup(


### PR DESCRIPTION
## Summary

Two changes, plus the 0.6.4 lockstep bump.

**1. The Python SDK now retries connection setup.**

`httpx` retries connection establishment zero times unless you hand it a
transport that says otherwise. Every SDK client was built without one, so a
connection that was reset or dropped while the TCP/TLS connection was still
being established surfaced straight to the caller as `httpx.ConnectError`, with
no second attempt. That is a poor default for a network client: the request has
not been sent at that point, so retrying is safe for every method, including
`POST` and `DELETE`.

All three request/response clients now pass
`transport=httpx.HTTPTransport(retries=CONNECT_RETRIES)`:

- `HttpTransport` in `sdk/python/inkbox/_http.py`, shared by every resource package
- the one-shot helper in `sdk/python/inkbox/client.py` behind `Inkbox.signup`
- `A2AClient` in `sdk/python/inkbox/a2a/client.py`

The tunnel runtime is deliberately untouched. Its `httpx.AsyncClient` instances
sit behind their own reconnect handling, and layering transport retries under
that would blur which layer owns a retry.

**2. The signup integration suites only drain stale leftovers.**

`test_sdk_signup.py` and `sdk_signup.test.ts` each claim leftover unclaimed
agents before signing up, so earlier failed runs cannot push the signup human
over its per-email unclaimed cap and 429 the test. The helper claimed
*everything* pending, and the signup human is shared, so when the Python and
TypeScript suites overlapped, one suite could claim the agent the other had
created a moment earlier. The victim's own `GET /agent-signup/pending` lookup
then found nothing and the test died on a missing-agent error.

Both helpers now skip anything created within the last 10 minutes, using the
`created_at` already present on the pending response. A genuine leftover from a
previous run is always older than that; a concurrent suite's agent never is.
Observed signup-to-approve time is a few seconds, so 10 minutes is far outside
any plausible in-flight window.

Trade-off worth a reviewer's eye: leftovers now survive until the next run
instead of being cleared immediately. A failed run leaves at most one leftover
per suite, and the cap allows three, so this only bites if two runs fail within
ten minutes of each other. That case self-heals on the following run, and I
would rather have that than suites claiming each other's agents.

## Testing

- `sdk/python/tests/test_http_connect_retries.py` (new, 4 tests): asserts each of
  the three clients constructs its transport with a positive retry count, by
  capturing the `httpx.HTTPTransport` kwargs rather than reaching into httpx
  internals. All 4 pass.
- `cd sdk/python && uv run pytest` — 1081 passed, 3 skipped.
- `cd sdk/typescript && npx vitest run` — 1085 passed, 3 skipped, 77 files. This
  covers `version.ts` staying in step with `package.json`.
- `uv run ruff check` clean on every changed Python file.
- `tsc --noEmit` clean on `tests/integration/typescript/sdk_signup.test.ts`. Note
  that `sdk_lifecycle.test.ts` has a pre-existing `UpdateDraftOptions.recipients`
  type error on `main`, untouched here.
- Not run locally: the live SDK integration suites, which need a deployed
  environment. The age gate is exercised the first time those suites run
  concurrently.

## Version

0.6.3 to 0.6.4, patch, in lockstep across `sdk/python/pyproject.toml` (+ `uv.lock`),
`sdk/typescript/package.json` (+ `package-lock.json`, `src/version.ts`),
`cli/package.json` (+ `package-lock.json`, the `@inkbox/sdk` range, `src/client.ts`),
`sdk/rust/Cargo.toml` (+ `Cargo.lock`), and `.claude-plugin/plugin.json`.
`CHANGELOG.md` carries the 0.6.4 entry.

## Compatibility

Backwards compatible. No API surface changes. Callers that already catch
`httpx.ConnectError` keep working, they just see it less often. Worst case a
failing connection now takes up to three connection attempts before raising
instead of one, bounded by the client timeout.

## Follow-up

The TypeScript and Rust SDKs do not have the equivalent retry yet, so this is a
Python-only behavior change for now. Rust can match it cleanly because `reqwest`
exposes `Error::is_connect()`. TypeScript is the awkward one: `fetch` rejects
with an opaque `TypeError` that does not distinguish "never connected" from
"sent, then failed", so a safe implementation needs an explicit decision about
which methods may be retried. Worth doing as its own PR rather than guessing here.
