### PR TITLE
Document organization voice catalogs and authenticated previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## Unreleased
+
+### Documentation
+
+- Clarify organization-specific voice catalogs and authenticated preview paths;
+  voice selection continues to accept opaque catalog IDs in every SDK and the CLI.
+
 ## 0.6.10 — Release an iMessage connection
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ voice and instructions, so preserve the saved instructions when changing only
 the voice. Discovery requires an API that supports the catalog endpoint;
 existing string-based voice selection does not require this new method.
 
+Catalogs can differ by organization. Custom voices assigned to your organization
+appear alongside the standard voices and use the same configuration setter;
+they are not listed for other organizations. Treat voice IDs as opaque strings.
+Preview URLs may be absolute public URLs or paths beginning with `/api/v1/`.
+Resolve a relative preview path against your Inkbox API origin and fetch it
+with the same authentication as the catalog. Do not send API credentials to
+external preview hosts. A missing preview does not prevent voice selection.
+
 ### A2A discovery and history
 
 Each identity can inspect work it received, work it requested, or both without

--- a/cli/README.md
+++ b/cli/README.md
@@ -292,6 +292,11 @@ returned alongside the entries in JSON output. Config setters are a full
 replacement: read the current config first and include its existing
 `--instructions` when changing only the voice.
 
+Custom voices assigned to your organization appear in this same catalog and
+use the same `--voice` option. Other organizations do not see them. A relative
+`previewUrl` is resolved against your API origin and requires authentication;
+absolute public preview URLs do not require your API key.
+
 Shared origination uses the identity's active iMessage-line assignment and
 does not require a dedicated phone number. The recipient must already have a
 shared iMessage connection to the identity; otherwise the call fails with

--- a/cli/tests/phone-command.test.mjs
+++ b/cli/tests/phone-command.test.mjs
@@ -96,6 +96,7 @@ test("hosted-agent voices requires no identity and preserves the full JSON catal
         { id: "future-voice", name: "Future Voice", description: "Warm", available: true, preview_url: "https://example.com/voice.wav" },
         { id: "unavailable-voice", name: "Unavailable Voice", description: "Clear", available: false, preview_url: null },
         { id: "no-preview", name: "No Preview", description: "Calm", available: true },
+        { id: "custom_0123456789abcdef0123456789abcdef", name: "Custom Voice", description: "Warm", available: true, preview_url: "/api/v1/phone/hosted-agent-voices/custom_0123456789abcdef0123456789abcdef/preview" },
       ],
       default_voice: "future-voice",
     }));
@@ -112,6 +113,7 @@ test("hosted-agent voices requires no identity and preserves the full JSON catal
         { id: "future-voice", name: "Future Voice", description: "Warm", available: true, previewUrl: "https://example.com/voice.wav" },
         { id: "unavailable-voice", name: "Unavailable Voice", description: "Clear", available: false, previewUrl: null },
         { id: "no-preview", name: "No Preview", description: "Calm", available: true, previewUrl: null },
+        { id: "custom_0123456789abcdef0123456789abcdef", name: "Custom Voice", description: "Warm", available: true, previewUrl: "/api/v1/phone/hosted-agent-voices/custom_0123456789abcdef0123456789abcdef/preview" },
       ],
       defaultVoice: "future-voice",
     });

--- a/sdk/python/inkbox/phone/types.py
+++ b/sdk/python/inkbox/phone/types.py
@@ -679,7 +679,8 @@ class HostedAgentVoiceOption:
     """A Voice AI voice and whether your organization can select it.
 
     Voice IDs are open-ended strings. ``preview_url`` is ``None`` when no
-    prerecorded sample is available.
+    prerecorded sample is available. Relative preview paths resolve against
+    the API origin and require authentication; external public URLs do not.
     """
 
     id: str

--- a/sdk/python/tests/test_hosted_agent_voices.py
+++ b/sdk/python/tests/test_hosted_agent_voices.py
@@ -3,9 +3,48 @@
 import httpx
 import pytest
 
-from inkbox import HostedAgentVoiceCatalog, HostedAgentVoiceOption, Inkbox, InkboxAPIError
+from inkbox import (
+    HostedAgentVoiceCatalog,
+    HostedAgentVoiceOption,
+    Inkbox,
+    InkboxAPIError,
+)
 from inkbox.phone import HostedAgentVoiceCatalog as PhoneVoiceCatalog
 from inkbox.phone import HostedAgentVoiceOption as PhoneVoiceOption
+from sample_data import HOSTED_AGENT_CONFIG_DICT
+
+
+def test_custom_voice_catalog_entry_can_be_selected_without_rewriting(
+    client, transport
+):
+    voice_id = "custom_0123456789abcdef0123456789abcdef"
+    preview = f"/api/v1/phone/hosted-agent-voices/{voice_id}/preview"
+    transport.get.return_value = {
+        "default_voice": "standard-voice",
+        "voices": [
+            {
+                "id": voice_id,
+                "name": "Custom Voice",
+                "description": "Warm",
+                "available": True,
+                "preview_url": preview,
+            }
+        ],
+    }
+    transport.put.return_value = {
+        **HOSTED_AGENT_CONFIG_DICT,
+        "voice": voice_id,
+        "effective_voice": voice_id,
+    }
+
+    voice = client.hosted_agent.list_voices().voices[0]
+    config = client.hosted_agent.set_config(voice=voice.id, instructions="Be brief.")
+
+    assert voice.preview_url == preview
+    transport.put.assert_called_once_with(
+        "/hosted-agent-config", json={"voice": voice_id, "instructions": "Be brief."}
+    )
+    assert config.voice == config.effective_voice == voice_id
 
 
 def test_list_voices_parses_options_without_filtering(client, transport):
@@ -90,7 +129,9 @@ def test_list_voices_exact_wire_and_errors(monkeypatch, status_code):
             ),
         )
 
-    monkeypatch.setattr(httpx, "HTTPTransport", lambda **kwargs: httpx.MockTransport(handler))
+    monkeypatch.setattr(
+        httpx, "HTTPTransport", lambda **kwargs: httpx.MockTransport(handler)
+    )
     with Inkbox(api_key="sk-test", base_url="https://example.com") as sdk:
         if status_code == 200:
             assert sdk.hosted_agent.list_voices().voices == []

--- a/sdk/rust/src/phone/resources/hosted_agent.rs
+++ b/sdk/rust/src/phone/resources/hosted_agent.rs
@@ -144,6 +144,42 @@ mod tests {
     }
 
     #[test]
+    fn custom_voice_catalog_entry_can_be_selected_without_rewriting() {
+        let server = MockServer::start();
+        let id = "custom_0123456789abcdef0123456789abcdef";
+        let preview = format!("/api/v1/phone/hosted-agent-voices/{id}/preview");
+        let catalog_mock = server.mock(|when, then| {
+            when.method(GET).path("/api/v1/phone/hosted-agent-voices");
+            then.status(200).json_body(json!({
+                "default_voice": "standard-voice",
+                "voices": [{"id": id, "name": "Custom Voice", "description": "Warm",
+                            "available": true, "preview_url": preview}]
+            }));
+        });
+        let config_mock = server.mock(|when, then| {
+            when.method(PUT)
+                .path("/api/v1/phone/hosted-agent-config")
+                .json_body(json!({"voice": id, "instructions": "Be brief."}));
+            let mut response = config_json();
+            response["voice"] = json!(id);
+            response["effective_voice"] = json!(id);
+            then.status(200).json_body(response);
+        });
+        let sdk = client(&server);
+        let catalog = sdk.hosted_agent().list_voices().unwrap();
+        let voice = &catalog.voices[0];
+        assert_eq!(voice.preview_url.as_deref(), Some(preview.as_str()));
+        let config = sdk
+            .hosted_agent()
+            .set_config(None, Some(&voice.id), None, Some("Be brief."))
+            .unwrap();
+        assert_eq!(config.voice.as_deref(), Some(id));
+        assert_eq!(config.effective_voice, id);
+        catalog_mock.assert();
+        config_mock.assert();
+    }
+
+    #[test]
     fn list_voices_preserves_catalog_without_identity_query() {
         fn no_query_params(req: &HttpMockRequest) -> bool {
             req.query_params.clone().unwrap_or_default().is_empty()

--- a/sdk/rust/src/phone/types.rs
+++ b/sdk/rust/src/phone/types.rs
@@ -557,6 +557,7 @@ pub struct HostedAgentVoiceOption {
     pub name: String,
     pub description: String,
     pub available: bool,
+    /// Relative paths use the API origin and require auth; public URLs do not.
     #[serde(default)]
     pub preview_url: Option<String>,
 }

--- a/sdk/typescript/src/phone/types.ts
+++ b/sdk/typescript/src/phone/types.ts
@@ -407,6 +407,7 @@ export interface HostedAgentVoiceOption {
   name: string;
   description: string;
   available: boolean;
+  /** Relative paths use the API origin and require auth; public URLs do not. */
   previewUrl: string | null;
 }
 

--- a/sdk/typescript/tests/phone/hostedAgent.test.ts
+++ b/sdk/typescript/tests/phone/hostedAgent.test.ts
@@ -22,6 +22,26 @@ function mockHttp() {
 const IDENTITY_ID = "eeee5555-0000-0000-0000-000000000001";
 
 describe("HostedAgentConfigResource.listVoices", () => {
+  it("selects an opaque custom voice and preserves its authenticated preview path", async () => {
+    const http = mockHttp();
+    const id = "custom_0123456789abcdef0123456789abcdef";
+    const preview = `/api/v1/phone/hosted-agent-voices/${id}/preview`;
+    vi.mocked(http.get).mockResolvedValue({
+      default_voice: "standard-voice",
+      voices: [{ id, name: "Custom Voice", description: "Warm", available: true, preview_url: preview }],
+    });
+    vi.mocked(http.put).mockResolvedValue({ ...RAW_HOSTED_AGENT_CONFIG, voice: id, effective_voice: id });
+    const resource = new HostedAgentConfigResource(http);
+
+    const voice = (await resource.listVoices()).voices[0];
+    const config = await resource.setConfig({ voice: voice.id, instructions: "Be brief." });
+
+    expect(voice.previewUrl).toBe(preview);
+    expect(http.put).toHaveBeenCalledExactlyOnceWith("/hosted-agent-config", { voice: id, instructions: "Be brief." });
+    expect(config.voice).toBe(id);
+    expect(config.effectiveVoice).toBe(id);
+  });
+
   it("fetches the organization catalog and preserves all voices and preview states", async () => {
     const http = mockHttp();
     const voice = { id: "future-voice", name: "Future Voice", description: "Warm", available: true };


### PR DESCRIPTION
## Executive Summary

Document organization-specific voice catalogs and verify opaque voice IDs across SDKs and the CLI.

- Preserve custom IDs when selecting a voice.
- Explain authenticated relative preview paths and public preview URLs.

## Description

Clarifies catalog and preview semantics in the README, CLI documentation, and Python, TypeScript, and Rust types. Contract tests exercise discovery followed by configuration without rewriting custom IDs; CLI JSON coverage preserves private preview paths.

## Reason

Applications should use the current organization catalog without a fixed voice list and fetch previews with the correct authentication.

## Decisions

- **Compatibility:** Keep existing string-based APIs unchanged because they already support custom IDs; this adds documentation and regression coverage rather than a new release requirement.
- **Preview authentication:** Describe relative API paths separately from external public URLs so credentials are sent only to the API origin.

## Testing

- Python `hosted_agent.list_voices()` → `set_config(voice=...)`: preserves opaque IDs and preview paths; full suite 1,097 passed, 3 skipped; Ruff passed.
- TypeScript `hostedAgent.listVoices()` → `setConfig({voice})`: 14 voice-contract tests and TypeScript build passed. Broader suite had one unrelated vault timing timeout under shared-host load; the isolated vault-file retry passed. Final CI TypeScript suite passed.
- Rust `hosted_agent().list_voices()` → `set_config(...)`: full unit suite 261 passed, doc tests 3 passed / 1 ignored; formatting passed.
- `inkbox phone hosted-agent voices --json`: preserves IDs and previews; CLI build and 23 phone-command tests passed.

## Compatibility

No API signatures, package versions, or wire payloads change. Existing SDK releases already accept organization-specific voice IDs; availability is determined by the catalog returned to the caller.

## CI status

All final-head checks passed, including Python/TypeScript/Rust, CodeQL, plugin validation, and Python/TypeScript/CLI integration checks.
