### PR TITLE
fix(tunnels/python): reset stream with upstream-error if ASGI handler raises after head

### DIFF
--- a/sdk/python/inkbox/tunnels/client/_callable_streaming.py
+++ b/sdk/python/inkbox/tunnels/client/_callable_streaming.py
@@ -145,3 +145,8 @@ async def invoke_asgi_streaming(
                 await response.end_body()
             except Exception:
                 pass
+        else:
+            try:
+                await response.reset("upstream-error")
+            except Exception:
+                pass

--- a/sdk/python/tests/test_tunnels_callable_streaming.py
+++ b/sdk/python/tests/test_tunnels_callable_streaming.py
@@ -127,3 +127,42 @@ async def test_callable_dispatch_outbound_body_cap_resets():
     )
     await dispatch.dispatch(request, sink)
     assert sink.reset_reason == "response-too-large"
+
+
+async def test_callable_dispatch_app_exception_before_head_sends_502():
+    async def app(scope, receive, send):
+        raise RuntimeError("boom before head")
+
+    dispatch = CallableDispatch(
+        app=app, public_host="agent.test", max_outbound_body_bytes=1_000_000,
+    )
+    sink = _CapturingSink()
+    request = DispatchRequest(
+        method="GET", path="/x", headers=[], body=_empty_body(),
+    )
+    await dispatch.dispatch(request, sink)
+    assert sink.head is not None
+    assert sink.head.status == 502
+    assert sink.body == b"upstream error"
+    assert sink.ended
+
+
+async def test_callable_dispatch_app_exception_after_head_resets_stream():
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"partial", "more_body": True})
+        raise RuntimeError("boom mid-stream")
+
+    dispatch = CallableDispatch(
+        app=app, public_host="agent.test", max_outbound_body_bytes=1_000_000,
+    )
+    sink = _CapturingSink()
+    request = DispatchRequest(
+        method="GET", path="/x", headers=[], body=_empty_body(),
+    )
+    await dispatch.dispatch(request, sink)
+    assert sink.head is not None
+    assert sink.head.status == 200
+    assert sink.body == b"partial"
+    assert sink.reset_reason == "upstream-error"
+    assert not sink.ended


### PR DESCRIPTION
## Summary

In `inkbox.tunnels.client._callable_streaming`, when an ASGI app streams a response in passthrough mode, `head_sent` is set to `True` once headers (`http.response.start`) are sent.

If the ASGI app subsequently raises an exception mid-stream (e.g., database connection loss, LLM stream interruption, network timeout, or unhandled generator exception), the `except Exception:` block caught the exception and logged it, but because `head_sent` was `True`, the `if not head_sent:` block was skipped. As a result, neither `response.reset("upstream-error")` nor `response.end_body()` was ever invoked.

This left downstream HTTP/2 streams hung indefinitely waiting for more data frames or a stream reset, leaking streams on the persistent HTTP/2 tunnel connection.

The TypeScript implementation (`sdk/typescript/src/tunnels/client/_callable_streaming.ts`) already handles this via `await response.reset("upstream-error")`.

## Proposed Fix

- In `invoke_asgi_streaming`, add an `else:` branch in the exception handler when `head_sent` is `True` to call `await response.reset("upstream-error")`.
- Added unit tests in `sdk/python/tests/test_tunnels_callable_streaming.py` verifying:
  1. Exception before head sends 502 with `upstream error`.
  2. Exception after head resets stream with `upstream-error`.

## Verification

```bash
pytest tests/test_tunnels_callable_streaming.py
# 6 passed in 0.80s
```
