### PR TITLE
Make Voice AI model selection platform-managed

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inkbox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Inkbox communication tools and SDK skills.",
   "author": {
     "name": "Inkbox AI",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "displayName": "Inkbox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Give Cursor an Inkbox identity for email, SMS, iMessage, voice calls, contacts, notes, and agent-to-agent tasks.",
   "author": {
     "name": "Inkbox",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.7 — Server-selected Voice AI model
+
+### Changed
+
+- Voice AI now always uses the platform-selected model. The Python,
+  TypeScript, and Rust SDKs retain their existing `model` arguments for source
+  compatibility but ignore them, and the CLI continues accepting `--model`
+  as a no-op for script compatibility.
+- Hosted-agent configuration responses retain `model` and `effective_model`;
+  `model` is now always unset and `effective_model` reports the active
+  platform selection.
+- Bundled plugin manifests receive patch releases: Claude `0.6.7`, Codex
+  `0.1.2`, and Cursor `1.0.1`.
+
+### Compatibility
+
+- Existing method calls, CLI commands, response parsing, and stored
+  configuration remain valid. No caller migration is required.
+
 ## 0.6.6 — Webhook delivery auth token
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.7 — Server-selected Voice AI model
+
+- Voice AI always uses the platform-selected model. `phone hosted-agent set`
+  continues accepting `--model` for script compatibility but ignores it.
+- CLI and SDK dependency versions moved in lockstep to 0.6.7.
+
 ## 0.6.6 — Webhook delivery auth token
 
 - `webhook subscription create` accepts `--auth-token-stdin`, which reads a

--- a/cli/README.md
+++ b/cli/README.md
@@ -276,7 +276,7 @@ inkbox phone hosted-agent get -i <handle>    # Show the Inkbox Voice AI config
 inkbox phone hosted-agent set -i <handle>    # Set it — full replace: an omitted flag
                                              #   resets that field to the server default
   --voice <voice>                            #   Voice override
-  --model <model>                            #   Model override
+  --model <model>                            #   Deprecated; accepted but ignored
   --instructions <text>                      #   Per-identity steering prompt
 
 inkbox phone hosted-agent authority-mode yolo -i <handle>  # Saved inbound/outbound default; admin API key

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.6",
+        "@inkbox/sdk": "^0.6.7",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.6",
+    "@inkbox/sdk": "^0.6.7",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.6";
+export const CLI_VERSION = "0.6.7";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/phone.ts
+++ b/cli/src/commands/phone.ts
@@ -425,7 +425,7 @@ export function registerPhoneCommands(program: Command): void {
     )
     .requiredOption("-i, --identity <handle>", "Agent identity handle")
     .option("--voice <voice>", "Voice override")
-    .option("--model <model>", "Model override")
+    .option("--model <model>", "Deprecated; accepted but ignored")
     .option("--instructions <text>", "Per-identity steering prompt")
     .action(
       withErrorHandler(async function (

--- a/cli/tests/phone-command.test.mjs
+++ b/cli/tests/phone-command.test.mjs
@@ -75,6 +75,10 @@ test("phone help exposes authority controls", () => {
   assert.match(help("phone", "call"), /dedicated_imessage_number/);
   assert.match(help("phone", "tool-activity"), /--limit <n>/);
   assert.match(help("phone", "tool-activity"), /--offset <n>/);
+  assert.match(
+    help("phone", "hosted-agent", "set"),
+    /--model <model>\s+Deprecated; accepted but ignored/,
+  );
   const authorityHelp = help("phone", "hosted-agent", "authority-mode");
   assert.match(authorityHelp, /admin API key/);
   const incomingHelp = help("phone", "incoming-action");

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.7 — Server-selected Voice AI model
+
+- Voice AI always uses the platform-selected model. The existing `model`
+  argument remains accepted for compatibility but is ignored.
+- Configuration responses retain `model` and `effective_model`; `model` is
+  unset and `effective_model` reports the active platform selection.
+
 ## 0.6.6 — Webhook delivery auth token
 
 - `webhooks.subscriptions.create(...)` accepts `auth_token`, a bearer token

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -952,11 +952,12 @@ class AgentIdentity:
     ) -> HostedAgentConfig:
         """Set this identity's Inkbox Voice AI config (full replace).
 
-        A field left at ``None`` resets to the server default.
+        Voice and instructions left at ``None`` reset to their defaults. The
+        deprecated ``model`` argument remains accepted but is ignored.
 
         Args:
             voice: Voice override, or ``None`` for the server default.
-            model: Model override, or ``None`` for the server default.
+            model: Deprecated compatibility argument; accepted but ignored.
             instructions: Per-identity steering prompt, or ``None`` for none.
         """
         return self._inkbox._hosted_agent.set_config(

--- a/sdk/python/inkbox/phone/resources/hosted_agent.py
+++ b/sdk/python/inkbox/phone/resources/hosted_agent.py
@@ -50,13 +50,12 @@ class HostedAgentConfigResource:
     ) -> HostedAgentConfig:
         """Set the Inkbox Voice AI config for an identity.
 
-        Full-replace PUT: every call sets all three fields, and a field
-        left at ``None`` resets to the server default — there is no
-        partial update.
+        Full-replace PUT: every call replaces voice and instructions. The
+        deprecated ``model`` argument remains accepted but is ignored.
 
         Args:
             voice: Voice override, or ``None`` for the server default.
-            model: Model override, or ``None`` for the server default.
+            model: Deprecated compatibility argument; accepted but ignored.
             instructions: Per-identity steering prompt appended to
                 Voice AI's system prompt, or ``None`` for none.
             agent_identity_id: UUID of the agent identity, or ``None`` for
@@ -69,8 +68,6 @@ class HostedAgentConfigResource:
         # full-replace PUT: the server resets them to its defaults.
         if voice is not None:
             body["voice"] = voice
-        if model is not None:
-            body["model"] = model
         if instructions is not None:
             body["instructions"] = instructions
         data = self._http.put("/hosted-agent-config", json=body)

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -678,8 +678,8 @@ class IncomingCallActionConfig:
 class HostedAgentConfig:
     """Per-identity Inkbox Voice AI configuration.
 
-    ``voice`` / ``model`` / ``instructions`` are nullable overrides.
-    ``effective_voice`` and ``effective_model`` show the resolved settings.
+    ``voice`` and ``instructions`` are nullable overrides. ``model`` is a
+    deprecated compatibility field; ``effective_model`` is server-selected.
     """
 
     agent_identity_id: UUID

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.6"
+version = "0.6.7"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_hosted_agent.py
+++ b/sdk/python/tests/test_hosted_agent.py
@@ -80,7 +80,7 @@ class TestHostedAgentGetConfig:
 
 
 class TestHostedAgentSetConfig:
-    def test_set_all_fields(self, client, transport):
+    def test_set_accepts_but_omits_deprecated_model(self, client, transport):
         transport.put.return_value = HOSTED_AGENT_CONFIG_DICT
 
         cfg = client._hosted_agent.set_config(
@@ -95,7 +95,6 @@ class TestHostedAgentSetConfig:
             json={
                 "agent_identity_id": IDENTITY_ID,
                 "voice": "warm-voice",
-                "model": "fast-model",
                 "instructions": "Always offer to text a summary after the call.",
             },
         )

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -822,7 +822,8 @@ impl AgentIdentity {
 
     /// Set this identity's Inkbox Voice AI config (full replace).
     ///
-    /// A field left `None` resets to the server default.
+    /// Voice and instructions left `None` reset to their defaults. The model
+    /// argument remains accepted for compatibility but is ignored.
     pub fn set_hosted_agent_config(
         &self,
         voice: Option<&str>,

--- a/sdk/rust/src/phone/resources/hosted_agent.rs
+++ b/sdk/rust/src/phone/resources/hosted_agent.rs
@@ -37,14 +37,14 @@ impl HostedAgentConfigResource {
 
     /// Set the Inkbox Voice AI config.
     ///
-    /// Full-replace PUT: every call sets all three fields, and a field left
-    /// `None` resets to the server default — there is no partial update.
+    /// Full-replace PUT: every call replaces voice and instructions. The
+    /// deprecated `model` argument remains accepted but is ignored.
     ///
     /// # Arguments
     /// * `agent_identity_id` - UUID (or string) of the agent identity. `None`
     ///   for agent-scoped keys; required under admin/JWT.
     /// * `voice` - Voice override; `None` for the server default.
-    /// * `model` - Model override; `None` for the server default.
+    /// * `model` - Deprecated compatibility argument; accepted but ignored.
     /// * `instructions` - Per-identity steering prompt appended to the hosted
     ///   agent's system prompt; `None` for none.
     pub fn set_config(
@@ -63,9 +63,7 @@ impl HostedAgentConfigResource {
         if let Some(v) = voice {
             body.insert("voice".into(), v.into());
         }
-        if let Some(m) = model {
-            body.insert("model".into(), m.into());
-        }
+        let _ = model;
         if let Some(i) = instructions {
             body.insert("instructions".into(), i.into());
         }
@@ -174,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn set_config_sends_full_body_when_all_args_given() {
+    fn set_config_accepts_but_omits_deprecated_model() {
         let server = MockServer::start();
         // Exact json_body match: full PUT body shape, no stray keys.
         let mock = server.mock(|when, then| {
@@ -183,7 +181,6 @@ mod tests {
                 .json_body(json!({
                     "agent_identity_id": "33333333-3333-3333-3333-333333333333",
                     "voice": "warm-voice",
-                    "model": "fast-model",
                     "instructions": "Always offer to text a summary after the call."
                 }));
             then.status(200).json_body(config_json());

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -552,8 +552,8 @@ pub struct PhoneCallForwarding {
 
 /// Per-identity Inkbox Voice AI configuration.
 ///
-/// `voice` / `model` / `instructions` are nullable overrides.
-/// `effective_voice` and `effective_model` show the resolved settings.
+/// `voice` and `instructions` are nullable overrides. `model` is a deprecated
+/// compatibility field; `effective_model` is server-selected.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostedAgentConfig {
     pub agent_identity_id: Uuid,

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.7 — Server-selected Voice AI model
+
+- Voice AI always uses the platform-selected model. The existing `model`
+  option remains accepted for compatibility but is ignored.
+- Configuration responses retain `model` and `effectiveModel`; `model` is
+  unset and `effectiveModel` reports the active platform selection.
+
 ## 0.6.6 — Webhook delivery auth token
 
 - `webhooks.subscriptions.create(...)` accepts `authToken`, a bearer token

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -692,14 +692,16 @@ export class AgentIdentity {
   /**
    * Set this identity's Inkbox Voice AI config (full replace).
    *
-   * A field left undefined resets to the server default.
+   * Voice and instructions left undefined reset to their defaults. The
+   * deprecated `model` option remains accepted but is ignored.
    *
    * @param options.voice - Voice override; omit for the server default.
-   * @param options.model - Model override; omit for the server default.
+   * @param options.model - Deprecated compatibility option; accepted but ignored.
    * @param options.instructions - Per-identity steering prompt; omit for none.
    */
   async setHostedAgentConfig(options?: {
     voice?: string;
+    /** @deprecated Accepted for compatibility but ignored. */
     model?: string;
     instructions?: string;
   }): Promise<HostedAgentConfig> {

--- a/sdk/typescript/src/phone/resources/hostedAgent.ts
+++ b/sdk/typescript/src/phone/resources/hostedAgent.ts
@@ -41,11 +41,11 @@ export class HostedAgentConfigResource {
   /**
    * Set the Inkbox Voice AI config.
    *
-   * Full-replace PUT: every call sets all three fields, and a field left
-   * undefined resets to the server default — there is no partial update.
+   * Full-replace PUT: every call replaces voice and instructions. The
+   * deprecated `model` option remains accepted but is ignored.
    *
    * @param options.voice - Voice override; omit for the server default.
-   * @param options.model - Model override; omit for the server default.
+   * @param options.model - Deprecated compatibility option; accepted but ignored.
    * @param options.instructions - Per-identity steering prompt appended to
    *   Voice AI's system prompt; omit for none.
    * @param options.agentIdentityId - UUID of the agent identity. Optional
@@ -53,6 +53,7 @@ export class HostedAgentConfigResource {
    */
   async setConfig(options?: {
     voice?: string;
+    /** @deprecated Accepted for compatibility but ignored. */
     model?: string;
     instructions?: string;
     agentIdentityId?: string;
@@ -64,7 +65,6 @@ export class HostedAgentConfigResource {
     // Omitted fields are equivalent to explicit nulls on this full-replace
     // PUT: the server resets them to its defaults.
     if (options?.voice !== undefined) body["voice"] = options.voice;
-    if (options?.model !== undefined) body["model"] = options.model;
     if (options?.instructions !== undefined) {
       body["instructions"] = options.instructions;
     }

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -387,12 +387,13 @@ export interface PhoneCallForwarding {
 /**
  * Per-identity Inkbox Voice AI configuration.
  *
- * `voice` / `model` / `instructions` are nullable overrides.
- * `effectiveVoice` and `effectiveModel` show the resolved settings.
+ * `voice` and `instructions` are nullable overrides. `model` is a deprecated
+ * compatibility field; `effectiveModel` is server-selected.
  */
 export interface HostedAgentConfig {
   agentIdentityId: string;
   voice: string | null;
+  /** @deprecated Current servers return `null`; use `effectiveModel`. */
   model: string | null;
   effectiveVoice: string;
   effectiveModel: string;

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.6";
+export const VERSION = "0.6.7";

--- a/sdk/typescript/tests/phone/hostedAgent.test.ts
+++ b/sdk/typescript/tests/phone/hostedAgent.test.ts
@@ -71,7 +71,7 @@ describe("HostedAgentConfigResource.getConfig", () => {
 });
 
 describe("HostedAgentConfigResource.setConfig", () => {
-  it("sends all set fields", async () => {
+  it("accepts but omits the deprecated model option", async () => {
     const http = mockHttp();
     vi.mocked(http.put).mockResolvedValue(RAW_HOSTED_AGENT_CONFIG);
     const res = new HostedAgentConfigResource(http);
@@ -86,7 +86,6 @@ describe("HostedAgentConfigResource.setConfig", () => {
     expect(http.put).toHaveBeenCalledWith("/hosted-agent-config", {
       agent_identity_id: IDENTITY_ID,
       voice: "warm-voice",
-      model: "fast-model",
       instructions: "Always offer to text a summary after the call.",
     });
     expect(config.voice).toBe("warm-voice");

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -290,7 +290,7 @@ inkbox phone incoming-action hosted_agent -i <handle>          # or auto_accept 
 inkbox phone incoming-action forward -i <handle> --forward-to-phone +15551234567
 inkbox phone incoming-action forward -i <handle> --forward-to-sip sip:agent@voice.example.com
 inkbox phone hosted-agent get -i <handle>
-inkbox phone hosted-agent set -i <handle> --voice <voice> --model <model> --instructions <text>
+inkbox phone hosted-agent set -i <handle> --voice <voice> --instructions <text>
 ```
 
 Before placing a call, confirm the destination number, origination, and the

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -352,8 +352,8 @@ for t in identity.list_transcripts(calls[0].id):
 # calls surface the server's 409)
 call = identity.hangup_call(calls[0].id)
 
-# Per-identity Inkbox Voice AI config: voice / model / instructions,
-# all nullable (None means the server default). set is a FULL REPLACE —
+# Per-identity Inkbox Voice AI config: voice and instructions.
+# Both are nullable (None means the server default). set is a FULL REPLACE —
 # an omitted field resets to the server default.
 cfg = identity.get_hosted_agent_config()
 cfg = identity.set_hosted_agent_config(instructions="Be brief and friendly.")

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -357,8 +357,8 @@ for (const t of segments) {
 // calls surface the server's 409)
 const hungUp = await identity.hangupCall(calls[0].id);
 
-// Per-identity Inkbox Voice AI config: voice / model / instructions,
-// all nullable (null means the server default). setHostedAgentConfig is
+// Per-identity Inkbox Voice AI config: voice and instructions.
+// Both are nullable (null means the server default). setHostedAgentConfig is
 // a FULL REPLACE — an omitted field resets to the server default.
 const cfg = await identity.getHostedAgentConfig();
 await identity.setHostedAgentConfig({ instructions: "Be brief and friendly." });


### PR DESCRIPTION
## Executive Summary

Voice AI model selection is now platform-managed while existing SDK and CLI calls remain source-compatible.

- Python, TypeScript, and Rust retain their model arguments as documented no-ops.
- The CLI retains `--model` as a documented no-op for script compatibility.
- Every release surface receives a patch version bump.

## Description

The SDKs no longer send a model override when replacing Voice AI configuration. Existing method signatures, response fields, and parsers remain intact, allowing applications to work across rollout order and continue parsing older responses.

Current guidance and bundled skills omit model configuration. Core Python, TypeScript, Rust, CLI, and Claude package versions move from `0.6.6` to `0.6.7`; the independently versioned Codex and Cursor plugin manifests move to `0.1.2` and `1.0.1`.

## Reason

Voice AI has one supported platform selection, so accepting a model argument as active configuration was misleading. Compatibility requires retiring its behavior without breaking existing source code or scripts.

## Decisions

- **API compatibility:** Kept all public method arguments and the CLI flag as no-ops instead of removing them in a breaking release.
- **Response compatibility:** Retained nullable model fields and tolerant parsers so clients work with responses from either side of the rollout.
- **Versioning:** Applied patch bumps to every shipped package and plugin manifest because all affected surfaces remain backwards compatible.

## Testing

- Python `set_hosted_agent_config(model=...)`: Expected the call to succeed without sending the model; 1,089 tests passed with 3 skipped.
- TypeScript `setHostedAgentConfig({ model: ... })`: Expected the call to succeed without sending the model; build passed and 1,091 tests passed with 3 skipped.
- Rust `set_hosted_agent_config(..., model, ...)`: Expected the call to succeed without sending the model; 256 tests and doctests passed, with Clippy and rustfmt clean.
- CLI `inkbox phone hosted-agent set --model ...`: Expected the flag to remain accepted and documented as ignored; 130 tests passed.
- Version parity: Expected core release surfaces to report `0.6.7` and independent plugin manifests to contain their patch releases; manifest parsing and lockstep tests passed.