### PR TITLE
fix(ts): accept Web API Headers in verifyWebhook

### DIFF
--- a/sdk/typescript/src/signing_keys.ts
+++ b/sdk/typescript/src/signing_keys.ts
@@ -63,19 +63,41 @@ function parseSigningKeyStatus(r: RawSigningKeyStatus): SigningKeyStatus {
 type HeaderValue = string | string[] | undefined;
 type HeaderMap = Record<string, HeaderValue>;
 
-/** Express `req.headers` is a plain object; Next.js / fetch give a `Headers` instance. */
-function headerList(headers: HeaderMap | Headers): [string, HeaderValue][] {
-  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+/**
+ * Web API `Headers`, Next.js `ReadonlyHeaders`, undici `Headers` from
+ * another realm, or any object with the same `.entries()` / `.get()` shape.
+ * `instanceof Headers` is not used: it fails across realms and for
+ * ReadonlyHeaders that do not inherit from the local `Headers` class.
+ */
+interface HeadersLike {
+  entries(): Iterable<[string, string]>;
+  get(name: string): string | null;
+}
+
+function isHeadersLike(headers: unknown): headers is HeadersLike {
+  return (
+    typeof headers === "object" &&
+    headers !== null &&
+    typeof (headers as HeadersLike).entries === "function" &&
+    typeof (headers as HeadersLike).get === "function"
+  );
+}
+
+/** Express `req.headers` is a plain object; Next.js / fetch give a Headers-like object. */
+function headerList(headers: HeaderMap | HeadersLike): [string, HeaderValue][] {
+  if (isHeadersLike(headers)) {
     return [...headers.entries()];
   }
-  return Object.entries(headers as HeaderMap);
+  return Object.entries(headers);
 }
 
 /**
  * Verify that an incoming webhook request was sent by Inkbox.
  *
  * @param payload  - Raw request body as a Buffer or string.
- * @param headers  - Request headers (plain object or Web API `Headers`). Keys are lowercased internally.
+ * @param headers  - Request headers (plain object, Web API `Headers`, or
+ *   any Headers-like object with `.entries()` / `.get()`, including Next.js
+ *   `headers()` / ReadonlyHeaders). Keys are lowercased internally.
  * @param secret   - Your signing key, with or without a `whsec_` prefix.
  * @returns True if the signature is valid.
  */
@@ -85,7 +107,7 @@ export function verifyWebhook({
   secret,
 }: {
   payload: Buffer | string;
-  headers: HeaderMap | Headers;
+  headers: HeaderMap | HeadersLike;
   secret: string;
 }): boolean {
   const h: Record<string, string | undefined> = {};

--- a/sdk/typescript/src/signing_keys.ts
+++ b/sdk/typescript/src/signing_keys.ts
@@ -60,11 +60,22 @@ function parseSigningKeyStatus(r: RawSigningKeyStatus): SigningKeyStatus {
   };
 }
 
+type HeaderValue = string | string[] | undefined;
+type HeaderMap = Record<string, HeaderValue>;
+
+/** Express `req.headers` is a plain object; Next.js / fetch give a `Headers` instance. */
+function headerList(headers: HeaderMap | Headers): [string, HeaderValue][] {
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return [...headers.entries()];
+  }
+  return Object.entries(headers as HeaderMap);
+}
+
 /**
  * Verify that an incoming webhook request was sent by Inkbox.
  *
  * @param payload  - Raw request body as a Buffer or string.
- * @param headers  - Request headers object (keys are lowercased internally).
+ * @param headers  - Request headers (plain object or Web API `Headers`). Keys are lowercased internally.
  * @param secret   - Your signing key, with or without a `whsec_` prefix.
  * @returns True if the signature is valid.
  */
@@ -74,11 +85,11 @@ export function verifyWebhook({
   secret,
 }: {
   payload: Buffer | string;
-  headers: Record<string, string | string[] | undefined>;
+  headers: HeaderMap | Headers;
   secret: string;
 }): boolean {
   const h: Record<string, string | undefined> = {};
-  for (const [k, v] of Object.entries(headers)) {
+  for (const [k, v] of headerList(headers)) {
     h[k.toLowerCase()] = Array.isArray(v) ? v[0] : v;
   }
   const signature = h["x-inkbox-signature"] ?? "";

--- a/sdk/typescript/tests/signing-keys.test.ts
+++ b/sdk/typescript/tests/signing-keys.test.ts
@@ -84,6 +84,16 @@ describe("verifyWebhook", () => {
   it("returns false when headers are missing", () => {
     expect(verifyWebhook({ payload: TEST_BODY, headers: {}, secret: TEST_KEY })).toBe(false);
   });
+
+  it("accepts a Web API Headers object", () => {
+    const sig = makeSignature(TEST_KEY, TEST_REQUEST_ID, TEST_TIMESTAMP, TEST_BODY);
+    const headers = new Headers({
+      "X-Inkbox-Signature": sig,
+      "X-Inkbox-Request-ID": TEST_REQUEST_ID,
+      "X-Inkbox-Timestamp": TEST_TIMESTAMP,
+    });
+    expect(verifyWebhook({ payload: TEST_BODY, headers, secret: TEST_KEY })).toBe(true);
+  });
 });
 
 describe("SigningKeysResource", () => {

--- a/sdk/typescript/tests/signing-keys.test.ts
+++ b/sdk/typescript/tests/signing-keys.test.ts
@@ -94,6 +94,28 @@ describe("verifyWebhook", () => {
     });
     expect(verifyWebhook({ payload: TEST_BODY, headers, secret: TEST_KEY })).toBe(true);
   });
+
+  it("accepts a Headers-like object that is not a Headers instance", () => {
+    const sig = makeSignature(TEST_KEY, TEST_REQUEST_ID, TEST_TIMESTAMP, TEST_BODY);
+    const pairs: [string, string][] = [
+      ["X-Inkbox-Signature", sig],
+      ["X-Inkbox-Request-ID", TEST_REQUEST_ID],
+      ["X-Inkbox-Timestamp", TEST_TIMESTAMP],
+    ];
+    // Next.js ReadonlyHeaders / cross-realm undici Headers fail instanceof.
+    const headers = {
+      entries() {
+        return pairs[Symbol.iterator]();
+      },
+      get(name: string) {
+        const wanted = name.toLowerCase();
+        const found = pairs.find(([key]) => key.toLowerCase() === wanted);
+        return found ? found[1] : null;
+      },
+    };
+    expect(headers instanceof Headers).toBe(false);
+    expect(verifyWebhook({ payload: TEST_BODY, headers, secret: TEST_KEY })).toBe(true);
+  });
 });
 
 describe("SigningKeysResource", () => {


### PR DESCRIPTION
## The bug

`verifyWebhook` only walked `Object.entries(headers)`. That works for Express `req.headers` (a plain object). It does not work for the Web `Headers` object you get from Next.js / `fetch`.

`Object.entries(new Headers({ ... }))` is `[]`, so every signature comes back `false` even when the hmac is fine. A Next.js route that does `if (!verifyWebhook({ headers: req.headers, ... }))` will 403 every real webhook.

## The fix

If `headers` is a `Headers` instance, use `.entries()`. Express `req.headers` is unchanged.

Not touching the truncated-signature `timingSafeEqual` throw. That's #144 / #145.

## Verification

```
npx vitest run tests/signing-keys.test.ts
# 13 passed
```

Added a test that builds a real `Headers` object and expects `true` for a valid signature. Existing Express-style object tests still pass.