### PR TITLE
fix: return false instead of throwing on a wrong-length webhook signature

### DIFF
--- a/sdk/typescript/src/signing_keys.ts
+++ b/sdk/typescript/src/signing_keys.ts
@@ -90,7 +90,13 @@ export function verifyWebhook({
   const message = Buffer.concat([Buffer.from(`${requestId}.${timestamp}.`), body]);
   const expected = createHmac("sha256", key).update(message).digest("hex");
   const received = signature.slice("sha256=".length);
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(received));
+  // Constant-time compare of the lowercase hex digests, matching Python's
+  // `hmac.compare_digest` and the Rust SDK. Differing lengths short-circuit to
+  // `false`: `timingSafeEqual` throws a RangeError on unequal buffer lengths.
+  const expectedBytes = Buffer.from(expected);
+  const receivedBytes = Buffer.from(received);
+  if (expectedBytes.length !== receivedBytes.length) return false;
+  return timingSafeEqual(expectedBytes, receivedBytes);
 }
 
 /**

--- a/sdk/typescript/tests/signing-keys.test.ts
+++ b/sdk/typescript/tests/signing-keys.test.ts
@@ -84,6 +84,22 @@ describe("verifyWebhook", () => {
   it("returns false when headers are missing", () => {
     expect(verifyWebhook({ payload: TEST_BODY, headers: {}, secret: TEST_KEY })).toBe(false);
   });
+
+  it("returns false for a truncated digest instead of throwing", () => {
+    expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders("sha256=abcd"), secret: TEST_KEY })).toBe(false);
+  });
+
+  it("returns false for an empty digest instead of throwing", () => {
+    expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders("sha256="), secret: TEST_KEY })).toBe(false);
+  });
+
+  it("returns false for an over-long digest instead of throwing", () => {
+    expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders(`sha256=${"a".repeat(65)}`), secret: TEST_KEY })).toBe(false);
+  });
+
+  it("returns false for an odd-length digest instead of throwing", () => {
+    expect(verifyWebhook({ payload: TEST_BODY, headers: makeHeaders(`sha256=${"a".repeat(63)}`), secret: TEST_KEY })).toBe(false);
+  });
 });
 
 describe("SigningKeysResource", () => {


### PR DESCRIPTION
Fixes #144.

`verifyWebhook` passes both digests straight to `timingSafeEqual`, which throws
`RangeError: Input buffers must have the same byte length` when the received
digest is not exactly 64 hex characters.

The consequence is worse than a bad return value. In a bare Node receiver the
throw is uncaught and **the process exits**, so one malformed signature takes
the whole webhook endpoint down and every request after it is refused. Behind a
framework that catches sync throws it surfaces as a 500 instead of a 403. Either
way it is attacker-triggerable with a single header.

Reproduced against a receiver that trusts the documented boolean return and does
not wrap the call in try/catch:

    before                                            after
    HTTP 200  valid signature           HTTP 200  valid signature
    HTTP 403  wrong digest              HTTP 403  wrong digest
    DEAD          truncated                   HTTP 403  truncated
    DEAD          empty                         HTTP 403  empty
    DEAD          over-long (65)           HTTP 403  over-long (65)
    DEAD          odd-length (63)        HTTP 403  odd-length (63)
    receiver:     DIED                           receiver:     still up

## Fix

Compare lengths first and return `false` when they differ, matching Python's
`hmac.compare_digest` and the explicit length guard already in `sdk/rust`, whose
comment notes the TS path is the odd one out.

The comparison is on the buffers actually handed to `timingSafeEqual`, not on
the strings. `expected` is always 64 ASCII hex chars, but `received` is
attacker-supplied, and a 64-character string is not necessarily 64 bytes:
`"é".repeat(32) + "a".repeat(32)` has `.length === 64` and
`Buffer.byteLength === 96`, so a string-length guard passes and the throw still
happens.

The received length is attacker-supplied rather than secret, so returning early
on it leaks nothing about the expected digest.

## Tests

Four cases added to `tests/signing-keys.test.ts`, all of which throw on `main`
and return `false` with this change: truncated, empty, over-long, odd-length.

Full suite passes (1099), `tsc --noEmit` clean, `signing_keys.ts` at 100% line
coverage.

No version bump or CHANGELOG entry, since releases move in lockstep per
RELEASING.md.

Note: #145 targets the same issue and predates this. Happy for either to land.
If you prefer #145, adding the byte comparison there closes the same gap.