### PR TITLE
Run SDK integration tests on Node 24

### DIFF
--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install SDK (local)
         if: matrix.source == 'local'
@@ -284,7 +284,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install and build SDK + CLI (local)
         if: matrix.source == 'local'


### PR DESCRIPTION
## Executive Summary

Run the TypeScript SDK and CLI integration test jobs on Node 24 so their dependency installs use npm 11.

- npm 10, bundled with Node 22, crashes while resolving the vitest 4 peer set now that vitest 5.0.0 is published.
- Only the two setup-node steps in the workflow change; the Python jobs, SDKs, CLI, and packages are untouched.

## Description

Both `actions/setup-node` steps in `.github/workflows/sdk_integration.yml` move from `node-version: 22` to `node-version: 24`. The `tests/integration/typescript` and `tests/integration/cli` directories install without a lockfile, so every run resolves vitest from scratch. vitest 4 depends on vite 8, whose optional peer `@vitejs/devtools` chains through `@vitejs/devtools-vitest` to an optional peer of `vitest: *`. That wildcard now resolves to vitest 5.0.0, which conflicts with the root vitest 4, and npm 10's resolver crashes with `Cannot read properties of null (reading 'edgesOut')` before anything is installed. npm 11 resolves the same tree without error. The SDK and CLI both declare `engines.node >=22`, so Node 24 is inside the supported range.

## Reason

Scheduled runs of the TypeScript SDK and CLI integration jobs have failed at the install step, before any test executes, since vitest 5.0.0 was published on 2026-09-03 at 12:24 UTC.

## Decisions

- **Node 24 instead of `--legacy-peer-deps`:** the failure is a resolver crash rather than a real peer conflict, so moving to a bundled npm that resolves the tree correctly was preferred over leaving a peer-resolution override in the workflow.
- **No committed test lockfiles:** the integration test directories are intentionally lockfile-free so the published matrix keeps resolving `@inkbox/sdk@latest` and `@inkbox/cli@latest`, and that behavior was kept rather than pinning the tree.

## Testing

- Manual run of the SDK Integration Tests workflow on this branch: https://github.com/inkbox-ai/inkbox/actions/runs/33783541842. Result: every TypeScript SDK and CLI job passed on Node 24.19.0 with npm 11.17.0. The published-package lane only runs on the scheduled trigger, so its install sequence is covered by the local check below and by the first scheduled run after merge.
- Local `npm install` of `tests/integration/typescript/package.json` and `tests/integration/cli/package.json`: crashes on npm 10.9.7; succeeds on npm 11.19.1 and npm 12.0.2, including the follow-up `npm install @inkbox/sdk@latest`.
- `npm install --before 2026-09-03T12:20:00Z` succeeds on npm 10 and `--before 2026-09-03T12:30:00Z` fails, bracketing the vitest 5.0.0 publish.
