### PR TITLE
0.6.11: Add verified domains and agent affiliations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "description": "Inkbox communication tools and SDK skills for Claude Code.",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "author": {
     "name": "Inkbox AI",
     "email": "hello@inkbox.ai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inkbox",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Inkbox communication tools and SDK skills.",
   "author": {
     "name": "Inkbox AI",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inkbox",
   "displayName": "Inkbox",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Give Cursor an Inkbox identity for email, SMS, iMessage, voice calls, contacts, notes, and agent-to-agent tasks.",
   "author": {
     "name": "Inkbox",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Inkbox SDK, CLI, and skills live here.
 Versions move in lockstep across `@inkbox/sdk` (TypeScript), `inkbox`
 (Python), `@inkbox/cli`, `inkbox` (Rust, crates.io), and the bundled plugin.
 
+## 0.6.11 — Verified domains
+
+### Added
+
+- Organization domain ownership claims with TXT instructions, verification, explicit transfer, and release in Python, TypeScript, Rust, and the CLI.
+- Agent domain affiliation with an explicit public-display choice. Authorized A2A participants can inspect current affiliations even when public display is off.
+- Exact verified-domain filtering for public A2A directory searches, including pagination. Task, context, message, and webhook types carry optional domain assertions and actual webhook senders.
+
+### Changed
+
+- SDK and CLI packages move to `0.6.11`; bundled plugin manifests move to Claude `0.6.11`, Codex `0.1.6`, and Cursor `1.0.4`.
+- Rust directory options and A2A response/webhook structs have new fields. Downstream exhaustive struct literals must include them; directory options can use `..Default::default()`.
+
 ## 0.6.10 — Release an iMessage connection
 
 ### Added

--- a/cli/README.md
+++ b/cli/README.md
@@ -823,3 +823,31 @@ The CLI honors `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` automatically on every 
 ## License
 
 MIT
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```bash
+inkbox organization-domain create example.com
+# Add the returned TXT record, then use its claim ID.
+inkbox organization-domain verify OrganizationDomainClaim_YOUR_ID
+inkbox identity domain-affiliation set helper OrganizationDomainClaim_YOUR_ID --visibility hidden
+inkbox identity domain-affiliation get helper
+inkbox a2a directory --public --verified-domain example.com
+```
+
+`organization-domain` provides `create`, `list`, `get`, `verify`, `transfer`, and
+`delete`. Transfer is explicit and requires fresh proof; it never happens merely
+by checking DNS. `identity domain-affiliation set` requires `--visibility public`
+or `--visibility hidden`. Use `remove <handle>` to stop all affiliation assertions.
+Use `--json` to inspect the complete response. Public search also accepts `--query`,
+`--cursor`, and `--limit`; preserve the same filters on every page.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/cli",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
-        "@inkbox/sdk": "^0.6.10",
+        "@inkbox/sdk": "^0.6.11",
         "commander": "^13.0.0",
         "undici": "^7.28.0"
       },
@@ -27,7 +27,7 @@
     },
     "../sdk/typescript": {
       "name": "@inkbox/sdk",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/cli",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "CLI for the Inkbox API",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@inkbox/sdk": "^0.6.10",
+    "@inkbox/sdk": "^0.6.11",
     "commander": "^13.0.0",
     "undici": "^7.28.0"
   },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -5,7 +5,7 @@ import { Inkbox } from "@inkbox/sdk";
 import type { Command } from "commander";
 
 // Keep in sync with package.json "version".
-export const CLI_VERSION = "0.6.10";
+export const CLI_VERSION = "0.6.11";
 
 export interface GlobalOpts {
   apiKey?: string;

--- a/cli/src/commands/a2a.ts
+++ b/cli/src/commands/a2a.ts
@@ -61,7 +61,7 @@ const CONTEXT_COLUMNS = [
   "lastActivityAt",
 ];
 const RULE_COLUMNS = ["id", "action", "matchTarget", "direction", "status"];
-const DIRECTORY_COLUMNS = ["name", "cardUrl", "visibility", "description"];
+const DIRECTORY_COLUMNS = ["name", "cardUrl", "visibility", "verifiedDomain", "description"];
 const INVITATION_COLUMNS = [
   "id",
   "status",
@@ -70,6 +70,14 @@ const INVITATION_COLUMNS = [
   "inviteeAgentHandle",
   "expiresAt",
 ];
+
+function directoryDomain(card: Record<string, unknown>): string {
+  const capabilities = card.capabilities as { extensions?: Array<{ uri?: string; params?: Record<string, unknown> }> } | undefined;
+  const assertion = capabilities?.extensions?.find((item) => item.uri === "https://inkbox.ai/a2a/extensions/domain-affiliation/v1")?.params;
+  return assertion?.verifier === "Inkbox" && typeof assertion.domain === "string"
+    && typeof assertion.valid_until === "string" && Date.parse(assertion.valid_until) > Date.now()
+    ? assertion.domain : "";
+}
 
 async function identityFor(command: Command, handle: string) {
   return createClient(getGlobalOpts(command)).getIdentity(handle);
@@ -311,6 +319,7 @@ export function registerA2ACommands(program: Command): void {
   a2a.command("directory")
     .description("Search the organization or public A2A directory")
     .option("--public", "Search the public directory")
+    .option("--verified-domain <domain>", "Exact verified domain (requires --public)")
     .option("-q, --query <query>", "Search handles, descriptions, and skills")
     .option("--cursor <cursor>", "Pagination cursor")
     .option("--limit <n>", "Results per page (1-100)", "50")
@@ -318,14 +327,17 @@ export function registerA2ACommands(program: Command): void {
       this: Command,
       options: {
         public?: boolean;
+        verifiedDomain?: string;
         query?: string;
         cursor?: string;
         limit: string;
       },
     ) {
       const client = createClient(getGlobalOpts(this));
+      if (options.verifiedDomain && !options.public) throw new TypeError("--verified-domain requires --public");
       const result = options.public
         ? await client.a2a.publicDirectory({
+          verifiedDomain: options.verifiedDomain,
           q: options.query,
           cursor: options.cursor,
           limit: positiveInt(options.limit, "--limit"),
@@ -343,6 +355,7 @@ export function registerA2ACommands(program: Command): void {
           ...item,
           name: item.card.name,
           description: item.card.description ?? "",
+          verifiedDomain: directoryDomain(item.card),
         })),
       );
     }));

--- a/cli/src/commands/identity.ts
+++ b/cli/src/commands/identity.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { createClient, getGlobalOpts } from "../client.js";
 import { output } from "../output.js";
 import { withErrorHandler } from "../errors.js";
@@ -325,6 +325,25 @@ export function registerIdentityCommands(program: Command): void {
   const identity = program
     .command("identity")
     .description("Manage agent identities");
+
+  const affiliation = identity.command("domain-affiliation")
+    .description("Manage an agent's verified domain (admin API key required)");
+  affiliation.command("get <handle>")
+    .action(withErrorHandler(async function (this: Command, handle: string) {
+      output(await createClient(getGlobalOpts(this)).identities.getDomainAffiliation(handle), { json: !!getGlobalOpts(this).json });
+    }));
+  affiliation.command("set <handle> <claim-id>")
+    .addOption(new Option("--visibility <visibility>", "Public display; hidden affiliations remain visible to authorized A2A peers").choices(["public", "hidden"]).makeOptionMandatory())
+    .action(withErrorHandler(async function (this: Command, handle: string, claimId: string, options: { visibility: string }) {
+      output(await createClient(getGlobalOpts(this)).identities.setDomainAffiliation(handle, {
+        domainClaimId: claimId, publishPublicly: options.visibility === "public",
+      }), { json: !!getGlobalOpts(this).json });
+    }));
+  affiliation.command("remove <handle>")
+    .action(withErrorHandler(async function (this: Command, handle: string) {
+      await createClient(getGlobalOpts(this)).identities.removeDomainAffiliation(handle);
+      output({ removed: handle }, { json: !!getGlobalOpts(this).json });
+    }));
 
   identity
     .command("list")

--- a/cli/src/commands/organization-domain.ts
+++ b/cli/src/commands/organization-domain.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import { createClient, getGlobalOpts } from "../client.js";
+import { withErrorHandler } from "../errors.js";
+import { output } from "../output.js";
+
+export function registerOrganizationDomainCommands(program: Command): void {
+  const domains = program.command("organization-domain")
+    .description("Certify domain ownership (admin API key required)");
+
+  domains.command("create <domain>")
+    .description("Create a TXT challenge without publishing an agent's affiliation")
+    .action(withErrorHandler(async function (this: Command, domain: string) {
+      output(await createClient(getGlobalOpts(this)).organizationDomains.create(domain), { json: !!getGlobalOpts(this).json });
+    }));
+
+  domains.command("list")
+    .option("--cursor <cursor>", "Pagination cursor")
+    .option("--limit <n>", "Results per page (1-100)", "50")
+    .action(withErrorHandler(async function (this: Command, options: { cursor?: string; limit: string }) {
+      const limit = Number(options.limit);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 100) throw new TypeError("limit must be between 1 and 100");
+      const page = await createClient(getGlobalOpts(this)).organizationDomains.list({ cursor: options.cursor, limit });
+      const json = !!getGlobalOpts(this).json;
+      output(json ? page : page.items, { json, columns: ["id", "domain", "state", "validUntil", "ownershipConflict"] });
+      if (!json && page.nextCursor) console.error(`Next cursor: ${page.nextCursor}`);
+    }));
+
+  for (const [name, description] of [
+    ["get", "Show a claim and its exact TXT instructions"],
+    ["verify", "Recheck DNS proof for a claim"],
+    ["transfer", "Explicitly request ownership transfer using fresh DNS proof"],
+  ] as const) {
+    domains.command(`${name} <claim-id>`).description(description)
+      .action(withErrorHandler(async function (this: Command, claimId: string) {
+        output(await createClient(getGlobalOpts(this)).organizationDomains[name](claimId), { json: !!getGlobalOpts(this).json });
+      }));
+  }
+
+  domains.command("delete <claim-id>")
+    .description("Release a claim and remove its agents' affiliations")
+    .action(withErrorHandler(async function (this: Command, claimId: string) {
+      await createClient(getGlobalOpts(this)).organizationDomains.delete(claimId);
+      output({ released: claimId }, { json: !!getGlobalOpts(this).json });
+    }));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -21,6 +21,7 @@ import { registerWebhookCommands } from "./commands/webhook.js";
 import { registerContactsCommands } from "./commands/contacts.js";
 import { registerNotesCommands } from "./commands/notes.js";
 import { registerDomainCommands } from "./commands/domain.js";
+import { registerOrganizationDomainCommands } from "./commands/organization-domain.js";
 import { registerA2ACommands } from "./commands/a2a.js";
 
 // Node's fetch ignores HTTP(S)_PROXY/NO_PROXY unless NODE_USE_ENV_PROXY is
@@ -65,6 +66,7 @@ registerWebhookCommands(program);
 registerContactsCommands(program);
 registerNotesCommands(program);
 registerDomainCommands(program);
+registerOrganizationDomainCommands(program);
 registerA2ACommands(program);
 
 program.parse();

--- a/cli/tests/organization-domain-command.test.mjs
+++ b/cli/tests/organization-domain-command.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { promisify } from "node:util";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const cli = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const exec = promisify(execFile);
+const fixture = JSON.parse(readFileSync(new URL("../../tests/fixtures/domain-certification.json", import.meta.url), "utf8"));
+
+test("claim commands, explicit publication, and filtered directory use the intended contracts", async (t) => {
+  const calls = [];
+  const server = createServer(async (request, response) => {
+    let raw = "";
+    for await (const chunk of request) raw += chunk;
+    const url = new URL(request.url, "http://localhost");
+    calls.push({ method: request.method, url, body: raw ? JSON.parse(raw) : null });
+    response.setHeader("content-type", "application/json");
+    if (request.method === "DELETE") { response.statusCode = 204; response.end(); return; }
+    if (url.pathname.endsWith("domain-affiliation")) {
+      response.end(JSON.stringify({ domain_claim_id: "claim", domain: "example.com", publish_publicly: false, affiliation: null }));
+    } else if (url.pathname === "/a2a/directory") {
+      response.end(JSON.stringify({ items: [{ card_url: "https://inkbox.ai/a2a/helper/card", visibility: "public", card: {
+        name: "@helper", capabilities: { extensions: [{ uri: "https://inkbox.ai/a2a/extensions/domain-affiliation/v1", params: fixture.affiliation }] },
+      } }], next_cursor: "next" }));
+    } else if (url.pathname.endsWith("organization-domains") && request.method === "GET") {
+      response.end(JSON.stringify({ items: [fixture.claim], next_cursor: "next" }));
+    } else { response.end(JSON.stringify(fixture.claim)); }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => server.close());
+  const env = { ...process.env, INKBOX_API_KEY: "test-key", INKBOX_BASE_URL: `http://127.0.0.1:${server.address().port}`, NODE_USE_ENV_PROXY: "0" };
+  const run = (...args) => exec(process.execPath, [cli, ...args], { env });
+  const claim = JSON.parse((await run("--json", "organization-domain", "create", "example.com")).stdout);
+  assert.equal(claim.dnsRecord.name, "_inkbox.example.com");
+  for (const action of ["get", "verify", "transfer", "delete"]) await run("--json", "organization-domain", action, "claim");
+  await run("organization-domain", "list", "--cursor", "before");
+  await assert.rejects(run("identity", "domain-affiliation", "set", "helper", "claim"), /required option/);
+  await run("--json", "identity", "domain-affiliation", "set", "@helper", "claim", "--visibility", "hidden");
+  await run("identity", "domain-affiliation", "get", "helper");
+  await run("identity", "domain-affiliation", "remove", "helper");
+  assert.deepEqual(calls.find((call) => call.method === "PUT").body, { domain_claim_id: "claim", publish_publicly: false });
+  assert(calls.some((call) => call.url.pathname === "/api/v1/identities/%40helper/domain-affiliation"));
+  await assert.rejects(run("a2a", "directory", "--verified-domain", "example.com"), /requires --public/);
+  const table = await run("a2a", "directory", "--public", "--verified-domain", "example.com", "--cursor", "next", "--query", "helper");
+  assert.match(table.stdout, /example.com/);
+  const directory = calls.find((call) => call.url.pathname === "/a2a/directory");
+  assert.equal(directory.url.searchParams.get("verified_domain"), "example.com");
+  assert.equal(directory.url.searchParams.get("cursor"), "next");
+  assert.equal(directory.url.searchParams.get("q"), "helper");
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1671,3 +1671,35 @@ Runnable example scripts are available in the [examples/python](https://github.c
 ## License
 
 MIT
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```python
+from inkbox import Inkbox
+
+client = Inkbox()
+claim = client.organization_domains.create("example.com")
+print(claim.dns_record.name, claim.dns_record.value)
+# Add the exact TXT record before verifying.
+claim = client.organization_domains.verify(claim.id)
+if claim.state == "verified":
+    client.identities.set_domain_affiliation("helper", claim.id, publish_publicly=False)
+for item in client.a2a.iter_public_directory(verified_domain="example.com"):
+    print(item.card.name)
+```
+
+Claim methods: `create`, `list`, `get`, `verify`, `transfer`, `delete`.
+Use `client.identities.get_domain_affiliation(handle)` to inspect saved settings,
+`set_domain_affiliation(..., publish_publicly=True)` to publish explicitly, and
+`remove_domain_affiliation(handle)` to remove the selection. Task and context
+participants expose optional `.affiliation`; message assertions identify the author.

--- a/sdk/python/inkbox/__init__.py
+++ b/sdk/python/inkbox/__init__.py
@@ -312,6 +312,7 @@ from inkbox.signing_keys import SigningKey, SigningKeyStatus, verify_webhook
 
 # Receiver-side webhook payload types
 from inkbox.webhooks import (
+    DomainAffiliationPayload,
     A2AWebhookCaller,
     A2AWebhookData,
     A2AWebhookEventType,
@@ -401,7 +402,12 @@ from inkbox.webhook_deliveries import (
 # API keys
 from inkbox.api_keys.types import ApiKey, ApiKeyStatus, CreatedApiKey
 
+from inkbox.domain_affiliation import DomainAffiliation
+from inkbox.organization_domains import DomainClaimState, DomainTxtRecord, IdentityDomainAffiliation, OrganizationDomain, OrganizationDomainPage, OrganizationDomainsResource
+
 __all__ = [
+    "DomainAffiliation", "DomainClaimState", "DomainTxtRecord", "IdentityDomainAffiliation",
+    "OrganizationDomain", "OrganizationDomainPage", "OrganizationDomainsResource",
     # A2A
     "A2ACard",
     "A2ACaller",
@@ -673,6 +679,7 @@ __all__ = [
     "SigningKeyStatus",
     "verify_webhook",
     # Receiver-side webhook payload types
+    "DomainAffiliationPayload",
     "A2AWebhookCaller",
     "A2AWebhookData",
     "A2AWebhookEventType",

--- a/sdk/python/inkbox/a2a/resource.py
+++ b/sdk/python/inkbox/a2a/resource.py
@@ -104,10 +104,12 @@ class A2AResource:
         q: str | None = None,
         cursor: str | None = None,
         limit: int = 50,
+        verified_domain: str | None = None,
     ) -> A2ADirectoryPage:
         data = self._public_http.get(
             "/a2a/directory",
-            params={"q": q, "cursor": cursor, "limit": limit},
+            params={"q": q, "cursor": cursor, "limit": limit,
+                    **({"verified_domain": verified_domain} if verified_domain is not None else {})},
         )
         return self._parse_directory(data)
 
@@ -129,8 +131,9 @@ class A2AResource:
         *,
         q: str | None = None,
         limit: int = 50,
+        verified_domain: str | None = None,
     ) -> Iterator[A2ADirectoryItem]:
-        yield from self._iter_directory(public=True, q=q, limit=limit)
+        yield from self._iter_directory(public=True, q=q, limit=limit, verified_domain=verified_domain)
 
     def iter_organization_directory(
         self,
@@ -146,11 +149,12 @@ class A2AResource:
         public: bool,
         q: str | None,
         limit: int,
+        verified_domain: str | None = None,
     ) -> Iterator[A2ADirectoryItem]:
         cursor = None
         while True:
             page = (
-                self.public_directory(q=q, cursor=cursor, limit=limit)
+                self.public_directory(q=q, cursor=cursor, limit=limit, verified_domain=verified_domain)
                 if public
                 else self.organization_directory(q=q, cursor=cursor, limit=limit)
             )

--- a/sdk/python/inkbox/a2a/types.py
+++ b/sdk/python/inkbox/a2a/types.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
+from inkbox.domain_affiliation import DomainAffiliation, parse_domain_affiliation
 
 
 class ForwardCompatibleStrEnum(StrEnum):
@@ -142,6 +143,7 @@ class A2ACaller:
     organization_id: str
     handle: str | None
     trust_tier: str = "inkbox_verified"
+    affiliation: DomainAffiliation | None = None
 
 
 @dataclass(frozen=True)
@@ -149,6 +151,7 @@ class A2ATarget:
     identity_id: str
     organization_id: str
     handle: str | None
+    affiliation: DomainAffiliation | None = None
 
 
 @dataclass(frozen=True)
@@ -161,6 +164,7 @@ class A2AMessage:
     extensions: list[str] | None
     reference_task_ids: list[str] | None
     created_at: datetime
+    affiliation: DomainAffiliation | None = None
 
 
 @dataclass(frozen=True)
@@ -216,6 +220,7 @@ class A2AHistoryMessage:
     extensions: list[str] | None
     reference_task_ids: list[str] | None
     created_at: datetime
+    affiliation: DomainAffiliation | None = None
 
 
 @dataclass(frozen=True)
@@ -313,6 +318,7 @@ def parse_caller(data: dict[str, Any]) -> A2ACaller:
         organization_id=data["organization_id"],
         handle=data.get("handle"),
         trust_tier=data.get("trust_tier", "inkbox_verified"),
+        affiliation=parse_domain_affiliation(data.get("affiliation")),
     )
 
 
@@ -323,6 +329,7 @@ def parse_target(data: dict[str, Any] | None) -> A2ATarget | None:
         identity_id=data["identity_id"],
         organization_id=data["organization_id"],
         handle=data.get("handle"),
+        affiliation=parse_domain_affiliation(data.get("affiliation")),
     )
 
 
@@ -336,6 +343,7 @@ def parse_message(data: dict[str, Any]) -> A2AMessage:
         extensions=data.get("extensions"),
         reference_task_ids=data.get("reference_task_ids"),
         created_at=parse_datetime(data["created_at"]),  # type: ignore[arg-type]
+        affiliation=parse_domain_affiliation(data.get("affiliation")),
     )
 
 
@@ -382,4 +390,5 @@ def parse_history_message(data: dict[str, Any]) -> A2AHistoryMessage:
         extensions=data.get("extensions"),
         reference_task_ids=data.get("reference_task_ids"),
         created_at=parse_datetime(data["created_at"]),  # type: ignore[arg-type]
+        affiliation=parse_domain_affiliation(data.get("affiliation")),
     )

--- a/sdk/python/inkbox/client.py
+++ b/sdk/python/inkbox/client.py
@@ -16,6 +16,7 @@ from inkbox._http import CONNECT_RETRIES, HttpTransport, sdk_user_agent
 from inkbox._config import resolve_client_settings
 from inkbox._cookies import CookieJar
 from inkbox.a2a.resource import A2AResource
+from inkbox.organization_domains import OrganizationDomainsResource
 from inkbox.a2a.invitations import (
     A2AInvitationPreview,
     A2AInvitationsResource,
@@ -294,6 +295,7 @@ class Inkbox:
         self._api_keys = ApiKeysResource(self._api_http)
         self._ids_resource = IdentitiesResource(self._ids_http)
         self._a2a = A2AResource(self._api_http, self._public_http)
+        self._organization_domains = OrganizationDomainsResource(self._api_http)
         self._a2a_invitations = A2AInvitationsResource(self._api_http, self._base_url)
 
         self._contacts = ContactsResource(self._contacts_http)
@@ -440,6 +442,11 @@ class Inkbox:
         return self._domains
 
     @property
+    def organization_domains(self) -> OrganizationDomainsResource:
+        """Verify domain control and manage organization claims."""
+        return self._organization_domains
+
+    @property
     def tunnels(self) -> TunnelsResource:
         """Tunnels (list, get, update, sign_csr). Tunnel lifecycle is owned by identity-create / identity-delete."""
         return self._tunnels
@@ -562,6 +569,11 @@ class Inkbox:
             vault_secret_ids=vault_secret_ids,
         )
         return AgentIdentity(data, self)
+
+    @property
+    def identities(self) -> IdentitiesResource:
+        """Identity administration, including domain affiliation."""
+        return self._ids_resource
 
     def get_identity(self, agent_handle: str) -> AgentIdentity:
         """

--- a/sdk/python/inkbox/domain_affiliation.py
+++ b/sdk/python/inkbox/domain_affiliation.py
@@ -1,0 +1,25 @@
+"""Verified-domain assertions supplied by Inkbox."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+DOMAIN_AFFILIATION_EXTENSION = "https://inkbox.ai/a2a/extensions/domain-affiliation/v1"
+
+
+@dataclass(frozen=True)
+class DomainAffiliation:
+    domain: str
+    verifier: str
+    last_success_at: datetime
+    valid_until: datetime
+
+
+def parse_domain_affiliation(data: dict[str, Any] | None) -> DomainAffiliation | None:
+    if data is None:
+        return None
+    return DomainAffiliation(
+        domain=data["domain"], verifier=data["verifier"],
+        last_success_at=datetime.fromisoformat(data["last_success_at"].replace("Z", "+00:00")),
+        valid_until=datetime.fromisoformat(data["valid_until"].replace("Z", "+00:00")),
+    )

--- a/sdk/python/inkbox/identities/resources/identities.py
+++ b/sdk/python/inkbox/identities/resources/identities.py
@@ -7,6 +7,9 @@ Identity CRUD. Mailbox and tunnel are provisioned atomically by
 
 from __future__ import annotations
 
+from urllib.parse import quote
+from inkbox.organization_domains.types import IdentityDomainAffiliation, parse_identity_domain_affiliation
+
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
@@ -30,6 +33,17 @@ if TYPE_CHECKING:
 class IdentitiesResource:
     def __init__(self, http: HttpTransport) -> None:
         self._http = http
+
+    def get_domain_affiliation(self, agent_handle: str) -> IdentityDomainAffiliation:
+        return parse_identity_domain_affiliation(self._http.get(f"/{quote(agent_handle, safe='')}/domain-affiliation"))
+
+    def set_domain_affiliation(self, agent_handle: str, domain_claim_id: str, *, publish_publicly: bool) -> IdentityDomainAffiliation:
+        return parse_identity_domain_affiliation(self._http.put(f"/{quote(agent_handle, safe='')}/domain-affiliation", json={
+            "domain_claim_id": domain_claim_id, "publish_publicly": publish_publicly,
+        }))
+
+    def remove_domain_affiliation(self, agent_handle: str) -> None:
+        self._http.delete(f"/{quote(agent_handle, safe='')}/domain-affiliation")
 
     def create(
         self,

--- a/sdk/python/inkbox/organization_domains/__init__.py
+++ b/sdk/python/inkbox/organization_domains/__init__.py
@@ -1,0 +1,7 @@
+from inkbox.organization_domains.resource import OrganizationDomainsResource
+from inkbox.organization_domains.types import (
+    DomainClaimState, DomainTxtRecord, IdentityDomainAffiliation, OrganizationDomain, OrganizationDomainPage,
+)
+
+__all__ = ["OrganizationDomainsResource", "DomainClaimState", "DomainTxtRecord", "IdentityDomainAffiliation",
+           "OrganizationDomain", "OrganizationDomainPage"]

--- a/sdk/python/inkbox/organization_domains/resource.py
+++ b/sdk/python/inkbox/organization_domains/resource.py
@@ -1,0 +1,31 @@
+"""Domain control verification for organization administrators."""
+
+from urllib.parse import quote
+
+from inkbox._http import HttpTransport
+from inkbox.organization_domains.types import OrganizationDomain, OrganizationDomainPage, parse_organization_domain
+
+
+class OrganizationDomainsResource:
+    def __init__(self, http: HttpTransport) -> None:
+        self._http = http
+
+    def create(self, domain: str) -> OrganizationDomain:
+        return parse_organization_domain(self._http.post("/organization-domains", json={"domain": domain}))
+
+    def list(self, *, cursor: str | None = None, limit: int = 50) -> OrganizationDomainPage:
+        data = self._http.get("/organization-domains", params={"cursor": cursor, "limit": limit})
+        return OrganizationDomainPage(items=[parse_organization_domain(row) for row in data["items"]],
+                                      next_cursor=data.get("next_cursor"))
+
+    def get(self, claim_id: str) -> OrganizationDomain:
+        return parse_organization_domain(self._http.get(f"/organization-domains/{quote(claim_id, safe='')}"))
+
+    def verify(self, claim_id: str) -> OrganizationDomain:
+        return parse_organization_domain(self._http.post(f"/organization-domains/{quote(claim_id, safe='')}/verify"))
+
+    def transfer(self, claim_id: str) -> OrganizationDomain:
+        return parse_organization_domain(self._http.post(f"/organization-domains/{quote(claim_id, safe='')}/transfer"))
+
+    def delete(self, claim_id: str) -> None:
+        self._http.delete(f"/organization-domains/{quote(claim_id, safe='')}")

--- a/sdk/python/inkbox/organization_domains/types.py
+++ b/sdk/python/inkbox/organization_domains/types.py
@@ -1,0 +1,79 @@
+"""Organization-domain management types."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from inkbox.a2a.types import ForwardCompatibleStrEnum, parse_datetime
+from inkbox.domain_affiliation import DomainAffiliation, parse_domain_affiliation
+
+
+class DomainClaimState(ForwardCompatibleStrEnum):
+    PENDING = "pending"
+    VERIFIED = "verified"
+    GRACE = "grace"
+    EXPIRED = "expired"
+    PENDING_EXPIRED = "pending_expired"
+    RELEASED = "released"
+
+
+@dataclass(frozen=True)
+class DomainTxtRecord:
+    type: str
+    name: str
+    value: str
+
+
+@dataclass(frozen=True)
+class OrganizationDomain:
+    id: str
+    domain: str
+    state: DomainClaimState
+    dns_record: DomainTxtRecord
+    verified_at: datetime | None
+    last_checked_at: datetime | None
+    last_success_at: datetime | None
+    valid_until: datetime | None
+    pending_expires_at: datetime | None
+    next_check_at: datetime | None
+    last_check_result: str | None
+    ownership_conflict: bool
+    transfer_eligible: bool
+    recovery_action: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class OrganizationDomainPage:
+    items: list[OrganizationDomain]
+    next_cursor: str | None
+
+
+@dataclass(frozen=True)
+class IdentityDomainAffiliation:
+    domain_claim_id: str | None
+    domain: str | None
+    publish_publicly: bool
+    affiliation: DomainAffiliation | None
+
+
+def parse_organization_domain(data: dict[str, Any]) -> OrganizationDomain:
+    return OrganizationDomain(
+        id=data["id"], domain=data["domain"], state=DomainClaimState(data["state"]),
+        dns_record=DomainTxtRecord(**data["dns_record"]),
+        verified_at=parse_datetime(data.get("verified_at")),
+        last_checked_at=parse_datetime(data.get("last_checked_at")),
+        last_success_at=parse_datetime(data.get("last_success_at")),
+        valid_until=parse_datetime(data.get("valid_until")),
+        pending_expires_at=parse_datetime(data.get("pending_expires_at")),
+        next_check_at=parse_datetime(data.get("next_check_at")), last_check_result=data.get("last_check_result"),
+        ownership_conflict=data.get("ownership_conflict", False), transfer_eligible=data.get("transfer_eligible", False),
+        recovery_action=data.get("recovery_action"),
+        created_at=datetime.fromisoformat(data["created_at"].replace("Z", "+00:00")),
+    )
+
+
+def parse_identity_domain_affiliation(data: dict[str, Any]) -> IdentityDomainAffiliation:
+    return IdentityDomainAffiliation(domain_claim_id=data.get("domain_claim_id"), domain=data.get("domain"),
+                                    publish_publicly=data.get("publish_publicly", False),
+                                    affiliation=parse_domain_affiliation(data.get("affiliation")))

--- a/sdk/python/inkbox/webhooks.py
+++ b/sdk/python/inkbox/webhooks.py
@@ -793,13 +793,22 @@ A2AWebhookEventType = Literal[
 ]
 
 
+class DomainAffiliationPayload(TypedDict):
+    domain: str
+    verifier: str
+    last_success_at: str
+    valid_until: str
+
+
 class A2AWebhookCaller(TypedDict):
+    affiliation: NotRequired[DomainAffiliationPayload | None]
     identity_id: str
     organization_id: str
     handle: str | None
 
 
 class A2AWebhookData(TypedDict):
+    sender: NotRequired[A2AWebhookCaller | None]
     task_id: str
     context_id: str
     state: str

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "inkbox"
-version = "0.6.10"
+version = "0.6.11"
 description = "Python SDK for the Inkbox API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sdk/python/tests/test_organization_domains.py
+++ b/sdk/python/tests/test_organization_domains.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from inkbox import Inkbox
+from inkbox.a2a.resource import A2AResource
+from inkbox.domain_affiliation import parse_domain_affiliation
+from inkbox.organization_domains.resource import OrganizationDomainsResource
+
+FIXTURE = json.loads((Path(__file__).parents[3] / "tests/fixtures/domain-certification.json").read_text())
+
+
+def test_claim_methods_encoding_and_unknown_state():
+    http = MagicMock()
+    http.post.return_value = http.get.return_value = {**FIXTURE["claim"], "state": "future_state"}
+    resource = OrganizationDomainsResource(http)
+    assert resource.create("example.com").state == "future_state"
+    http.post.assert_called_with("/organization-domains", json={"domain": "example.com"})
+    assert resource.get("claim/id").dns_record.name == "_inkbox.example.com"
+    http.get.assert_called_with("/organization-domains/claim%2Fid")
+    for action in ("verify", "transfer"):
+        getattr(resource, action)("claim/id")
+        http.post.assert_called_with(f"/organization-domains/claim%2Fid/{action}")
+    resource.delete("claim/id")
+    http.delete.assert_called_once_with("/organization-domains/claim%2Fid")
+    http.get.return_value = {"items": [FIXTURE["claim"]], "next_cursor": "next"}
+    assert resource.list(cursor="before").next_cursor == "next"
+    http.get.assert_called_with("/organization-domains", params={"cursor": "before", "limit": 50})
+
+
+def test_public_identity_resource_requires_explicit_publication_and_preserves_expired_selection():
+    client = Inkbox(api_key="test-key")
+    http = MagicMock()
+    client.identities._http = http
+    http.get.return_value = http.put.return_value = {
+        "domain_claim_id": "claim", "domain": "example.com", "publish_publicly": False, "affiliation": None,
+    }
+    assert client.identities.get_domain_affiliation("@helper").domain_claim_id == "claim"
+    http.get.assert_called_with("/%40helper/domain-affiliation")
+    with pytest.raises(TypeError):
+        client.identities.set_domain_affiliation("helper", "claim")
+    client.identities.set_domain_affiliation("@helper", "claim", publish_publicly=False)
+    http.put.assert_called_with("/%40helper/domain-affiliation", json={"domain_claim_id": "claim", "publish_publicly": False})
+    client.identities.remove_domain_affiliation("@helper")
+    http.delete.assert_called_with("/%40helper/domain-affiliation")
+
+
+def test_filtered_iterator_preserves_filter_and_raw_card_extension():
+    http = MagicMock()
+    item = {"card_url": "https://inkbox.ai/a2a/helper/card", "visibility": "public", "card": {
+        "name": "@helper", "capabilities": {"extensions": [{
+            "uri": "https://inkbox.ai/a2a/extensions/domain-affiliation/v1", "params": FIXTURE["affiliation"],
+        }]},
+    }}
+    http.get.side_effect = [{"items": [item], "next_cursor": "next"}, {"items": [item], "next_cursor": None}]
+    items = list(A2AResource(MagicMock(), http).iter_public_directory(q="help", verified_domain="example.com"))
+    assert len(items) == 2
+    assert all(call.kwargs["params"]["verified_domain"] == "example.com" for call in http.get.call_args_list)
+    assert http.get.call_args_list[1].kwargs["params"]["cursor"] == "next"
+    assert parse_domain_affiliation(None) is None
+    assert parse_domain_affiliation(FIXTURE["affiliation"]).domain == "example.com"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.10"
+version = "0.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "inkbox"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "inkbox"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 rust-version = "1.74"
 description = "Rust SDK for the Inkbox API"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -580,3 +580,35 @@ WebSocket). See `src/tunnels/client/`.
 ## License
 
 MIT
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```rust
+let client = inkbox::Inkbox::from_env()?;
+let claim = client.organization_domains().create("example.com")?;
+println!("{} {}", claim.dns_record.name, claim.dns_record.value);
+// Add the exact TXT record before verifying.
+let claim = client.organization_domains().verify(&claim.id)?;
+if claim.state == "verified" {
+    client.identities().set_domain_affiliation("helper", &claim.id, false)?;
+}
+let page = client.a2a().public_directory(&inkbox::a2a::A2ADirectoryListOptions {
+    verified_domain: Some("example.com".into()),
+    ..Default::default()
+})?;
+```
+
+Claim methods: `create`, `list`, `get`, `verify`, `transfer`, `delete`.
+Identity resources expose `get_domain_affiliation`, `set_domain_affiliation`, and
+`remove_domain_affiliation`. The boolean publication argument is required.
+A2A participants and messages expose optional `affiliation` values.

--- a/sdk/rust/src/a2a/resource.rs
+++ b/sdk/rust/src/a2a/resource.rs
@@ -45,6 +45,14 @@ impl A2AResource {
         options: &A2ADirectoryListOptions,
     ) -> Result<A2ADirectoryPage> {
         let mut params = Vec::new();
+        if let Some(domain) = &options.verified_domain {
+            if !public {
+                return Err(InkboxError::InvalidArgument(
+                    "verified_domain is only available in the public directory".into(),
+                ));
+            }
+            params.push(("verified_domain", domain.clone()));
+        }
         if let Some(value) = &options.q {
             params.push(("q", value.clone()));
         }
@@ -424,6 +432,7 @@ mod tests {
             q: Some("research".to_string()),
             cursor: Some("page".to_string()),
             limit: Some(20),
+            ..Default::default()
         };
 
         let public_page = client.a2a().public_directory(&options).unwrap();

--- a/sdk/rust/src/a2a/types.rs
+++ b/sdk/rust/src/a2a/types.rs
@@ -1,3 +1,4 @@
+use crate::organization_domains::DomainAffiliation;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
@@ -84,6 +85,7 @@ pub struct A2AContextListOptions {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct A2ADirectoryListOptions {
+    pub verified_domain: Option<String>,
     pub q: Option<String>,
     pub cursor: Option<String>,
     pub limit: Option<u32>,
@@ -114,6 +116,8 @@ pub struct A2ADirectoryPage {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2ACaller {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affiliation: Option<DomainAffiliation>,
     pub identity_id: Uuid,
     pub organization_id: String,
     pub handle: Option<String>,
@@ -122,6 +126,8 @@ pub struct A2ACaller {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2ATarget {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affiliation: Option<DomainAffiliation>,
     pub identity_id: Uuid,
     pub organization_id: String,
     pub handle: Option<String>,
@@ -129,6 +135,8 @@ pub struct A2ATarget {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2AMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affiliation: Option<DomainAffiliation>,
     pub id: Uuid,
     pub message_id: String,
     pub role: String,
@@ -166,6 +174,8 @@ pub struct A2ATaskPage {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2AHistoryMessage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affiliation: Option<DomainAffiliation>,
     pub id: Uuid,
     pub message_id: String,
     pub task_id: Uuid,

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -7,6 +7,7 @@
 //! `Arc<Inkbox>` (built with [`Arc::new_cyclic`] so the tunnels resource can
 //! capture a `Weak` without a reference cycle).
 
+use crate::organization_domains::OrganizationDomainsResource;
 use std::sync::{Arc, Weak};
 
 use serde_json::Value;
@@ -170,6 +171,7 @@ pub struct Inkbox {
     identities: IdentitiesResource,
     tunnels: TunnelsResource,
     a2a: A2AResource,
+    organization_domains: OrganizationDomainsResource,
 
     // Transport used for the bare `/api` root (whoami, signup parity).
     root_api_http: Arc<HttpTransport>,
@@ -297,6 +299,7 @@ impl Inkbox {
             api_keys: ApiKeysResource::new(api_http.clone()),
             identities: IdentitiesResource::new(ids_http.clone()),
             tunnels: TunnelsResource::new(api_http.clone(), weak.clone()),
+            organization_domains: OrganizationDomainsResource::new(api_http.clone()),
             a2a: A2AResource::new(api_http.clone(), public_http.clone(), trimmed.to_string()),
 
             root_api_http: root_api_http.clone(),
@@ -418,6 +421,10 @@ impl Inkbox {
     pub fn tunnels(&self) -> &TunnelsResource {
         &self.tunnels
     }
+    pub fn organization_domains(&self) -> &OrganizationDomainsResource {
+        &self.organization_domains
+    }
+
     pub fn a2a(&self) -> &A2AResource {
         &self.a2a
     }

--- a/sdk/rust/src/identities/resources/identities.rs
+++ b/sdk/rust/src/identities/resources/identities.rs
@@ -18,6 +18,7 @@ use crate::identities::types::{
     AgentIdentityData, AgentIdentitySummary, IdentityMailboxCreateOptions,
     IdentityPhoneNumberCreateOptions, IdentityTunnelCreateOptions, Unset, VaultSecretIds,
 };
+use crate::organization_domains::{path_segment, IdentityDomainAffiliation};
 use uuid::Uuid;
 
 pub struct IdentitiesResource {
@@ -27,6 +28,30 @@ pub struct IdentitiesResource {
 impl IdentitiesResource {
     pub fn new(http: Arc<HttpTransport>) -> Self {
         Self { http }
+    }
+
+    pub fn get_domain_affiliation(&self, agent_handle: &str) -> Result<IdentityDomainAffiliation> {
+        Ok(serde_json::from_value(self.http.get(
+            &format!("/{}/domain-affiliation", path_segment(agent_handle)),
+            crate::http::NO_QUERY,
+        )?)?)
+    }
+
+    pub fn set_domain_affiliation(
+        &self,
+        agent_handle: &str,
+        domain_claim_id: &str,
+        publish_publicly: bool,
+    ) -> Result<IdentityDomainAffiliation> {
+        Ok(serde_json::from_value(self.http.put(&format!("/{}/domain-affiliation", path_segment(agent_handle)),
+            &serde_json::json!({"domain_claim_id": domain_claim_id, "publish_publicly": publish_publicly}))?)?)
+    }
+
+    pub fn remove_domain_affiliation(&self, agent_handle: &str) -> Result<()> {
+        self.http.delete(&format!(
+            "/{}/domain-affiliation",
+            path_segment(agent_handle)
+        ))
     }
 
     /// Create a new agent identity. Atomically provisions the identity's

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -65,3 +65,9 @@ pub use client::{Inkbox, InkboxBuilder, DEFAULT_BASE_URL};
 pub use credentials::Credentials;
 pub use error::{ApiErrorDetail, InkboxError, Result};
 pub use filters::DateRangeFilter;
+
+pub mod organization_domains;
+pub use organization_domains::{
+    DomainAffiliation, DomainTxtRecord, IdentityDomainAffiliation, OrganizationDomain,
+    OrganizationDomainListOptions, OrganizationDomainPage, OrganizationDomainsResource,
+};

--- a/sdk/rust/src/organization_domains.rs
+++ b/sdk/rust/src/organization_domains.rs
@@ -1,0 +1,253 @@
+//! Organization domain control and agent affiliation.
+
+use crate::error::Result;
+use crate::http::{HttpTransport, NO_QUERY};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainAffiliation {
+    pub domain: String,
+    pub verifier: String,
+    pub last_success_at: String,
+    pub valid_until: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainTxtRecord {
+    #[serde(rename = "type")]
+    pub record_type: String,
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationDomain {
+    pub id: String,
+    pub domain: String,
+    pub state: String,
+    pub dns_record: DomainTxtRecord,
+    pub verified_at: Option<String>,
+    pub last_checked_at: Option<String>,
+    pub last_success_at: Option<String>,
+    pub valid_until: Option<String>,
+    pub pending_expires_at: Option<String>,
+    pub next_check_at: Option<String>,
+    pub last_check_result: Option<String>,
+    #[serde(default)]
+    pub ownership_conflict: bool,
+    #[serde(default)]
+    pub transfer_eligible: bool,
+    pub recovery_action: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationDomainPage {
+    pub items: Vec<OrganizationDomain>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityDomainAffiliation {
+    pub domain_claim_id: Option<String>,
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub publish_publicly: bool,
+    pub affiliation: Option<DomainAffiliation>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OrganizationDomainListOptions {
+    pub cursor: Option<String>,
+    pub limit: Option<u32>,
+}
+
+pub(crate) fn path_segment(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() || b"-_.~".contains(&byte) {
+                char::from(byte).to_string()
+            } else {
+                format!("%{byte:02X}")
+            }
+        })
+        .collect()
+}
+
+pub struct OrganizationDomainsResource {
+    http: Arc<HttpTransport>,
+}
+
+impl OrganizationDomainsResource {
+    pub(crate) fn new(http: Arc<HttpTransport>) -> Self {
+        Self { http }
+    }
+
+    pub fn create(&self, domain: &str) -> Result<OrganizationDomain> {
+        Ok(serde_json::from_value(self.http.post(
+            "/organization-domains",
+            Some(&json!({"domain": domain})),
+            NO_QUERY,
+        )?)?)
+    }
+
+    pub fn list(&self, options: &OrganizationDomainListOptions) -> Result<OrganizationDomainPage> {
+        let mut params = vec![("limit", options.limit.unwrap_or(50).to_string())];
+        if let Some(cursor) = &options.cursor {
+            params.push(("cursor", cursor.clone()));
+        }
+        Ok(serde_json::from_value(
+            self.http.get("/organization-domains", &params)?,
+        )?)
+    }
+
+    pub fn get(&self, claim_id: &str) -> Result<OrganizationDomain> {
+        Ok(serde_json::from_value(self.http.get(
+            &format!("/organization-domains/{}", path_segment(claim_id)),
+            NO_QUERY,
+        )?)?)
+    }
+
+    pub fn verify(&self, claim_id: &str) -> Result<OrganizationDomain> {
+        Ok(serde_json::from_value(self.http.post::<Value>(
+            &format!("/organization-domains/{}/verify", path_segment(claim_id)),
+            None,
+            NO_QUERY,
+        )?)?)
+    }
+
+    pub fn transfer(&self, claim_id: &str) -> Result<OrganizationDomain> {
+        Ok(serde_json::from_value(self.http.post::<Value>(
+            &format!("/organization-domains/{}/transfer", path_segment(claim_id)),
+            None,
+            NO_QUERY,
+        )?)?)
+    }
+
+    pub fn delete(&self, claim_id: &str) -> Result<()> {
+        self.http
+            .delete(&format!("/organization-domains/{}", path_segment(claim_id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{a2a::A2ADirectoryListOptions, Inkbox};
+    use httpmock::prelude::*;
+
+    fn claim() -> Value {
+        serde_json::from_str(r#"{"id": "OrganizationDomainClaim_00000000-0000-4000-8000-000000000001", "domain": "example.com", "state": "verified", "dns_record": {"type": "TXT", "name": "_inkbox.example.com", "value": "inkbox-domain-verification=example-proof"}, "verified_at": "2026-09-10T00:00:00Z", "last_checked_at": "2026-09-10T00:00:00Z", "last_success_at": "2026-09-10T00:00:00Z", "valid_until": "2026-09-11T00:00:00Z", "pending_expires_at": null, "next_check_at": "2026-09-10T01:00:00Z", "last_check_result": "present", "ownership_conflict": false, "transfer_eligible": false, "recovery_action": null, "created_at": "2026-09-10T00:00:00Z"}"#).unwrap()
+    }
+
+    #[test]
+    fn claim_lifecycle_and_identity_wire_contract() {
+        let server = MockServer::start();
+        let client = Inkbox::builder("test-key")
+            .base_url(server.base_url())
+            .build()
+            .unwrap();
+        let create = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/organization-domains")
+                .json_body(json!({"domain":"example.com"}));
+            then.status(201).json_body(claim());
+        });
+        assert_eq!(
+            client
+                .organization_domains()
+                .create("example.com")
+                .unwrap()
+                .domain,
+            "example.com"
+        );
+        create.assert();
+        for action in ["get", "verify", "transfer"] {
+            let path = format!(
+                "/api/v1/organization-domains/claim%2Fid{}",
+                if action == "get" {
+                    String::new()
+                } else {
+                    format!("/{action}")
+                }
+            );
+            let expected = server.mock(|when, then| {
+                when.method(if action == "get" { GET } else { POST })
+                    .path(path);
+                then.status(200).json_body(claim());
+            });
+            let result = match action {
+                "get" => client.organization_domains().get("claim/id"),
+                "verify" => client.organization_domains().verify("claim/id"),
+                _ => client.organization_domains().transfer("claim/id"),
+            };
+            assert_eq!(result.unwrap().dns_record.record_type, "TXT");
+            expected.assert();
+        }
+        let affiliation = server.mock(|when, then| {
+            when.method(PUT).path("/api/v1/identities/%40helper/domain-affiliation")
+                .json_body(json!({"domain_claim_id":"claim", "publish_publicly":false}));
+            then.status(200).json_body(json!({"domain_claim_id":"claim", "domain":"example.com", "publish_publicly":false, "affiliation":null}));
+        });
+        assert!(client
+            .identities()
+            .set_domain_affiliation("@helper", "claim", false)
+            .unwrap()
+            .affiliation
+            .is_none());
+        affiliation.assert();
+        let remove = server.mock(|when, then| {
+            when.method(DELETE)
+                .path("/api/v1/identities/%40helper/domain-affiliation");
+            then.status(204);
+        });
+        client
+            .identities()
+            .remove_domain_affiliation("@helper")
+            .unwrap();
+        remove.assert();
+        let release = server.mock(|when, then| {
+            when.method(DELETE)
+                .path("/api/v1/organization-domains/claim");
+            then.status(204);
+        });
+        client.organization_domains().delete("claim").unwrap();
+        release.assert();
+        let mut future = claim();
+        future["state"] = json!("future_state");
+        assert_eq!(
+            serde_json::from_value::<OrganizationDomain>(future)
+                .unwrap()
+                .state,
+            "future_state"
+        );
+    }
+
+    #[test]
+    fn public_filter_is_sent_and_rejected_for_organization_directory() {
+        let server = MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(GET)
+                .path("/a2a/directory")
+                .query_param("verified_domain", "example.com")
+                .query_param("cursor", "next");
+            then.status(200)
+                .json_body(json!({"items":[], "next_cursor":null}));
+        });
+        let client = Inkbox::builder("test-key")
+            .base_url(server.base_url())
+            .build()
+            .unwrap();
+        let options = A2ADirectoryListOptions {
+            verified_domain: Some("example.com".into()),
+            cursor: Some("next".into()),
+            ..Default::default()
+        };
+        client.a2a().public_directory(&options).unwrap();
+        request.assert();
+        assert!(client.a2a().organization_directory(&options).is_err());
+    }
+}

--- a/sdk/rust/src/webhooks/types.rs
+++ b/sdk/rust/src/webhooks/types.rs
@@ -976,6 +976,8 @@ pub enum A2AWebhookEventType {
 /// Authenticated caller attached to an A2A task event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2AWebhookCaller {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affiliation: Option<crate::organization_domains::DomainAffiliation>,
     pub identity_id: String,
     pub organization_id: String,
     pub handle: Option<String>,
@@ -984,6 +986,8 @@ pub struct A2AWebhookCaller {
 /// Task-ledger data carried by every A2A task event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct A2AWebhookData {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<A2AWebhookCaller>,
     pub task_id: String,
     pub context_id: String,
     pub state: String,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1701,3 +1701,39 @@ Runnable example scripts are available in the [examples/typescript](https://gith
 ## License
 
 MIT
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```typescript
+import { Inkbox } from "@inkbox/sdk";
+
+const client = new Inkbox();
+let claim = await client.organizationDomains.create("example.com");
+console.log(claim.dnsRecord.name, claim.dnsRecord.value);
+// Add the exact TXT record before verifying.
+claim = await client.organizationDomains.verify(claim.id);
+if (claim.state === "verified") {
+  await client.identities.setDomainAffiliation("helper", {
+    domainClaimId: claim.id, publishPublicly: false,
+  });
+}
+for await (const item of client.a2a.iterPublicDirectory({ verifiedDomain: "example.com" })) {
+  console.log(item.card.name);
+}
+```
+
+Claim methods: `create`, `list`, `get`, `verify`, `transfer`, `delete`.
+Use `client.identities.getDomainAffiliation(handle)` for saved settings,
+`setDomainAffiliation(handle, { domainClaimId, publishPublicly: true })` to publish
+explicitly, and `removeDomainAffiliation(handle)` to remove it. A2A participants
+and messages expose optional `.affiliation`. Webhook types retain wire casing.

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inkbox/sdk",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkbox/sdk",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "TypeScript SDK for the Inkbox API",
   "license": "MIT",
   "type": "module",

--- a/sdk/typescript/src/a2a/resource.ts
+++ b/sdk/typescript/src/a2a/resource.ts
@@ -9,6 +9,7 @@ import type {
   A2AContextPage,
   A2ADirectoryItem,
   A2ADirectoryListOptions,
+  A2APublicDirectoryListOptions,
   A2ADirectoryPage,
   A2AHistoryMessage,
   A2AHistoryMessagePage,
@@ -115,9 +116,10 @@ export class A2AResource {
   }
 
   async publicDirectory(
-    options: A2ADirectoryListOptions = {},
+    options: A2APublicDirectoryListOptions = {},
   ): Promise<A2ADirectoryPage> {
     return parseDirectory(await this.publicHttp.get<Raw>("/a2a/directory", {
+      ...(options.verifiedDomain === undefined ? {} : { verified_domain: options.verifiedDomain }),
       q: options.q,
       cursor: options.cursor,
       limit: options.limit ?? 50,
@@ -127,6 +129,7 @@ export class A2AResource {
   async organizationDirectory(
     options: A2ADirectoryListOptions = {},
   ): Promise<A2ADirectoryPage> {
+    if ("verifiedDomain" in options) throw new TypeError("verifiedDomain is only available in the public directory");
     return parseDirectory(await this.http.get<Raw>("/identities/a2a/directory", {
       q: options.q,
       cursor: options.cursor,
@@ -135,7 +138,7 @@ export class A2AResource {
   }
 
   async *iterPublicDirectory(
-    options: Omit<A2ADirectoryListOptions, "cursor"> = {},
+    options: Omit<A2APublicDirectoryListOptions, "cursor"> = {},
   ): AsyncGenerator<A2ADirectoryItem> {
     yield* this.iterDirectory(true, options);
   }
@@ -148,7 +151,7 @@ export class A2AResource {
 
   private async *iterDirectory(
     publicDirectory: boolean,
-    options: Omit<A2ADirectoryListOptions, "cursor">,
+    options: Omit<A2APublicDirectoryListOptions, "cursor">,
   ): AsyncGenerator<A2ADirectoryItem> {
     let cursor: string | undefined;
     do {

--- a/sdk/typescript/src/a2a/types.ts
+++ b/sdk/typescript/src/a2a/types.ts
@@ -1,4 +1,6 @@
 /** Inkbox A2A inbox types and standard A2A 1.0 wire types. */
+import { parseDomainAffiliation } from "../organization_domains/types.js";
+import type { DomainAffiliation } from "../organization_domains/types.js";
 
 export type A2ATaskState =
   | "submitted"
@@ -83,7 +85,12 @@ export interface A2ADirectoryListOptions {
   limit?: number;
 }
 
+export interface A2APublicDirectoryListOptions extends A2ADirectoryListOptions {
+  verifiedDomain?: string;
+}
+
 export interface A2ACaller {
+  affiliation?: DomainAffiliation | null;
   identityId: string;
   organizationId: string;
   handle: string | null;
@@ -91,12 +98,14 @@ export interface A2ACaller {
 }
 
 export interface A2ATarget {
+  affiliation?: DomainAffiliation | null;
   identityId: string;
   organizationId: string;
   handle: string | null;
 }
 
 export interface A2AMessage {
+  affiliation?: DomainAffiliation | null;
   id: string;
   messageId: string;
   role: string;
@@ -167,6 +176,7 @@ export type A2ASentContextListOptions = Omit<
 >;
 
 export interface A2AHistoryMessage {
+  affiliation?: DomainAffiliation | null;
   id: string;
   messageId: string;
   taskId: string;
@@ -257,16 +267,19 @@ export function parseA2ATask(raw: Record<string, any>): A2ATask {
       organizationId: raw.caller.organization_id,
       handle: raw.caller.handle ?? null,
       trustTier: raw.caller.trust_tier ?? "inkbox_verified",
+      affiliation: parseDomainAffiliation(raw.caller.affiliation),
     },
     target: raw.target ? {
       identityId: raw.target.identity_id,
       organizationId: raw.target.organization_id,
       handle: raw.target.handle ?? null,
+      affiliation: parseDomainAffiliation(raw.target.affiliation),
     } : null,
     messages: (raw.messages ?? []).map((item: Record<string, any>) => ({
       id: item.id,
       messageId: item.message_id,
       role: item.role,
+      affiliation: parseDomainAffiliation(item.affiliation),
       parts: item.parts ?? [],
       metadata: item.metadata ?? null,
       extensions: item.extensions ?? null,
@@ -289,11 +302,13 @@ export function parseA2AContext(raw: Record<string, any>): A2AContext {
       organizationId: raw.caller.organization_id,
       handle: raw.caller.handle ?? null,
       trustTier: raw.caller.trust_tier ?? "inkbox_verified",
+      affiliation: parseDomainAffiliation(raw.caller.affiliation),
     },
     target: raw.target ? {
       identityId: raw.target.identity_id,
       organizationId: raw.target.organization_id,
       handle: raw.target.handle ?? null,
+      affiliation: parseDomainAffiliation(raw.target.affiliation),
     } : null,
     tasks: (raw.tasks ?? []).map(parseA2ATask),
     tasksTruncated: raw.tasks_truncated ?? false,
@@ -316,13 +331,16 @@ export function parseA2AHistoryMessage(
       organizationId: raw.caller.organization_id,
       handle: raw.caller.handle ?? null,
       trustTier: raw.caller.trust_tier ?? "inkbox_verified",
+      affiliation: parseDomainAffiliation(raw.caller.affiliation),
     },
     target: raw.target ? {
       identityId: raw.target.identity_id,
       organizationId: raw.target.organization_id,
       handle: raw.target.handle ?? null,
+      affiliation: parseDomainAffiliation(raw.target.affiliation),
     } : null,
     role: raw.role,
+    affiliation: parseDomainAffiliation(raw.affiliation),
     parts: raw.parts ?? [],
     metadata: raw.metadata ?? null,
     extensions: raw.extensions ?? null,

--- a/sdk/typescript/src/identities/resources/identities.ts
+++ b/sdk/typescript/src/identities/resources/identities.ts
@@ -8,6 +8,8 @@
  */
 
 import { HttpTransport, InkboxAPIError, validateIdempotencyKey } from "../../_http.js";
+import { parseIdentityDomainAffiliation } from "../../organization_domains/types.js";
+import type { IdentityDomainAffiliation, SetDomainAffiliationOptions } from "../../organization_domains/types.js";
 import { mapIdentityConflictError } from "../exceptions.js";
 import {
   AgentIdentitySummary,
@@ -28,6 +30,20 @@ import {
 
 export class IdentitiesResource {
   constructor(private readonly http: HttpTransport) {}
+
+  async getDomainAffiliation(agentHandle: string): Promise<IdentityDomainAffiliation> {
+    return parseIdentityDomainAffiliation(await this.http.get(`/${encodeURIComponent(agentHandle)}/domain-affiliation`));
+  }
+
+  async setDomainAffiliation(agentHandle: string, options: SetDomainAffiliationOptions): Promise<IdentityDomainAffiliation> {
+    return parseIdentityDomainAffiliation(await this.http.put(`/${encodeURIComponent(agentHandle)}/domain-affiliation`, {
+      domain_claim_id: options.domainClaimId, publish_publicly: options.publishPublicly,
+    }));
+  }
+
+  async removeDomainAffiliation(agentHandle: string): Promise<void> {
+    await this.http.delete(`/${encodeURIComponent(agentHandle)}/domain-affiliation`);
+  }
 
   /**
    * Create a new agent identity. Atomically provisions the identity's

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -455,3 +455,7 @@ export {
   TunnelStateConflict,
   TunnelTLSModeMismatch,
 } from "./tunnels/exceptions.js";
+
+export { OrganizationDomainsResource } from "./organization_domains/resource.js";
+export type { DomainAffiliation, DomainClaimState, DomainTxtRecord, IdentityDomainAffiliation, OrganizationDomain, OrganizationDomainPage, SetDomainAffiliationOptions } from "./organization_domains/types.js";
+export type { A2APublicDirectoryListOptions } from "./a2a/types.js";

--- a/sdk/typescript/src/inkbox.ts
+++ b/sdk/typescript/src/inkbox.ts
@@ -40,6 +40,7 @@ import { TunnelsResource } from "./tunnels/resources/tunnels.js";
 import { ApiKeysResource } from "./api_keys/resources/apiKeys.js";
 import { AgentIdentity } from "./agent_identity.js";
 import { A2AResource } from "./a2a/resource.js";
+import { OrganizationDomainsResource } from "./organization_domains/resource.js";
 import {
   A2AInvitationsResource,
   extractA2AInvitationToken,
@@ -182,6 +183,7 @@ export class Inkbox {
   readonly _apiKeys: ApiKeysResource;
   readonly _rootApiHttp: HttpTransport;
   readonly _a2a: A2AResource;
+  readonly organizationDomains: OrganizationDomainsResource;
   readonly _a2aInvitations: A2AInvitationsResource;
   /** @internal — used by the tunnel-agent runtime for data-plane auth. */
   readonly _apiKey: string;
@@ -233,6 +235,7 @@ export class Inkbox {
     const domainsHttp  = new HttpTransport(apiKey, `${apiRoot}/domains`, ms, cookieJar, userAgent);
     const rootApiHttp  = new HttpTransport(apiKey, `${baseUrl.replace(/\/$/, "")}/api`, ms, cookieJar, userAgent);
     const apiHttp      = new HttpTransport(apiKey, apiRoot, ms, cookieJar, userAgent);
+    this.organizationDomains = new OrganizationDomainsResource(apiHttp);
     const publicHttp   = new HttpTransport(apiKey, this._baseUrl, ms, cookieJar, userAgent);
 
     this._mailboxes        = new MailboxesResource(mailHttp);
@@ -484,6 +487,10 @@ export class Inkbox {
     if (options.tunnel !== undefined) createArgs.tunnel = options.tunnel;
     const data = await this._idsResource.create(createArgs);
     return new AgentIdentity(data, this);
+  }
+
+  get identities(): IdentitiesResource {
+    return this._idsResource;
   }
 
   /**

--- a/sdk/typescript/src/organization_domains/resource.ts
+++ b/sdk/typescript/src/organization_domains/resource.ts
@@ -1,0 +1,34 @@
+import type { HttpTransport } from "../_http.js";
+import { parseOrganizationDomain } from "./types.js";
+import type { OrganizationDomain, OrganizationDomainPage } from "./types.js";
+
+type Raw = Record<string, any>;
+
+export class OrganizationDomainsResource {
+  constructor(private readonly http: HttpTransport) {}
+
+  async create(domain: string): Promise<OrganizationDomain> {
+    return parseOrganizationDomain(await this.http.post<Raw>("/organization-domains", { domain }));
+  }
+
+  async list(options: { cursor?: string; limit?: number } = {}): Promise<OrganizationDomainPage> {
+    const data = await this.http.get<Raw>("/organization-domains", { cursor: options.cursor, limit: options.limit ?? 50 });
+    return { items: data.items.map(parseOrganizationDomain), nextCursor: data.next_cursor ?? null };
+  }
+
+  async get(claimId: string): Promise<OrganizationDomain> {
+    return parseOrganizationDomain(await this.http.get<Raw>(`/organization-domains/${encodeURIComponent(claimId)}`));
+  }
+
+  async verify(claimId: string): Promise<OrganizationDomain> {
+    return parseOrganizationDomain(await this.http.post<Raw>(`/organization-domains/${encodeURIComponent(claimId)}/verify`));
+  }
+
+  async transfer(claimId: string): Promise<OrganizationDomain> {
+    return parseOrganizationDomain(await this.http.post<Raw>(`/organization-domains/${encodeURIComponent(claimId)}/transfer`));
+  }
+
+  async delete(claimId: string): Promise<void> {
+    await this.http.delete(`/organization-domains/${encodeURIComponent(claimId)}`);
+  }
+}

--- a/sdk/typescript/src/organization_domains/types.ts
+++ b/sdk/typescript/src/organization_domains/types.ts
@@ -1,0 +1,73 @@
+export interface DomainAffiliation {
+  domain: string;
+  verifier: string;
+  lastSuccessAt: string;
+  validUntil: string;
+}
+
+export type DomainClaimState = "pending" | "verified" | "grace" | "expired" | "pending_expired" | "released" | (string & {});
+
+export interface DomainTxtRecord {
+  type: "TXT";
+  name: string;
+  value: string;
+}
+
+export interface OrganizationDomain {
+  id: string;
+  domain: string;
+  state: DomainClaimState;
+  dnsRecord: DomainTxtRecord;
+  verifiedAt: string | null;
+  lastCheckedAt: string | null;
+  lastSuccessAt: string | null;
+  validUntil: string | null;
+  pendingExpiresAt: string | null;
+  nextCheckAt: string | null;
+  lastCheckResult: string | null;
+  ownershipConflict: boolean;
+  transferEligible: boolean;
+  recoveryAction: string | null;
+  createdAt: string;
+}
+
+export interface OrganizationDomainPage {
+  items: OrganizationDomain[];
+  nextCursor: string | null;
+}
+
+export interface IdentityDomainAffiliation {
+  domainClaimId: string | null;
+  domain: string | null;
+  publishPublicly: boolean;
+  affiliation: DomainAffiliation | null;
+}
+
+export interface SetDomainAffiliationOptions {
+  domainClaimId: string;
+  publishPublicly: boolean;
+}
+
+type Raw = Record<string, any>;
+
+export function parseDomainAffiliation(raw: Raw | null | undefined): DomainAffiliation | null {
+  return raw == null ? null : { domain: raw.domain, verifier: raw.verifier,
+    lastSuccessAt: raw.last_success_at, validUntil: raw.valid_until };
+}
+
+export function parseOrganizationDomain(raw: Raw): OrganizationDomain {
+  return {
+    id: raw.id, domain: raw.domain, state: raw.state, dnsRecord: raw.dns_record,
+    verifiedAt: raw.verified_at ?? null, lastCheckedAt: raw.last_checked_at ?? null,
+    lastSuccessAt: raw.last_success_at ?? null, validUntil: raw.valid_until ?? null,
+    pendingExpiresAt: raw.pending_expires_at ?? null, nextCheckAt: raw.next_check_at ?? null,
+    lastCheckResult: raw.last_check_result ?? null, ownershipConflict: raw.ownership_conflict ?? false,
+    transferEligible: raw.transfer_eligible ?? false, recoveryAction: raw.recovery_action ?? null,
+    createdAt: raw.created_at,
+  };
+}
+
+export function parseIdentityDomainAffiliation(raw: Raw): IdentityDomainAffiliation {
+  return { domainClaimId: raw.domain_claim_id ?? null, domain: raw.domain ?? null,
+    publishPublicly: raw.publish_publicly ?? false, affiliation: parseDomainAffiliation(raw.affiliation) };
+}

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,2 +1,2 @@
 // Keep in sync with package.json "version".
-export const VERSION = "0.6.10";
+export const VERSION = "0.6.11";

--- a/sdk/typescript/src/webhooks/types.ts
+++ b/sdk/typescript/src/webhooks/types.ts
@@ -757,12 +757,14 @@ export type A2AWebhookEventType =
   | "a2a.sent_task.updated";
 
 export interface A2AWebhookCaller {
+  affiliation?: { domain: string; verifier: string; last_success_at: string; valid_until: string } | null;
   identity_id: string;
   organization_id: string;
   handle: string | null;
 }
 
 export interface A2AWebhookData {
+  sender?: A2AWebhookCaller | null;
   task_id: string;
   context_id: string;
   state: string;

--- a/sdk/typescript/tests/organization-domains.test.ts
+++ b/sdk/typescript/tests/organization-domains.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { Inkbox } from "../src/inkbox.js";
+import { OrganizationDomainsResource } from "../src/organization_domains/resource.js";
+import { parseDomainAffiliation } from "../src/organization_domains/types.js";
+import { A2AResource } from "../src/a2a/resource.js";
+import type { HttpTransport } from "../src/_http.js";
+
+const fixture = JSON.parse(readFileSync(new URL("../../../tests/fixtures/domain-certification.json", import.meta.url), "utf8"));
+
+describe("organization domains", () => {
+  it("preserves unknown states and uses encoded management paths", async () => {
+    const http = { get: vi.fn(), post: vi.fn(), delete: vi.fn() };
+    http.get.mockResolvedValue(fixture.claim);
+    http.post.mockResolvedValue({ ...fixture.claim, state: "future_state" });
+    const resource = new OrganizationDomainsResource(http as unknown as HttpTransport);
+    expect((await resource.create("example.com")).state).toBe("future_state");
+    expect(http.post).toHaveBeenCalledWith("/organization-domains", { domain: "example.com" });
+    expect((await resource.get("claim/id")).dnsRecord.name).toBe("_inkbox.example.com");
+    expect(http.get).toHaveBeenCalledWith("/organization-domains/claim%2Fid");
+    for (const action of ["verify", "transfer"] as const) {
+      await resource[action]("claim/id");
+      expect(http.post).toHaveBeenCalledWith(`/organization-domains/claim%2Fid/${action}`);
+    }
+    await resource.delete("claim/id");
+    expect(http.delete).toHaveBeenCalledWith("/organization-domains/claim%2Fid");
+    http.get.mockResolvedValue({ items: [fixture.claim], next_cursor: "next" });
+    expect((await resource.list({ cursor: "before" })).nextCursor).toBe("next");
+  });
+
+  it("exposes identity management without fetching an identity first", async () => {
+    const client = new Inkbox({ apiKey: "test-key" });
+    const http = { get: vi.fn(), put: vi.fn(), delete: vi.fn() };
+    const config = { domain_claim_id: "claim", domain: "example.com", publish_publicly: false, affiliation: fixture.affiliation };
+    http.get.mockResolvedValue(config); http.put.mockResolvedValue(config);
+    Object.assign(client.identities, { http });
+    expect((await client.identities.getDomainAffiliation("@helper")).affiliation?.validUntil).toBe(fixture.affiliation.valid_until);
+    await client.identities.setDomainAffiliation("@helper", { domainClaimId: "claim", publishPublicly: false });
+    expect(http.put).toHaveBeenCalledWith("/%40helper/domain-affiliation", { domain_claim_id: "claim", publish_publicly: false });
+    await client.identities.removeDomainAffiliation("@helper");
+    expect(http.delete).toHaveBeenCalledWith("/%40helper/domain-affiliation");
+  });
+
+  it("carries the public filter across pages and rejects organization filtering", async () => {
+    const item = { card_url: "https://inkbox.ai/a2a/helper/card", visibility: "public", card: {
+      name: "@helper", capabilities: { extensions: [{ uri: "https://inkbox.ai/a2a/extensions/domain-affiliation/v1", params: fixture.affiliation }] },
+    } };
+    const http = { get: vi.fn().mockResolvedValueOnce({ items: [item], next_cursor: "next" }).mockResolvedValueOnce({ items: [item], next_cursor: null }) };
+    const resource = new A2AResource(http as unknown as HttpTransport, http as unknown as HttpTransport);
+    const items = [];
+    for await (const row of resource.iterPublicDirectory({ q: "help", verifiedDomain: "example.com" })) items.push(row);
+    expect(items).toHaveLength(2);
+    expect(items[0].card.capabilities).toEqual(item.card.capabilities);
+    expect(http.get.mock.calls[1][1]).toMatchObject({ cursor: "next", verified_domain: "example.com", q: "help" });
+    await expect(resource.organizationDirectory({ verifiedDomain: "example.com" } as never)).rejects.toThrow("public directory");
+    expect(parseDomainAffiliation(undefined)).toBeNull();
+  });
+});

--- a/skills/inkbox-cli/SKILL.md
+++ b/skills/inkbox-cli/SKILL.md
@@ -843,3 +843,31 @@ SDK skills (`inkbox-ts`, `inkbox-python`).
 - Prefer `--json` for anything that needs stable parsing.
 - Use the identity handle, not mailbox address or phone number, for identity-scoped commands.
 - If a command fails because the identity lacks a mailbox or phone number, inspect it first with `inkbox identity get <handle>`.
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```bash
+inkbox organization-domain create example.com
+# Add the returned TXT record, then use its claim ID.
+inkbox organization-domain verify OrganizationDomainClaim_YOUR_ID
+inkbox identity domain-affiliation set helper OrganizationDomainClaim_YOUR_ID --visibility hidden
+inkbox identity domain-affiliation get helper
+inkbox a2a directory --public --verified-domain example.com
+```
+
+`organization-domain` provides `create`, `list`, `get`, `verify`, `transfer`, and
+`delete`. Transfer is explicit and requires fresh proof; it never happens merely
+by checking DNS. `identity domain-affiliation set` requires `--visibility public`
+or `--visibility hidden`. Use `remove <handle>` to stop all affiliation assertions.
+Use `--json` to inspect the complete response. Public search also accepts `--query`,
+`--cursor`, and `--limit`; preserve the same filters on every page.

--- a/skills/inkbox-python/SKILL.md
+++ b/skills/inkbox-python/SKILL.md
@@ -1382,3 +1382,35 @@ except InkboxAPIError as e:
 - To clear a nullable field (e.g. webhook URL), pass `field=None`
 - The `Inkbox` client **must** be used as a context manager (`with` statement) or `.close()` called manually
 - Mail/phone methods on `AgentIdentity` raise `InkboxError` if the relevant channel isn't assigned
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```python
+from inkbox import Inkbox
+
+client = Inkbox()
+claim = client.organization_domains.create("example.com")
+print(claim.dns_record.name, claim.dns_record.value)
+# Add the exact TXT record before verifying.
+claim = client.organization_domains.verify(claim.id)
+if claim.state == "verified":
+    client.identities.set_domain_affiliation("helper", claim.id, publish_publicly=False)
+for item in client.a2a.iter_public_directory(verified_domain="example.com"):
+    print(item.card.name)
+```
+
+Claim methods: `create`, `list`, `get`, `verify`, `transfer`, `delete`.
+Use `client.identities.get_domain_affiliation(handle)` to inspect saved settings,
+`set_domain_affiliation(..., publish_publicly=True)` to publish explicitly, and
+`remove_domain_affiliation(handle)` to remove the selection. Task and context
+participants expose optional `.affiliation`; message assertions identify the author.

--- a/skills/inkbox-ts/SKILL.md
+++ b/skills/inkbox-ts/SKILL.md
@@ -1398,3 +1398,39 @@ try {
 - To clear a nullable field (e.g. webhook URL), pass `field: null`
 - No context manager needed — `new Inkbox({...})` is all that's required
 - All methods are `async` and return Promises — always `await` them
+
+## Verified domains
+
+An organization admin can prove DNS control, select a domain for an agent, and
+choose public display independently from public directory listing. Hidden
+selected domains remain available to authorized A2A peers. Proof expires at the
+returned `valid_until`; assertions do not establish legal identity or endorse an
+agent. Keep the TXT record in place. Domain certification is separate from custom
+email sending domains.
+
+See [verified domains](https://inkbox.ai/docs/capabilities/verified-domains) for
+expiry, transfer, and recovery rules. These methods require version 0.6.5 or later.
+
+```typescript
+import { Inkbox } from "@inkbox/sdk";
+
+const client = new Inkbox();
+let claim = await client.organizationDomains.create("example.com");
+console.log(claim.dnsRecord.name, claim.dnsRecord.value);
+// Add the exact TXT record before verifying.
+claim = await client.organizationDomains.verify(claim.id);
+if (claim.state === "verified") {
+  await client.identities.setDomainAffiliation("helper", {
+    domainClaimId: claim.id, publishPublicly: false,
+  });
+}
+for await (const item of client.a2a.iterPublicDirectory({ verifiedDomain: "example.com" })) {
+  console.log(item.card.name);
+}
+```
+
+Claim methods: `create`, `list`, `get`, `verify`, `transfer`, `delete`.
+Use `client.identities.getDomainAffiliation(handle)` for saved settings,
+`setDomainAffiliation(handle, { domainClaimId, publishPublicly: true })` to publish
+explicitly, and `removeDomainAffiliation(handle)` to remove it. A2A participants
+and messages expose optional `.affiliation`. Webhook types retain wire casing.

--- a/tests/fixtures/domain-certification.json
+++ b/tests/fixtures/domain-certification.json
@@ -1,0 +1,29 @@
+{
+  "affiliation": {
+    "domain": "example.com",
+    "verifier": "Inkbox",
+    "last_success_at": "2026-09-10T00:00:00Z",
+    "valid_until": "2100-01-01T00:00:00Z"
+  },
+  "claim": {
+    "id": "OrganizationDomainClaim_00000000-0000-4000-8000-000000000001",
+    "domain": "example.com",
+    "state": "verified",
+    "dns_record": {
+      "type": "TXT",
+      "name": "_inkbox.example.com",
+      "value": "inkbox-domain-verification=example-proof"
+    },
+    "verified_at": "2026-09-10T00:00:00Z",
+    "last_checked_at": "2026-09-10T00:00:00Z",
+    "last_success_at": "2026-09-10T00:00:00Z",
+    "valid_until": "2026-09-11T00:00:00Z",
+    "pending_expires_at": null,
+    "next_check_at": "2026-09-10T01:00:00Z",
+    "last_check_result": "present",
+    "ownership_conflict": false,
+    "transfer_eligible": false,
+    "recovery_action": null,
+    "created_at": "2026-09-10T00:00:00Z"
+  }
+}

--- a/tests/integration/cli/cli_lifecycle.test.ts
+++ b/tests/integration/cli/cli_lifecycle.test.ts
@@ -49,6 +49,17 @@ describe("CLI lifecycle", { timeout: 300_000 }, () => {
     const whoami = inkboxJson<{ organizationId: string }>("whoami", cliOpts);
     expect(whoami.organizationId).toBe(bootstrap.orgId);
 
+    const claimDomain = `certification-${randomUUID().replaceAll("-", "")}.example.com`;
+    const claim = inkboxJson<{ id: string; state: string }>(`organization-domain create ${claimDomain}`, cliOpts);
+    try {
+      expect(claim.state).toBe("pending");
+      expect(inkboxJson<{ id: string }>(`organization-domain get ${claim.id}`, cliOpts).id).toBe(claim.id);
+      expect(inkboxJson<{ validUntil: string | null }>(`organization-domain verify ${claim.id}`, cliOpts).validUntil).toBeNull();
+      expect(inkboxJson<{ items: unknown[] }>(`a2a directory --public --verified-domain ${claimDomain}`, cliOpts).items).toEqual([]);
+    } finally {
+      inkbox(`organization-domain delete ${claim.id}`, cliOpts);
+    }
+
     // ── empty state ────────────────────────────────────────────
     logStep(config, "verify empty identity list");
     const emptyList = inkboxJson<unknown[]>("identity list", cliOpts);

--- a/tests/integration/python/test_sdk_lifecycle.py
+++ b/tests/integration/python/test_sdk_lifecycle.py
@@ -34,6 +34,18 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         whoami = inkbox.whoami()
         assert whoami.organization_id == ctx.bootstrap.org_id
 
+        claim_domain = f"certification-{uuid4().hex}.example.com"
+        claim = inkbox.organization_domains.create(claim_domain)
+        try:
+            assert claim.state == "pending"
+            repeated = inkbox.organization_domains.create(claim_domain.upper() + ".")
+            assert repeated.id == claim.id
+            assert inkbox.organization_domains.get(claim.id).dns_record.name == f"_inkbox.{claim_domain}"
+            assert inkbox.organization_domains.verify(claim.id).valid_until is None
+            assert inkbox.a2a.public_directory(verified_domain=claim_domain).items == []
+        finally:
+            inkbox.organization_domains.delete(claim.id)
+
         # ── empty state ────────────────────────────────────────────
         log_step(ctx, "verify empty identity list")
         identities = inkbox.list_identities()
@@ -51,6 +63,7 @@ def test_python_sdk_lifecycle(sdk_context: SdkIntegrationContext) -> None:
         assert alpha.tunnel.public_host.startswith(f"{alpha_handle}.")
         assert alpha.tunnel.public_host.endswith(".inkboxwire.com")
         assert alpha.description == "alpha integration-test identity"
+        assert inkbox.identities.get_domain_affiliation(alpha_handle).affiliation is None
 
         log_step(ctx, f"create identity {bravo_handle}")
         bravo = inkbox.create_identity(bravo_handle)

--- a/tests/integration/typescript/sdk_lifecycle.test.ts
+++ b/tests/integration/typescript/sdk_lifecycle.test.ts
@@ -51,6 +51,18 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
     const whoami = await inkbox.whoami();
     expect(whoami.organizationId).toBe(bootstrap.orgId);
 
+    const claimDomain = `certification-${randomUUID().replaceAll("-", "")}.example.com`;
+    const claim = await inkbox.organizationDomains.create(claimDomain);
+    try {
+      expect(claim.state).toBe("pending");
+      expect((await inkbox.organizationDomains.create(claimDomain.toUpperCase() + ".")).id).toBe(claim.id);
+      expect((await inkbox.organizationDomains.get(claim.id)).dnsRecord.name).toBe(`_inkbox.${claimDomain}`);
+      expect((await inkbox.organizationDomains.verify(claim.id)).validUntil).toBeNull();
+      expect((await inkbox.a2a.publicDirectory({ verifiedDomain: claimDomain })).items).toEqual([]);
+    } finally {
+      await inkbox.organizationDomains.delete(claim.id);
+    }
+
     // ── empty state ────────────────────────────────────────────
     logStep(config, "verify empty identity list");
     const empty = await inkbox.listIdentities();
@@ -67,6 +79,7 @@ describe("TypeScript SDK lifecycle", { timeout: 300_000 }, () => {
     expect(alpha.tunnel).not.toBeNull();
     expect(alpha.tunnel!.publicHost).toMatch(publicHostRe);
     expect(alpha.description).toBe("alpha integration-test identity");
+    expect((await inkbox.identities.getDomainAffiliation(alphaHandle)).affiliation).toBeNull();
 
     logStep(config, `create identity ${bravoHandle}`);
     const bravo = await inkbox.createIdentity(bravoHandle);


### PR DESCRIPTION
## Executive Summary

Adds verified organization domains and agent affiliations to the Python, TypeScript, Rust, and CLI packages in version 0.6.11.

- Manage TXT challenges, verification, explicit transfers, and claim release.
- Select an agent's domain with an explicit public-display choice.
- Search public agents by verified domain and parse optional A2A affiliation assertions.

## Description

Adds organization-domain resources and identity affiliation methods across all three SDKs, plus `organization-domain` and `identity domain-affiliation` CLI commands. Public directory methods and iterators carry the exact-domain filter across pages. A2A participant, message, and webhook types expose optional domain assertions and the actual webhook message sender.

Updates examples, skills, integration scenarios, and the changelog. SDK/CLI versions, lockfiles, User-Agent constants, and the Claude plugin move to 0.6.11; the bundled Codex and Cursor manifests receive patch bumps to 0.1.6 and 1.0.4.

## Reason

Developers need to associate agents with domains their organization controls and inspect that affiliation through the same SDK and CLI surfaces used for A2A.

## Decisions

- **Publication:** Require an explicit public-display choice when setting an affiliation; hidden affiliations remain visible to authorized A2A participants.
- **Compatibility:** Optional response fields tolerate absent assertions and domain states remain forward-compatible; Rust exhaustive struct literals must include the new fields, with `..Default::default()` available for directory options.
- **Release:** Use the next patch version, 0.6.11, and publish the TypeScript SDK before the CLI because the CLI depends on it.

## Testing

- Python: `uv run ruff check .`, `uv lock --check`, and `uv run pytest --no-cov -q` passed; 1,099 tests passed, 3 skipped.
- TypeScript: `npm run build` and `npm test -- --run` passed; 1,098 tests passed, 3 skipped.
- Rust: `cargo test` passed 262 tests; `cargo test --features tunnels-runtime` passed 345 tests, with 3 doc tests passing in each run. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- CLI: `npm test` passed all 135 tests using a locally packed TypeScript SDK 0.6.11.
- `client.organization_domains.create/get/verify/transfer/delete` (Python), `client.organizationDomains` (TypeScript), and `client.organization_domains()` (Rust): preserve TXT instructions, timestamps, unknown states, encoded claim IDs, and pagination.
- `inkbox identity domain-affiliation set helper CLAIM_ID --visibility hidden`: sends an explicit false publication choice; omitting `--visibility` fails before making a request.
- `inkbox a2a directory --public --verified-domain example.com`: carries the filter and cursor; organization scope rejects the filter.
- Live integration scenarios are included but were not run against a deployed API in this pass. No packages were published.

## Release dependency

Release after the organization-domain API is available. Publish `@inkbox/sdk` before `@inkbox/cli`, then release the Python and Rust packages according to `RELEASING.md`.
