### PR TITLE
`0.6.5`: Add identity onboarding skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inkbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Inkbox communication tools and SDK skills.",
   "author": {
     "name": "Inkbox AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.5 — Identity onboarding skill
+
+### Added
+
+- A language-agnostic `inkbox-onboarding` skill guides agents through inspecting
+  an existing identity, checking email, SMS, voice, and iMessage readiness,
+  completing recipient consent, choosing inbound handling, and offering bounded
+  recurring triage. It includes API, CLI, Python, and TypeScript examples while
+  keeping channel-specific reference material in the existing skills.
+
+### Compatibility
+
+- No API, SDK, or CLI behavior changes. This release updates bundled guidance
+  only.
+
 ## 0.6.4 — Retry connection setup
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ bilateral A2A contact rules needed for the invited peer bundle.
 | [`cli/`](./cli/) | CLI (`@inkbox/cli`) |
 | [`skills/inkbox-python/`](./skills/inkbox-python/) | Python agent skill for Claude Code and other coding agents |
 | [`skills/inkbox-ts/`](./skills/inkbox-ts/) | TypeScript agent skill for Claude Code and other coding agents |
+| [`skills/inkbox-onboarding/`](./skills/inkbox-onboarding/) | Language-agnostic identity and channel onboarding skill |
 | [`skills/inkbox-tunnels/`](./skills/inkbox-tunnels/) | Tunnels skill — bring a local server online at a public Inkbox URL |
 | [`examples/use-inkbox-browser-use/`](./examples/use-inkbox-browser-use/) | Inkbox + Browser Use — give your agent an email, phone, and vault |
 | [`examples/use-inkbox-kernel/`](./examples/use-inkbox-kernel/) | Inkbox + Kernel — give your agent an email and browser |

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.4",
+        "@inkbox/sdk": "^0.6.5",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.4",
+    "@inkbox/sdk": "^0.6.5",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.4";
+export const CLI_VERSION = "0.6.5";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.4"
+version = "0.6.5"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.4";
+export const VERSION = "0.6.5";

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,7 +12,7 @@ Official AI agent skills from [Inkbox](https://inkbox.ai) — load them into you
 /reload-plugins
 ```
 
-Installs six skills for automatic use. Self-signup is also available as `/inkbox:inkbox-agent-self-signup`. The plugin connects the Inkbox MCP server; sign in when prompted to authorize an identity.
+Installs seven skills for automatic use. Onboarding and self-signup are also available as `/inkbox:inkbox-onboarding` and `/inkbox:inkbox-agent-self-signup`. The plugin connects the Inkbox MCP server; sign in when prompted to authorize an identity.
 
 ### Codex (plugin)
 
@@ -54,6 +54,7 @@ Once the skills are installed, your coding agent will automatically know how to 
 
 | Skill | Language | Description |
 |-------|----------|-------------|
+| **inkbox-onboarding** | Language-agnostic | Set up an existing identity's channels, recipient consent, inbound handling, and recurring triage with API, CLI, Python, and TypeScript examples |
 | **inkbox-python** | Python ≥ 3.11 | Agent signup, identities, email, phone, text, iMessage, A2A history, contacts, notes, contact rules, vault, and webhooks using the `inkbox` Python SDK |
 | **inkbox-ts** | TypeScript / Node ≥ 22 | Agent signup, identities, email, phone, text, iMessage, A2A history, contacts, notes, contact rules, vault, and webhooks using the `@inkbox/sdk` TypeScript SDK |
 | **inkbox-cli** | TypeScript / Node ≥ 22 | CLI reference for `inkbox` / `@inkbox/cli` commands covering signup, identities, email, phone, text, iMessage, A2A history, contacts, notes, contact rules, vault, mailboxes, numbers, webhooks, and signing keys |

--- a/skills/inkbox-all/SKILL.md
+++ b/skills/inkbox-all/SKILL.md
@@ -14,9 +14,13 @@ Useful links:
 - LLMs: https://inkbox.ai/llms.txt
 - OpenAPI: https://inkbox.ai/api/openapi.json
 
-This skill is just a directory of the other Inkbox skills in this repository. Use it when you want to see the full menu before choosing a more specific skill. In practice, the SDK skills are the main references for application code, `inkbox-agent-self-signup` covers the self-registration flow, `inkbox-cli` covers shell usage, and the example skills under `examples/` are prompt templates for browser-capable agents.
+This skill is just a directory of the other Inkbox skills in this repository. Use it when you want to see the full menu before choosing a more specific skill. In practice, `inkbox-onboarding` covers channel setup and readiness, the SDK skills are the main references for application code, `inkbox-agent-self-signup` covers the self-registration flow, `inkbox-cli` covers shell usage, and the example skills under `examples/` are prompt templates for browser-capable agents.
 
 ## Core Skills
+
+- `inkbox-onboarding`
+  GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-onboarding/SKILL.md
+  Language-agnostic setup flow for an existing identity, including channel readiness, recipient consent, inbound handling, recurring triage, and API/CLI/SDK examples.
 
 - `inkbox-agent-self-signup`
   GitHub: https://github.com/inkbox-ai/inkbox/blob/main/skills/inkbox-agent-self-signup/SKILL.md
@@ -121,6 +125,7 @@ sent mail, duplicate or delete it instead.
 - Use `inkbox-ts` when writing TypeScript or JavaScript application code against the SDK.
 - Use `inkbox-cli` when the task is operational and best handled with shell commands.
 - Use `inkbox-tunnels` when bringing a local server online at a public Inkbox URL via `inkbox.tunnels.connect(...)`.
+- Use `inkbox-onboarding` when an identity exists but its communication channels, recipient setup, inbound handling, or recurring triage still need configuration.
 - Use `inkbox-agent-self-signup` when the agent does not have an API key yet and needs to self-register.
 - Use the example skills when you want a reusable agent prompt rather than SDK integration code.
 - Use the related examples when you want runnable scripts or end-to-end sample workflows instead of a reusable skill prompt.

--- a/skills/inkbox-onboarding/SKILL.md
+++ b/skills/inkbox-onboarding/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: inkbox-onboarding
+description: Use when setting up an existing Inkbox identity for email, SMS, iMessage, calls, inbound handling, and recurring communications triage with the API, CLI, Python SDK, or TypeScript SDK.
+user-invocable: true
+---
+
+# Inkbox Onboarding
+
+Use this skill after an API key exists. If the agent still needs an account or
+API key, use `inkbox-agent-self-signup` first.
+
+## Onboarding Process
+
+1. Confirm which Inkbox API key and identity should be used. Never print, log,
+   or commit the key.
+2. Inspect the authenticated principal and current identities before creating or
+   changing anything.
+3. Check each requested channel independently. A working mailbox does not imply
+   that SMS, calls, or iMessage are ready.
+4. Ask before provisioning a number, enabling a channel, changing inbound
+   routing, creating a webhook, or sending test traffic.
+5. Complete any recipient-side connection or consent step.
+6. Run one bounded test per requested channel and verify the resulting record or
+   reply instead of assuming an accepted request was delivered.
+7. Choose an inbound strategy: polling for simple agents, signed webhooks for
+   event-driven agents, or both.
+8. Offer recurring inbox and conversation triage only after the channels are
+   ready. Confirm cadence, channels, identities, and whether replies are allowed.
+
+## Readiness Checklist
+
+| Channel | Ready when | Recipient-side step |
+|---|---|---|
+| Email | The identity has a mailbox | None |
+| SMS/MMS | The identity has a local phone number and its SMS status is `ready` | The recipient must text `START` before the first outbound message |
+| Calls | The identity has a phone number, or a supported connected shared iMessage line is selected for the call | Shared-line calls require an existing iMessage connection |
+| iMessage, shared service | iMessage is enabled for the identity | The person texts the runtime-provided `connect @handle` command to the current router number |
+| iMessage, dedicated line | iMessage is enabled and a dedicated line is attached | Server-side contact policy must allow the send |
+
+Identity creation provisions a mailbox and tunnel together. A phone number is
+optional and must be local; do not request a toll-free number. New local numbers
+can remain pending while messaging registration completes, so inspect
+`sms_status` and wait for `ready` rather than retrying sends.
+
+Router numbers and connection commands can change. Always retrieve the current
+iMessage triage details at runtime and present them exactly as returned.
+
+## CLI
+
+Install the CLI and keep the key in the environment:
+
+```bash
+npm install -g @inkbox/cli
+export INKBOX_API_KEY="ApiKey_..."
+```
+
+Inspect before mutating:
+
+```bash
+inkbox whoami --json
+inkbox identity list
+inkbox identity get support-agent --json
+```
+
+With the user's approval, enable or provision only the requested channels:
+
+```bash
+inkbox identity update support-agent --imessage-enabled true
+inkbox number provision --handle support-agent --type local --state NY
+inkbox imessage triage-number
+```
+
+After number provisioning, run `inkbox identity get support-agent --json` again and
+wait for `smsStatus` to become `ready`. Before texting a recipient, verify that
+the recipient has opted in:
+
+```bash
+inkbox sms-opt-in get +15551234567
+```
+
+Use `--json` when another program will consume the output. Sending email, text,
+iMessage, or a call creates real external traffic and requires confirmation.
+
+## Python SDK
+
+```python
+import os
+
+from inkbox import Inkbox
+
+with Inkbox(api_key=os.environ["INKBOX_API_KEY"]) as inkbox:
+    principal = inkbox.whoami()
+    identities = inkbox.list_identities()
+    identity = inkbox.get_identity("support-agent")
+
+    print(principal.auth_type)
+    print(identity.mailbox)
+    print(identity.phone_number)
+    print(identity.imessage_enabled)
+
+    # Mutations require the user's approval.
+    # identity.update(imessage_enabled=True)
+    # identity.provision_phone_number(type="local", state="NY")
+
+    triage = inkbox.imessages.get_triage_number()
+    print(triage.number, triage.connect_command)
+```
+
+After provisioning a number, refresh the identity before checking readiness:
+
+```python
+identity.refresh()
+if identity.phone_number is not None:
+    print(identity.phone_number.sms_status)
+```
+
+For channel-specific operations, continue with `inkbox-python` rather than
+guessing method names or response fields.
+
+## TypeScript SDK
+
+```typescript
+import { Inkbox } from "@inkbox/sdk";
+
+const inkbox = new Inkbox({ apiKey: process.env.INKBOX_API_KEY! });
+const principal = await inkbox.whoami();
+const identities = await inkbox.listIdentities();
+const identity = await inkbox.getIdentity("support-agent");
+
+console.log(principal.authType);
+console.log(identity.mailbox);
+console.log(identity.phoneNumber);
+console.log(identity.imessageEnabled);
+
+// Mutations require the user's approval.
+// await identity.update({ imessageEnabled: true });
+// await identity.provisionPhoneNumber({ type: "local", state: "NY" });
+
+const triage = await inkbox.imessages.getTriageNumber();
+console.log(triage.number, triage.connectCommand);
+```
+
+Refresh after provisioning before checking `identity.phoneNumber?.smsStatus`:
+
+```typescript
+await identity.refresh();
+console.log(identity.phoneNumber?.smsStatus);
+```
+
+For channel-specific operations, continue with `inkbox-ts`.
+
+## Direct API
+
+The API uses the same key and returns snake_case JSON:
+
+```bash
+export INKBOX_API_KEY="ApiKey_..."
+
+curl -sS https://inkbox.ai/api/v1/whoami \
+  -H "X-API-Key: ${INKBOX_API_KEY}"
+
+curl -sS https://inkbox.ai/api/v1/identities \
+  -H "X-API-Key: ${INKBOX_API_KEY}"
+
+curl -sS https://inkbox.ai/api/v1/identities/support-agent \
+  -H "X-API-Key: ${INKBOX_API_KEY}"
+```
+
+These mutations require confirmation:
+
+```bash
+curl -sS -X PATCH https://inkbox.ai/api/v1/identities/support-agent \
+  -H "X-API-Key: ${INKBOX_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"imessage_enabled":true}'
+
+curl -sS -X POST https://inkbox.ai/api/v1/phone/numbers \
+  -H "X-API-Key: ${INKBOX_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_handle":"support-agent","type":"local","state":"NY"}'
+```
+
+Use the published OpenAPI document at
+`https://inkbox.ai/api/openapi.json` for complete request and response schemas.
+
+## Inbound Communications
+
+Polling is the smallest setup for an agent that already runs on a schedule. List
+unread email and recent SMS, iMessage, calls, and A2A tasks; fetch only the
+bounded conversation context needed; then persist a cursor or last-success time
+so the next run does not reply twice.
+
+Use webhooks when the agent needs prompt delivery. Subscribe to only the event
+types and identity resources the agent needs, verify every signature against the
+raw request body, return quickly, and process idempotently. Use an Inkbox tunnel
+when the receiver runs locally; see `inkbox-tunnels` for setup and recovery.
+
+## Recurring Triage
+
+When the client supports scheduling, offer a task with an explicit cadence and
+scope. A safe default instruction is:
+
+> Check unread email, new SMS and iMessage conversations, recent or missed calls,
+> and new or input-required A2A tasks since the last successful run. Read only
+> the context needed to understand each item. Reply only where the schedule
+> explicitly allows it, use the same channel, never respond twice, and report
+> sends that fail. Finish with actions taken, items needing a decision, and any
+> channel setup problems.
+
+Do not create a schedule or authorize automatic replies without the user's
+approval.


### PR DESCRIPTION
## Executive Summary

Adds a language-agnostic skill for onboarding an existing Inkbox identity.

- Covers channel readiness, recipient consent, inbound handling, and recurring triage.
- Includes direct API, CLI, Python, and TypeScript examples.
- Updates skill indexes and release versions so plugin installations receive the new skill.

## Description

This adds `inkbox-onboarding` as a focused setup guide for existing identities. It keeps detailed channel operations in the existing reference skills while providing a safe sequence for inspection, configuration, consent, testing, and ongoing communications handling.

The skill catalogs, plugin manifests, package versions, and changelog are updated for release `0.6.5`.

## Reason

Agents need one entry point that connects identity setup, channel readiness, and ongoing communications without requiring users to assemble the workflow from channel-specific references.

## Decisions

- **Skill scope:** Kept the guide language-agnostic and linked users to existing skills for detailed channel operations.
- **Release version:** Bumped the lockstep package and plugin versions so existing installations can receive the bundled skill update.

## Testing

- Python SDK test suite: 1,081 passed and 3 skipped.
- TypeScript SDK test suite: 1,085 passed and 3 skipped.
- CLI test suite: 129 passed.
- Rust SDK test suite: 255 passed; formatting and documentation tests passed.
- Public API and SDK/CLI references in `inkbox-onboarding`: Verified against the published interfaces.