### PR TITLE
Standardize scheduled integration notifications

### DIFF
--- a/.github/tests/notification-format.test.mjs
+++ b/.github/tests/notification-format.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const workflow = readFileSync(new URL('../workflows/sdk_integration.yml', import.meta.url), 'utf8');
+const components = { 'python-sdk': 'Python SDK', 'typescript-sdk': 'TypeScript SDK', cli: 'CLI' };
+const title = '📦 SDK integration tests';
+const environments = { development: '🛠️ Development', beta: '🧪 Beta', production: '🚀 Production' };
+
+// Execute the actual workflow shell with a local curl replacement: no network or secrets.
+function render(job, environment, source, repository = 'example/sdk') {
+  const section = workflow.split(/^  (?=[\w-]+:)/m).find(part => part.startsWith(`${job}:`));
+  const notification = section.slice(section.indexOf('      - name: Notify Google Chat'));
+  const values = {
+    'matrix.environment': environment, 'matrix.source': source,
+    'github.repository': repository, 'github.server_url': 'https://github.example',
+    'github.run_id': '123', 'github.run_attempt': '2', 'secrets.GOOGLE_CHAT_WEBHOOK_URL': 'https://invalid.example/webhook',
+  };
+  const substitute = value => value.replace(/\$\{\{\s*(.*?)\s*\}\}/g, (_, key) => {
+    assert.ok(key in values, `Unexpected expression: ${key}`);
+    return values[key];
+  });
+  const env = { ...process.env };
+  for (const match of notification.matchAll(/^          ([A-Z_]+): (.+)$/gm)) {
+    env[match[1]] = substitute(match[2]);
+  }
+  const body = notification.match(/        run: \|\n((?:          .*\n|\n)*)/)[1]
+    .replace(/^          /gm, '');
+  const intercept = 'curl() { while (( $# )); do if [[ "$1" == "-d" || "$1" == "--data" ]]; then printf "%s" "$2"; return; fi; shift; done; return 1; };\n';
+  const result = spawnSync('bash', ['-e', '-c', intercept + substitute(body)], { env, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+for (const [job, component] of Object.entries(components)) {
+  for (const [environment, header] of Object.entries(environments)) {
+    for (const source of ['local', 'published']) {
+      test(`${job}: ${environment}, ${source}`, () => {
+        const payload = render(job, environment, source);
+        assert.equal(payload.text, `${header}\n❌ Failed\n${title}\n\nSummary: ${component} integration job failed.\nScope: example/sdk · ${component} · ${source}\nDetails: <https://github.example/example/sdk/actions/runs/123|View run>`);
+        assert.equal(payload.thread.threadKey, `ci-example-sdk-123-2-${environment}`);
+        assert.deepEqual(render(job, environment, source), payload, 'threading must be deterministic');
+      });
+    }
+  }
+  test(`${job}: safely encodes shell and JSON metacharacters`, () => {
+    const repository = 'example/quote\'"\\$(printf unsafe)';
+    const payload = render(job, 'beta', 'local', repository);
+    assert.ok(payload.text.includes(`Scope: ${repository} · ${component} · local`));
+    assert.ok(payload.text.includes(`Details: <https://github.example/${repository}/actions/runs/123|View run>`));
+  });
+}

--- a/.github/tests/notification-format.test.mjs
+++ b/.github/tests/notification-format.test.mjs
@@ -9,7 +9,7 @@ const title = '📦 SDK integration tests';
 const environments = { development: '🛠️ Development', beta: '🧪 Beta', production: '🚀 Production' };
 
 // Execute the actual workflow shell with a local curl replacement: no network or secrets.
-function render(job, environment, source, repository = 'example/sdk') {
+function run(job, environment, source, repository = 'example/sdk') {
   const section = workflow.split(/^  (?=[\w-]+:)/m).find(part => part.startsWith(`${job}:`));
   const notification = section.slice(section.indexOf('      - name: Notify Google Chat'));
   const values = {
@@ -28,7 +28,11 @@ function render(job, environment, source, repository = 'example/sdk') {
   const body = notification.match(/        run: \|\n((?:          .*\n|\n)*)/)[1]
     .replace(/^          /gm, '');
   const intercept = 'curl() { while (( $# )); do if [[ "$1" == "-d" || "$1" == "--data" ]]; then printf "%s" "$2"; return; fi; shift; done; return 1; };\n';
-  const result = spawnSync('bash', ['-e', '-c', intercept + substitute(body)], { env, encoding: 'utf8' });
+  return spawnSync('bash', ['-e', '-c', intercept + substitute(body)], { env, encoding: 'utf8' });
+}
+
+function render(job, environment, source, repository) {
+  const result = run(job, environment, source, repository);
   assert.equal(result.status, 0, result.stderr);
   return JSON.parse(result.stdout);
 }
@@ -44,6 +48,12 @@ for (const [job, component] of Object.entries(components)) {
       });
     }
   }
+  test(`${job}: unknown environment fails instead of posting an unlabeled alert`, () => {
+    const result = run(job, 'staging', 'local');
+    assert.notEqual(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /Unknown environment: staging/);
+  });
   test(`${job}: safely encodes shell and JSON metacharacters`, () => {
     const repository = 'example/quote\'"\\$(printf unsafe)';
     const payload = render(job, 'beta', 'local', repository);

--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -189,12 +189,13 @@ jobs:
             --arg run_id "$ALERT_RUN_ID" \
             --arg attempt "$ALERT_RUN_ATTEMPT" \
             --arg run_url "$ALERT_RUN_URL" '
-            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            ({development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment]
+              // error("Unknown environment: " + $environment)) as $header |
             {
               text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
               thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
             }')
-          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+          curl --fail-with-body --silent --show-error -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
             "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
             -d "$payload"
@@ -296,12 +297,13 @@ jobs:
             --arg run_id "$ALERT_RUN_ID" \
             --arg attempt "$ALERT_RUN_ATTEMPT" \
             --arg run_url "$ALERT_RUN_URL" '
-            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            ({development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment]
+              // error("Unknown environment: " + $environment)) as $header |
             {
               text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
               thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
             }')
-          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+          curl --fail-with-body --silent --show-error -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
             "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
             -d "$payload"
@@ -401,12 +403,13 @@ jobs:
             --arg run_id "$ALERT_RUN_ID" \
             --arg attempt "$ALERT_RUN_ATTEMPT" \
             --arg run_url "$ALERT_RUN_URL" '
-            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            ({development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment]
+              // error("Unknown environment: " + $environment)) as $header |
             {
               text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
               thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
             }')
-          curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
+          curl --fail-with-body --silent --show-error -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
             "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
             -d "$payload"

--- a/.github/workflows/sdk_integration.yml
+++ b/.github/workflows/sdk_integration.yml
@@ -25,6 +25,16 @@ permissions:
   checks: read  # required by lewagon/wait-on-check-action to poll check-runs
 
 jobs:
+  notification-format-tests:
+    name: CI notification format tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - run: node --test .github/tests/notification-format.test.mjs
+
   # On PRs, gate the rest of the workflow on the unit-test workflow
   # succeeding first. Skipped for scheduled and manual runs, and for
   # draft PRs (tests run once marked ready for review).
@@ -161,13 +171,33 @@ jobs:
 
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
+        env:
+          CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          ALERT_ENVIRONMENT: ${{ matrix.environment }}
+          ALERT_COMPONENT: Python SDK
+          ALERT_SOURCE: ${{ matrix.source }}
+          ALERT_REPOSITORY: ${{ github.repository }}
+          ALERT_RUN_ID: ${{ github.run_id }}
+          ALERT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ALERT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          payload=$(jq -n \
+            --arg environment "$ALERT_ENVIRONMENT" \
+            --arg component "$ALERT_COMPONENT" \
+            --arg source "$ALERT_SOURCE" \
+            --arg repository "$ALERT_REPOSITORY" \
+            --arg run_id "$ALERT_RUN_ID" \
+            --arg attempt "$ALERT_RUN_ATTEMPT" \
+            --arg run_url "$ALERT_RUN_URL" '
+            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            {
+              text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
+              thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
+            }')
           curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
-            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
-            -d '{
-              "text": "⚠️ Python SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }'
+            -d "$payload"
 
   typescript-sdk:
     name: TypeScript SDK (${{ matrix.environment }}, ${{ matrix.source }})
@@ -248,13 +278,33 @@ jobs:
 
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
+        env:
+          CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          ALERT_ENVIRONMENT: ${{ matrix.environment }}
+          ALERT_COMPONENT: TypeScript SDK
+          ALERT_SOURCE: ${{ matrix.source }}
+          ALERT_REPOSITORY: ${{ github.repository }}
+          ALERT_RUN_ID: ${{ github.run_id }}
+          ALERT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ALERT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          payload=$(jq -n \
+            --arg environment "$ALERT_ENVIRONMENT" \
+            --arg component "$ALERT_COMPONENT" \
+            --arg source "$ALERT_SOURCE" \
+            --arg repository "$ALERT_REPOSITORY" \
+            --arg run_id "$ALERT_RUN_ID" \
+            --arg attempt "$ALERT_RUN_ATTEMPT" \
+            --arg run_url "$ALERT_RUN_URL" '
+            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            {
+              text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
+              thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
+            }')
           curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
-            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
-            -d '{
-              "text": "⚠️ TypeScript SDK integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }'
+            -d "$payload"
 
   cli:
     name: CLI (${{ matrix.environment }}, ${{ matrix.source }})
@@ -333,10 +383,30 @@ jobs:
 
       - name: Notify Google Chat on scheduled failure
         if: failure() && github.event_name == 'schedule'
+        env:
+          CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          ALERT_ENVIRONMENT: ${{ matrix.environment }}
+          ALERT_COMPONENT: CLI
+          ALERT_SOURCE: ${{ matrix.source }}
+          ALERT_REPOSITORY: ${{ github.repository }}
+          ALERT_RUN_ID: ${{ github.run_id }}
+          ALERT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ALERT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          payload=$(jq -n \
+            --arg environment "$ALERT_ENVIRONMENT" \
+            --arg component "$ALERT_COMPONENT" \
+            --arg source "$ALERT_SOURCE" \
+            --arg repository "$ALERT_REPOSITORY" \
+            --arg run_id "$ALERT_RUN_ID" \
+            --arg attempt "$ALERT_RUN_ATTEMPT" \
+            --arg run_url "$ALERT_RUN_URL" '
+            {development: "🛠️ Development", beta: "🧪 Beta", production: "🚀 Production"}[$environment] as $header |
+            {
+              text: ($header + "\n❌ Failed\n📦 SDK integration tests\n\nSummary: " + $component + " integration job failed.\nScope: " + $repository + " · " + $component + " · " + $source + "\nDetails: <" + $run_url + "|View run>"),
+              thread: {threadKey: ("ci-" + ($repository | gsub("/"; "-")) + "-" + $run_id + "-" + $attempt + "-" + $environment)}
+            }')
           curl -s -X POST --retry 5 --retry-all-errors --retry-delay 2 --max-time 30 \
-            "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+            "${CHAT_WEBHOOK_URL}&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" \
             -H 'Content-Type: application/json' \
-            -d '{
-              "text": "⚠️ CLI integration tests *FAILED* for *${{ matrix.environment }}* (${{ matrix.source }})\n\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }'
+            -d "$payload"


### PR DESCRIPTION
## Executive Summary

Standardize scheduled integration failure notifications.

- Show environment, status, and test type on separate lines.
- Keep component and package source in labeled details.
- Separate notification threads by run, attempt, and environment.

## Description

Updates the Python, TypeScript, and CLI workflow notifications to use the same three-line header and Summary, Scope, and Details fields. Each environment has a distinct emoji, with no brackets around its name. Rendering tests exercise the workflow shell with synthetic inputs and run in CI. The notification step fails visibly when the webhook post is rejected or the environment label is unknown, instead of posting an unlabeled message or exiting quietly.

## Reason

Consistent formatting makes failures easier to scan and keeps unrelated runs out of the same thread.

## Decisions

- Share a run/attempt/environment thread across failing components; component and package source remain visible in each message.
- Keep existing alert conditions and scheduled test behavior unchanged; no package release is needed for workflow-only changes.

## Testing

- `node --test .github/tests/notification-format.test.mjs`: 24 passed. Renders each notification variant, checks header order and fields, validates thread identity using synthetic values, and confirms an unknown environment fails before anything is posted.
- No live notifications were sent.