### PR TITLE
fix(vault): guard AES-GCM ciphertext length before buffer slicing

### DIFF
--- a/sdk/python/inkbox/vault/crypto.py
+++ b/sdk/python/inkbox/vault/crypto.py
@@ -159,6 +159,8 @@ def _aes_gcm_decrypt(key: bytes, blob: bytes, aad: str = "") -> bytes:
         blob: Ciphertext blob.
         aad: Additional authenticated data (must match what was used during encryption).
     """
+    if len(blob) < AES_IV_BYTES + 16:
+        raise InkboxVaultKeyError("Invalid ciphertext: payload is too short")
     ct = blob[:-28]
     nonce = blob[-28:-16]
     tag = blob[-16:]

--- a/sdk/python/tests/test_vault_crypto.py
+++ b/sdk/python/tests/test_vault_crypto.py
@@ -173,3 +173,21 @@ class TestGenerateRecoveryCode:
         c1, _ = generate_recovery_code("org_test_123", org_key)
         c2, _ = generate_recovery_code("org_test_123", org_key)
         assert c1 != c2
+
+
+class TestShortCiphertextValidation:
+    def test_unwrap_org_key_too_short(self):
+        import base64
+        salt = derive_salt("org_test_wrap")
+        mk = derive_master_key("pw", salt)
+        short_b64 = base64.b64encode(b"short-data").decode()
+        with pytest.raises(InkboxVaultKeyError, match="payload is too short"):
+            unwrap_org_key(mk, short_b64)
+
+    def test_decrypt_payload_too_short(self):
+        import base64
+        org_key = generate_org_encryption_key()
+        short_b64 = base64.b64encode(b"short-data").decode()
+        with pytest.raises(InkboxVaultKeyError, match="payload is too short"):
+            decrypt_payload(org_key, short_b64)
+

--- a/sdk/typescript/src/vault/crypto.ts
+++ b/sdk/typescript/src/vault/crypto.ts
@@ -145,6 +145,9 @@ function aesGcmEncrypt(key: Uint8Array, plaintext: Uint8Array, aad: string = "")
 }
 
 function aesGcmDecrypt(key: Uint8Array, blob: Uint8Array, aad: string = ""): Uint8Array {
+  if (blob.length < AES_IV_BYTES + AES_TAG_BYTES) {
+    throw new InkboxVaultKeyError("Invalid ciphertext: payload is too short");
+  }
   const tag = blob.slice(-AES_TAG_BYTES);
   const nonce = blob.slice(-(AES_IV_BYTES + AES_TAG_BYTES), -AES_TAG_BYTES);
   const ct = blob.slice(0, -(AES_IV_BYTES + AES_TAG_BYTES));

--- a/sdk/typescript/tests/vault/crypto.test.ts
+++ b/sdk/typescript/tests/vault/crypto.test.ts
@@ -207,3 +207,20 @@ describe("cross-SDK compatibility", () => {
     expect(hash.startsWith("056863c98cd0759f")).toBe(true);
   });
 });
+
+describe("short ciphertext payload validation", () => {
+  it("unwrapOrgKey throws InkboxVaultKeyError on truncated payload (< 28 bytes)", async () => {
+    const mk = await deriveMasterKey("pw", deriveSalt("org_test_wrap"));
+    const shortPayloadB64 = Buffer.from("short-data").toString("base64");
+    expect(() => unwrapOrgKey(mk, shortPayloadB64)).toThrow(InkboxVaultKeyError);
+    expect(() => unwrapOrgKey(mk, shortPayloadB64)).toThrow("payload is too short");
+  });
+
+  it("decryptPayload throws InkboxVaultKeyError on truncated payload (< 28 bytes)", () => {
+    const orgKey = generateOrgEncryptionKey();
+    const shortPayloadB64 = Buffer.from("short-data").toString("base64");
+    expect(() => decryptPayload(orgKey, shortPayloadB64)).toThrow(InkboxVaultKeyError);
+    expect(() => decryptPayload(orgKey, shortPayloadB64)).toThrow("payload is too short");
+  });
+});
+


### PR DESCRIPTION
## Summary

In both the TypeScript (`sdk/typescript/src/vault/crypto.ts`) and Python (`sdk/python/inkbox/vault/crypto.py`) SDKs, encrypted vault payloads are formatted as `ciphertext || nonce (12B) || tag (16B)`, requiring a minimum payload length of 28 bytes.

When decrypting a truncated or corrupted payload ($< 28$ bytes):
- In TypeScript: `blob.slice(-28, -16)` returns an empty `Uint8Array(0)` when the input length is shorter than 16 bytes. Passing a 0-byte IV to Node's `createDecipheriv("aes-256-gcm", key, nonce)` threw an unhandled engine error:
  ```
  TypeError [ERR_CRYPTO_INVALID_IV]: Invalid IV length 0 (must be 12 bytes)
  ```
- In Python: `blob[-28:-16]` returns a slice with length $< 12$ bytes, causing `AESGCM(key).decrypt(...)` to raise `ValueError: Nonce must be at least 12 bytes`.

In both languages, this resulted in uncaught low-level runtime errors rather than throwing `InkboxVaultKeyError`.

## Proposed Fix

- Added payload length validation before buffer slicing in `aesGcmDecrypt` (TS) and `_aes_gcm_decrypt` (Python):
  ```typescript
  if (blob.length < AES_IV_BYTES + AES_TAG_BYTES) {
    throw new InkboxVaultKeyError("Invalid ciphertext: payload is too short");
  }
  ```
- Added unit tests in `sdk/typescript/tests/vault/crypto.test.ts` and `sdk/python/tests/test_vault_crypto.py` asserting that truncated base64 payloads to `unwrapOrgKey` / `unwrap_org_key` and `decryptPayload` / `decrypt_payload` consistently reject with `InkboxVaultKeyError`.

## Verification

**TypeScript:**
```bash
npx vitest run tests/vault/crypto.test.ts
# 26 passed in 10.98s
```

**Python:**
```bash
pytest tests/test_vault_crypto.py
# 25 passed in 8.47s
```
