### PR TITLE
Raise the CLI integration hook timeout

### DIFF
--- a/tests/integration/cli/vitest.config.ts
+++ b/tests/integration/cli/vitest.config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 660_000,
+    // beforeAll bootstraps a test org over the network; the 10s default is
+    // shorter than bootstrapTestOrg's own retry schedule, so retries never land.
+    hookTimeout: 120_000,
     include: ["**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Executive Summary

Set an explicit `hookTimeout` on the CLI integration suite so a slow test-org bootstrap no longer fails the run before its own retries can fire.

- `beforeAll` runs under vitest's 10s default, not the suite's `testTimeout: 660_000`.
- `bootstrapTestOrg` retries up to four times with 2/4/8s backoff, which needs ~30s of budget.
- Verified an 11s `beforeAll` passes under the new config and fails without it.

## Description

`tests/integration/cli/cli_lifecycle.test.ts` provisions its test organization inside `beforeAll`. Vitest applies `hookTimeout` to hooks and `testTimeout` to test bodies, and `tests/integration/cli/vitest.config.ts` configured only the latter, so the bootstrap ran on the 10s default. `postWithRetry` in `tests/integration/cli/helpers.ts` is built to absorb a transient upstream failure with four attempts and 2/4/8s backoff, but at a 10s budget the hook is killed partway through the first backoff, so the retry path is unreachable and any bootstrap slower than 10s is a hard failure.

The other integration suites are unaffected: the TypeScript suite bootstraps in `globalSetup`, which is not bound by `hookTimeout`, and the Python suite runs under pytest, which applies no hook timeout. This makes the CLI suite the only one where a slow bootstrap is fatal. Setting `hookTimeout: 120_000` brings the hook's budget in line with the retry schedule already implemented inside it.

## Reason

A scheduled CLI integration run went red when the test-org bootstrap took slightly longer than 10s, even though the bootstrap request itself completed successfully moments later.

## Decisions

- **Timeout value:** Chose 120s rather than matching `testTimeout: 660_000`, because it comfortably covers the ~30s retry schedule plus a slow upstream while still failing fast if the bootstrap endpoint is genuinely down.

## Testing

- Probe in `tests/integration/cli`: a throwaway `beforeAll` that sleeps 11s passes under this config, and fails with `Hook timed out in 10000ms` without it. Probe file was not committed.
- `npx vitest list` in `tests/integration/cli`: config loads and the suite still collects.
- Full CLI integration run: not executed locally (needs configured integration credentials). Draft PRs skip the integration jobs, so `SDK Integration Tests` will exercise this once the PR is marked ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
