### PR TITLE
`0.6.10`: Add release-connection methods to the SDKs and CLI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inkbox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Inkbox communication tools and SDK skills.",
   "author": {
     "name": "Inkbox AI",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "displayName": "Inkbox",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Give Cursor an Inkbox identity for email, SMS, iMessage, voice calls, contacts, notes, and agent-to-agent tasks.",
   "author": {
     "name": "Inkbox",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.10 — Release an iMessage connection
+
+### Added
+
+- `imessages.release_assignment` / `identity.release_imessage_assignment`
+  (Python), `imessages.releaseAssignment` /
+  `identity.releaseIMessageAssignment` (TypeScript), `release_assignment` /
+  `release_imessage_assignment` (Rust), and `inkbox imessage disconnect
+  <assignment-id> -i <handle>` (CLI) call the new
+  `DELETE /imessage/assignments/{assignment_id}`. Releasing a connection stops
+  routing the recipient's inbound to the agent and frees the shared line. The
+  recipient is not notified and can reconnect by texting the triage number.
+  Identity-scoped keys can only release their own identity's connections; a
+  missing or already-released connection is a not-found error.
+
 ## 0.6.9 — Creating a contact saves a matching suggestion
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   (Python), `imessages.releaseAssignment` /
   `identity.releaseIMessageAssignment` (TypeScript), `release_assignment` /
   `release_imessage_assignment` (Rust), and `inkbox imessage disconnect
-  <assignment-id> -i <handle>` (CLI) call the new
+  <assignment-id>` (CLI) call the new
   `DELETE /imessage/assignments/{assignment_id}`. Releasing a connection stops
   routing the recipient's inbound to the agent and frees the shared line. The
   recipient is not notified and can reconnect by texting the triage number.
   Requires an admin API key; identity-scoped keys are rejected. A missing or
   already-released connection is a not-found error.
+- Bundled plugin manifests receive patch releases: Claude `0.6.10`, Codex
+  `0.1.5`, and Cursor `1.0.3`.
 
 ## 0.6.9 — Creating a contact saves a matching suggestion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
   `DELETE /imessage/assignments/{assignment_id}`. Releasing a connection stops
   routing the recipient's inbound to the agent and frees the shared line. The
   recipient is not notified and can reconnect by texting the triage number.
-  Identity-scoped keys can only release their own identity's connections; a
-  missing or already-released connection is a not-found error.
+  Requires an admin API key; identity-scoped keys are rejected. A missing or
+  already-released connection is a not-found error.
 
 ## 0.6.9 — Creating a contact saves a matching suggestion
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.9",
+        "@inkbox/sdk": "^0.6.10",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.9",
+    "@inkbox/sdk": "^0.6.10",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.9";
+export const CLI_VERSION = "0.6.10";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/imessage.ts
+++ b/cli/src/commands/imessage.ts
@@ -390,7 +390,7 @@ export function registerIMessageCommands(program: Command): void {
 
   imessage
     .command("disconnect <assignment-id>")
-    .description("Release an active connection; the recipient is not notified and can reconnect")
+    .description("Release an active connection (admin API key only); the recipient is not notified and can reconnect")
     .requiredOption("-i, --identity <handle>", "Agent identity handle")
     .action(
       withErrorHandler(async function (

--- a/cli/src/commands/imessage.ts
+++ b/cli/src/commands/imessage.ts
@@ -389,6 +389,24 @@ export function registerIMessageCommands(program: Command): void {
     );
 
   imessage
+    .command("disconnect <assignment-id>")
+    .description("Release an active connection; the recipient is not notified and can reconnect")
+    .requiredOption("-i, --identity <handle>", "Agent identity handle")
+    .action(
+      withErrorHandler(async function (
+        this: Command,
+        assignmentId: string,
+        cmdOpts: { identity: string },
+      ) {
+        const opts = getGlobalOpts(this);
+        const inkbox = createClient(opts);
+        const identity = await inkbox.getIdentity(cmdOpts.identity);
+        await identity.releaseIMessageAssignment(assignmentId);
+        output({ id: assignmentId, released: true }, { json: !!opts.json });
+      }),
+    );
+
+  imessage
     .command("conversations")
     .description("List iMessage conversation summaries")
     .requiredOption("-i, --identity <handle>", "Agent identity handle")

--- a/cli/src/commands/imessage.ts
+++ b/cli/src/commands/imessage.ts
@@ -391,17 +391,11 @@ export function registerIMessageCommands(program: Command): void {
   imessage
     .command("disconnect <assignment-id>")
     .description("Release an active connection (admin API key only); the recipient is not notified and can reconnect")
-    .requiredOption("-i, --identity <handle>", "Agent identity handle")
     .action(
-      withErrorHandler(async function (
-        this: Command,
-        assignmentId: string,
-        cmdOpts: { identity: string },
-      ) {
+      withErrorHandler(async function (this: Command, assignmentId: string) {
         const opts = getGlobalOpts(this);
         const inkbox = createClient(opts);
-        const identity = await inkbox.getIdentity(cmdOpts.identity);
-        await identity.releaseIMessageAssignment(assignmentId);
+        await inkbox.imessages.releaseAssignment(assignmentId);
         output({ id: assignmentId, released: true }, { json: !!opts.json });
       }),
     );

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -664,7 +664,7 @@ print(group_convos[0].group_creation_status)
 # Who is currently connected? (Disconnected conversations stay readable
 # with assignment_status == "released"; sends into them return 409.)
 connections = identity.list_imessage_assignments()
-identity.release_imessage_assignment(connections[0].id)  # disconnect; they can reconnect via triage
+identity.release_imessage_assignment(connections[0].id)  # admin key only; they can reconnect via triage
 
 # Tapbacks target inbound one-to-one or group messages by message_id. The seven
 # named reactions include "eyes" ("custom" is rejected locally on send), and a

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -664,6 +664,7 @@ print(group_convos[0].group_creation_status)
 # Who is currently connected? (Disconnected conversations stay readable
 # with assignment_status == "released"; sends into them return 409.)
 connections = identity.list_imessage_assignments()
+identity.release_imessage_assignment(connections[0].id)  # disconnect; they can reconnect via triage
 
 # Tapbacks target inbound one-to-one or group messages by message_id. The seven
 # named reactions include "eyes" ("custom" is rejected locally on send), and a

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -1327,6 +1327,19 @@ class AgentIdentity:
             offset=offset,
         )
 
+    def release_imessage_assignment(self, assignment_id: UUID | str) -> None:
+        """Disconnect a recipient from this identity.
+
+        Inbound from them stops routing here and the shared line can be
+        reassigned. They are not notified and can reconnect by texting the
+        triage number again.
+
+        Args:
+            assignment_id: UUID of the connection, from ``list_imessage_assignments``.
+        """
+        self._require_imessage()
+        self._inkbox._imessages.release_assignment(assignment_id)
+
     def list_imessage_conversations(
         self,
         *,

--- a/sdk/python/inkbox/agent_identity.py
+++ b/sdk/python/inkbox/agent_identity.py
@@ -1330,9 +1330,10 @@ class AgentIdentity:
     def release_imessage_assignment(self, assignment_id: UUID | str) -> None:
         """Disconnect a recipient from this identity.
 
-        Inbound from them stops routing here and the shared line can be
-        reassigned. They are not notified and can reconnect by texting the
-        triage number again.
+        Requires an admin API key; identity-scoped keys are rejected. Inbound
+        from them stops routing here and the shared line can be reassigned.
+        They are not notified and can reconnect by texting the triage number
+        again.
 
         Args:
             assignment_id: UUID of the connection, from ``list_imessage_assignments``.

--- a/sdk/python/inkbox/imessage/resources/imessages.py
+++ b/sdk/python/inkbox/imessage/resources/imessages.py
@@ -267,11 +267,11 @@ class IMessagesResource:
     def release_assignment(self, assignment_id: UUID | str) -> None:
         """Release an active iMessage connection.
 
-        Inbound from the recipient stops routing to the agent and the shared
-        line can be reassigned. The recipient is not notified and can reconnect
-        by texting the triage number again. Identity-scoped keys can only
-        release their own identity's connections. Raises ``NotFoundError`` if
-        the connection does not exist or is already released.
+        Requires an admin API key; identity-scoped keys are rejected. Inbound
+        from the recipient stops routing to the agent and the shared line can
+        be reassigned. The recipient is not notified and can reconnect by
+        texting the triage number again. Raises ``NotFoundError`` if the
+        connection does not exist or is already released.
 
         Args:
             assignment_id: UUID of the connection, from ``list_assignments``.

--- a/sdk/python/inkbox/imessage/resources/imessages.py
+++ b/sdk/python/inkbox/imessage/resources/imessages.py
@@ -264,6 +264,20 @@ class IMessagesResource:
         data = self._http.get("/assignments", params=params)
         return [IMessageAssignment._from_dict(a) for a in data]
 
+    def release_assignment(self, assignment_id: UUID | str) -> None:
+        """Release an active iMessage connection.
+
+        Inbound from the recipient stops routing to the agent and the shared
+        line can be reassigned. The recipient is not notified and can reconnect
+        by texting the triage number again. Identity-scoped keys can only
+        release their own identity's connections. Raises ``NotFoundError`` if
+        the connection does not exist or is already released.
+
+        Args:
+            assignment_id: UUID of the connection, from ``list_assignments``.
+        """
+        self._http.delete(f"/assignments/{assignment_id}")
+
     def list_conversations(
         self,
         *,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.9"
+version = "0.6.10"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_imessage.py
+++ b/sdk/python/tests/test_imessage.py
@@ -619,6 +619,13 @@ class TestIMessageAssignments:
         assert rows[0].remote_number == REMOTE
         assert rows[0].released_at is None
 
+    def test_release_assignment(self, client, transport):
+        assignment_id = "bbbb2222-0000-0000-0000-000000000001"
+
+        client._imessages.release_assignment(UUID(assignment_id))
+
+        transport.delete.assert_called_once_with(f"/assignments/{assignment_id}")
+
 
 class TestConversationAssignmentStatus:
     def test_parses_assignment_status(self, client, transport):

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.9"
+version = "0.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1227,9 +1227,10 @@ impl AgentIdentity {
 
     /// Disconnect a recipient from this identity.
     ///
-    /// Inbound from them stops routing here and the shared line can be
-    /// reassigned. They are not notified and can reconnect by texting the
-    /// triage number again.
+    /// Requires an admin API key; identity-scoped keys are rejected. Inbound
+    /// from them stops routing here and the shared line can be reassigned.
+    /// They are not notified and can reconnect by texting the triage number
+    /// again.
     ///
     /// # Arguments
     /// * `assignment_id` - UUID of the connection, from `list_imessage_assignments`.

--- a/sdk/rust/src/agent_identity.rs
+++ b/sdk/rust/src/agent_identity.rs
@@ -1225,6 +1225,19 @@ impl AgentIdentity {
             .list_assignments(Some(&id), limit, offset)
     }
 
+    /// Disconnect a recipient from this identity.
+    ///
+    /// Inbound from them stops routing here and the shared line can be
+    /// reassigned. They are not notified and can reconnect by texting the
+    /// triage number again.
+    ///
+    /// # Arguments
+    /// * `assignment_id` - UUID of the connection, from `list_imessage_assignments`.
+    pub fn release_imessage_assignment(&self, assignment_id: &Uuid) -> Result<()> {
+        self.require_imessage()?;
+        self.inkbox.imessages().release_assignment(assignment_id)
+    }
+
     /// List this identity's iMessage conversations.
     pub fn list_imessage_conversations(
         &self,

--- a/sdk/rust/src/imessage/resources/imessages.rs
+++ b/sdk/rust/src/imessage/resources/imessages.rs
@@ -332,6 +332,20 @@ impl IMessagesResource {
         Ok(serde_json::from_value(data)?)
     }
 
+    /// Release an active iMessage connection.
+    ///
+    /// Inbound from the recipient stops routing to the agent and the shared
+    /// line can be reassigned. The recipient is not notified and can reconnect
+    /// by texting the triage number again. Identity-scoped keys can only
+    /// release their own identity's connections. Returns a not-found error if
+    /// the connection does not exist or is already released.
+    ///
+    /// # Arguments
+    /// * `assignment_id` - UUID of the connection, from `list_assignments`.
+    pub fn release_assignment(&self, assignment_id: &Uuid) -> Result<()> {
+        self.http.delete(&format!("/assignments/{assignment_id}"))
+    }
+
     /// List iMessage conversations with latest-message preview.
     ///
     /// # Arguments
@@ -916,6 +930,24 @@ mod tests {
         mock.assert();
         assert_eq!(reaction.assignment_id, None);
         assert_eq!(reaction.reaction, IMessageReactionType::Eyes);
+    }
+
+    #[test]
+    fn release_assignment_deletes_the_connection_by_id() {
+        let server = MockServer::start();
+        let assignment_id = Uuid::parse_str("bbbb2222-0000-0000-0000-000000000001").unwrap();
+        let mock = server.mock(|when, then| {
+            when.method(DELETE)
+                .path(format!("/api/v1/imessage/assignments/{assignment_id}"));
+            then.status(204);
+        });
+
+        client(&server)
+            .imessages()
+            .release_assignment(&assignment_id)
+            .unwrap();
+
+        mock.assert();
     }
 
     #[test]

--- a/sdk/rust/src/imessage/resources/imessages.rs
+++ b/sdk/rust/src/imessage/resources/imessages.rs
@@ -334,11 +334,11 @@ impl IMessagesResource {
 
     /// Release an active iMessage connection.
     ///
-    /// Inbound from the recipient stops routing to the agent and the shared
-    /// line can be reassigned. The recipient is not notified and can reconnect
-    /// by texting the triage number again. Identity-scoped keys can only
-    /// release their own identity's connections. Returns a not-found error if
-    /// the connection does not exist or is already released.
+    /// Requires an admin API key; identity-scoped keys are rejected. Inbound
+    /// from the recipient stops routing to the agent and the shared line can
+    /// be reassigned. The recipient is not notified and can reconnect by
+    /// texting the triage number again. Returns a not-found error if the
+    /// connection does not exist or is already released.
     ///
     /// # Arguments
     /// * `assignment_id` - UUID of the connection, from `list_assignments`.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -649,7 +649,7 @@ await identity.sendIMessage({
 // Who is currently connected? (Disconnected conversations stay readable
 // with assignmentStatus === "released"; sends into them return 409.)
 const connections = await identity.listIMessageAssignments();
-await identity.releaseIMessageAssignment(connections[0].id); // disconnect; they can reconnect via triage
+await identity.releaseIMessageAssignment(connections[0].id); // admin key only; they can reconnect via triage
 
 // Tapbacks target inbound one-to-one or group messages by messageId. The seven
 // named reactions include "eyes" ("custom" is rejected locally on send), and a

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -649,6 +649,7 @@ await identity.sendIMessage({
 // Who is currently connected? (Disconnected conversations stay readable
 // with assignmentStatus === "released"; sends into them return 409.)
 const connections = await identity.listIMessageAssignments();
+await identity.releaseIMessageAssignment(connections[0].id); // disconnect; they can reconnect via triage
 
 // Tapbacks target inbound one-to-one or group messages by messageId. The seven
 // named reactions include "eyes" ("custom" is rejected locally on send), and a

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -1013,6 +1013,20 @@ export class AgentIdentity {
   }
 
   /**
+   * Disconnect a recipient from this identity.
+   *
+   * Inbound from them stops routing here and the shared line can be
+   * reassigned. They are not notified and can reconnect by texting the
+   * triage number again.
+   *
+   * @param assignmentId - UUID of the connection, from `listIMessageAssignments`.
+   */
+  async releaseIMessageAssignment(assignmentId: string): Promise<void> {
+    this._requireIMessage();
+    await this._inkbox._imessages.releaseAssignment(assignmentId);
+  }
+
+  /**
    * List this identity's iMessage conversations.
    *
    * @param options.limit - Maximum number of results. Defaults to 50.

--- a/sdk/typescript/src/agent_identity.ts
+++ b/sdk/typescript/src/agent_identity.ts
@@ -1015,9 +1015,10 @@ export class AgentIdentity {
   /**
    * Disconnect a recipient from this identity.
    *
-   * Inbound from them stops routing here and the shared line can be
-   * reassigned. They are not notified and can reconnect by texting the
-   * triage number again.
+   * Requires an admin API key; identity-scoped keys are rejected. Inbound
+   * from them stops routing here and the shared line can be reassigned.
+   * They are not notified and can reconnect by texting the triage number
+   * again.
    *
    * @param assignmentId - UUID of the connection, from `listIMessageAssignments`.
    */

--- a/sdk/typescript/src/imessage/resources/imessages.ts
+++ b/sdk/typescript/src/imessage/resources/imessages.ts
@@ -268,6 +268,21 @@ export class IMessagesResource {
   }
 
   /**
+   * Release an active iMessage connection.
+   *
+   * Inbound from the recipient stops routing to the agent and the shared
+   * line can be reassigned. The recipient is not notified and can reconnect
+   * by texting the triage number again. Identity-scoped keys can only
+   * release their own identity's connections. Throws `NotFoundError` if the
+   * connection does not exist or is already released.
+   *
+   * @param assignmentId - UUID of the connection, from `listAssignments`.
+   */
+  async releaseAssignment(assignmentId: string): Promise<void> {
+    await this.http.delete(`/assignments/${assignmentId}`);
+  }
+
+  /**
    * List iMessage conversations with latest-message preview.
    *
    * @param options.agentIdentityId - Narrow to one agent identity.

--- a/sdk/typescript/src/imessage/resources/imessages.ts
+++ b/sdk/typescript/src/imessage/resources/imessages.ts
@@ -270,11 +270,11 @@ export class IMessagesResource {
   /**
    * Release an active iMessage connection.
    *
-   * Inbound from the recipient stops routing to the agent and the shared
-   * line can be reassigned. The recipient is not notified and can reconnect
-   * by texting the triage number again. Identity-scoped keys can only
-   * release their own identity's connections. Throws `NotFoundError` if the
-   * connection does not exist or is already released.
+   * Requires an admin API key; identity-scoped keys are rejected. Inbound
+   * from the recipient stops routing to the agent and the shared line can be
+   * reassigned. The recipient is not notified and can reconnect by texting
+   * the triage number again. Throws `NotFoundError` if the connection does
+   * not exist or is already released.
    *
    * @param assignmentId - UUID of the connection, from `listAssignments`.
    */

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.9";
+export const VERSION = "0.6.10";

--- a/sdk/typescript/tests/imessage.test.ts
+++ b/sdk/typescript/tests/imessage.test.ts
@@ -807,6 +807,25 @@ describe("IMessagesResource.listAssignments", () => {
     expect(rows[0].remoteNumber).toBe(REMOTE);
     expect(rows[0].releasedAt).toBeNull();
   });
+
+  it("releaseAssignment deletes the connection by id", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      headers: { get() { return null; }, getSetCookie() { return []; } } as unknown as Headers,
+      json: () => Promise.resolve(undefined),
+    } as Response);
+    const resource = new IMessagesResource(new HttpTransport("k", BASE));
+    const assignmentId = "bbbb2222-0000-0000-0000-000000000001";
+
+    await resource.releaseAssignment(assignmentId);
+
+    const { url, init } = lastCall();
+    expect(url).toBe(`${BASE}/assignments/${assignmentId}`);
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+  });
 });
 
 describe("conversation assignmentStatus", () => {

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -372,7 +372,7 @@ inkbox imessage send -i <handle> --to +15551234567,+15557654321 --text "Hello gr
 inkbox imessage send -i <handle> --conversation-id <group-conversation-id> --text "Reply" --media-url https://example.com/follow-up.jpg --send-style lasers
 inkbox imessage list -i <handle> --limit 20 --unread-only --include-groups
 inkbox imessage assignments -i <handle> --limit 20   # active connections, newest first
-inkbox imessage disconnect <assignment-id> -i <handle>  # admin key only; recipient can reconnect via triage
+inkbox imessage disconnect <assignment-id>   # admin key only; recipient can reconnect via triage
 inkbox imessage conversations -i <handle> --limit 20 --include-groups
 inkbox imessage conversation <conversation-id> -i <handle> --limit 50
 inkbox imessage react <message-id> -i <handle> --reaction like

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -372,6 +372,7 @@ inkbox imessage send -i <handle> --to +15551234567,+15557654321 --text "Hello gr
 inkbox imessage send -i <handle> --conversation-id <group-conversation-id> --text "Reply" --media-url https://example.com/follow-up.jpg --send-style lasers
 inkbox imessage list -i <handle> --limit 20 --unread-only --include-groups
 inkbox imessage assignments -i <handle> --limit 20   # active connections, newest first
+inkbox imessage disconnect <assignment-id> -i <handle>  # release one; recipient can reconnect via triage
 inkbox imessage conversations -i <handle> --limit 20 --include-groups
 inkbox imessage conversation <conversation-id> -i <handle> --limit 50
 inkbox imessage react <message-id> -i <handle> --reaction like

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -372,7 +372,7 @@ inkbox imessage send -i <handle> --to +15551234567,+15557654321 --text "Hello gr
 inkbox imessage send -i <handle> --conversation-id <group-conversation-id> --text "Reply" --media-url https://example.com/follow-up.jpg --send-style lasers
 inkbox imessage list -i <handle> --limit 20 --unread-only --include-groups
 inkbox imessage assignments -i <handle> --limit 20   # active connections, newest first
-inkbox imessage disconnect <assignment-id> -i <handle>  # release one; recipient can reconnect via triage
+inkbox imessage disconnect <assignment-id> -i <handle>  # admin key only; recipient can reconnect via triage
 inkbox imessage conversations -i <handle> --limit 20 --include-groups
 inkbox imessage conversation <conversation-id> -i <handle> --limit 50
 inkbox imessage react <message-id> -i <handle> --reaction like

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -559,6 +559,7 @@ print(convo.assignment_status)
 
 # Who is actively connected to this identity right now (paginated)?
 connections = identity.list_imessage_assignments(limit=20)
+identity.release_imessage_assignment(connections[0].id)  # disconnect; they can reconnect via triage
 for a in connections:
     print(a.remote_number, a.status, a.created_at)
 

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -559,7 +559,7 @@ print(convo.assignment_status)
 
 # Who is actively connected to this identity right now (paginated)?
 connections = identity.list_imessage_assignments(limit=20)
-identity.release_imessage_assignment(connections[0].id)  # disconnect; they can reconnect via triage
+identity.release_imessage_assignment(connections[0].id)  # admin key only; they can reconnect via triage
 for a in connections:
     print(a.remote_number, a.status, a.created_at)
 

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -537,7 +537,7 @@ console.log(convo.assignmentStatus);
 
 // Who is actively connected to this identity right now (paginated)?
 const connections = await identity.listIMessageAssignments({ limit: 20 });
-await identity.releaseIMessageAssignment(connections[0].id); // disconnect; they can reconnect via triage
+await identity.releaseIMessageAssignment(connections[0].id); // admin key only; they can reconnect via triage
 for (const a of connections) {
   console.log(a.remoteNumber, a.status, a.createdAt);
 }

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -537,6 +537,7 @@ console.log(convo.assignmentStatus);
 
 // Who is actively connected to this identity right now (paginated)?
 const connections = await identity.listIMessageAssignments({ limit: 20 });
+await identity.releaseIMessageAssignment(connections[0].id); // disconnect; they can reconnect via triage
 for (const a of connections) {
   console.log(a.remoteNumber, a.status, a.createdAt);
 }


### PR DESCRIPTION
## Summary

Agents could list their active iMessage connections but had no way to end one; only the recipient could, by texting the router. This release adds a per-connection release to every package, calling the new `DELETE /api/v1/imessage/assignments/{assignment_id}`.

- **Python:** `imessages.release_assignment(id)` and `identity.release_imessage_assignment(id)`
- **TypeScript:** `imessages.releaseAssignment(id)` and `identity.releaseIMessageAssignment(id)`
- **Rust:** `imessages().release_assignment(&id)` and `identity.release_imessage_assignment(&id)`
- **CLI:** `inkbox imessage disconnect <assignment-id>` (no identity flag: the release is organization-wide)

Behavior: inbound from the recipient stops routing to the agent and the line can be reassigned. The recipient is not notified and can reconnect by texting the router again. Requires an admin API key; identity-scoped keys are rejected. A missing or already-released connection is a not-found error.

Version bumped 0.6.9 to 0.6.10 in lockstep (all four packages, both User-Agent constants, lockfiles). Bundled plugin manifests move with it: Claude `0.6.10`, Codex `0.1.5`, Cursor `1.0.3`. Changelog entry added. Skills and READMEs carry a one-line example.

## Testing

- Python: `uv run pytest` in `sdk/python`, 1096 passed. New test asserts `DELETE /assignments/{id}`.
- TypeScript: `npx vitest run` in `sdk/typescript`, 1095 passed. New test asserts method, URL, and empty body.
- Rust: `cargo test imessage`, 27 passed; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean. New mock-server test for the DELETE.
- CLI: `npm test`, 134 passed; `tsc --noEmit` clean against the rebuilt SDK.
- Not exercised against a live environment; the server side ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD6cENFdt9SisoQ98UG2LL


